### PR TITLE
Update DbxWebAuth.java

### DIFF
--- a/src/com/dropbox/core/DbxWebAuth.java
+++ b/src/com/dropbox/core/DbxWebAuth.java
@@ -207,7 +207,7 @@ public class DbxWebAuth
             givenUrlState = null;
         } else {
             givenCsrfToken = state.substring(0, divPos);
-            givenUrlState = state.substring(divPos);
+            givenUrlState = state.substring(divPos + 1);
         }
         if (!StringUtil.secureStringEquals(csrfTokenFromSession, givenCsrfToken)) {
             throw new CsrfException("expecting " + jq(csrfTokenFromSession) + ", got " + jq(givenCsrfToken));


### PR DESCRIPTION
DbxWebAuth is prepending the pipe separator char '|' to DbxAuthFinish.urlState at the conclusion of finish.  This does not seem like the intended behavior.
