### PR TITLE
Change DbxUrlWithExpiration class to public

### DIFF
--- a/src/com/dropbox/core/DbxUrlWithExpiration.java
+++ b/src/com/dropbox/core/DbxUrlWithExpiration.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
 import java.util.Date;
 
-final class DbxUrlWithExpiration
+public final class DbxUrlWithExpiration
 {
     public final String url;
     public final Date expires;


### PR DESCRIPTION
The createTemporaryDirectUrl method returns DbxUrlWithExpiration but it isnt accessible.
