### PR TITLE
Use bundle-plugin to allow Dropbox SDK to be deployed to OSGi containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>dropbox-core-sdk</artifactId>
     <version>0-SNAPSHOT</version>
 
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <url>https://www.dropbox.com/developers/core</url>
     <scm>
@@ -200,14 +200,28 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <version>2.5.0</version>
                 <extensions>true</extensions>
-
-                <configuration>
-                    <excludeDependencies>true</excludeDependencies>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Checker Framework -->
             <plugin>


### PR DESCRIPTION
I added the maven-bundle-plugin [1] to the pom.xml to be able to deploy the Dropbox SDK to a OSGi container. The bundle plugin adds the Bundle-\* and Export-Packages Attributes to the manifest automatically.

[1] http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html.
