### PR TITLE
Added maven profile for builds with JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,24 +273,24 @@
         </plugins>
     </build>
 
-	<profiles>
-		<profile>
-			<id>jdk18</id>
-			<activation>
-				<jdk>[1.8,)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+    <profiles>
+        <profile>
+            <id>jdk18</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Bug executing `mvn install` with JDK 8 and Maven 3.2 (See: http://jira.codehaus.org/browse/MPLUGIN-244)
### How reproduce:

Just execute `mvn install` with JDK8 and Maven 3.2
### Solution:

Added a profile to deactivate the strict html options when compiling with JDK 8.
