### PR TITLE
Adding team_id in Auth response for Business API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 
 # Output file when rendering ReadMe.md locally.
 /ReadMe.html
+
+.classpath
+.settings
+.project

--- a/src/com/dropbox/core/DbxAccountInfo.java
+++ b/src/com/dropbox/core/DbxAccountInfo.java
@@ -14,14 +14,16 @@ import java.io.IOException;
 public class DbxAccountInfo extends Dumpable
 {
     public final long userId;
+    public final String email;
     public final String displayName;
     public final String country;
     public final String referralLink;
     public final Quota quota;
 
-    public DbxAccountInfo(long userId, String displayName, String country, String referralLink, Quota quota)
+    public DbxAccountInfo(long userId, String email, String displayName, String country, String referralLink, Quota quota)
     {
         this.userId = userId;
+        this.email = email;
         this.displayName = displayName;
         this.country = country;
         this.referralLink = referralLink;
@@ -32,6 +34,7 @@ public class DbxAccountInfo extends Dumpable
     protected void dumpFields(DumpWriter out)
     {
         out.field("userId", userId);
+        out.field("email", email);
         out.field("displayName", displayName);
         out.field("country", country);
         out.field("referralLink", referralLink);
@@ -129,6 +132,7 @@ public class DbxAccountInfo extends Dumpable
             JsonLocation top = JsonReader.expectObjectStart(parser);
 
             long uid = -1;
+            String email = null;
             String display_name = null;
             String country = null;
             String referral_link = null;
@@ -143,6 +147,7 @@ public class DbxAccountInfo extends Dumpable
                     switch (fi) {
                         case -1: JsonReader.skipValue(parser); break;
                         case FM_uid: uid = JsonReader.readUnsignedLongField(parser, fieldName, uid); break;
+                        case FM_email: email = JsonReader.StringReader.readField(parser, fieldName, email); break;
                         case FM_display_name: display_name = JsonReader.StringReader.readField(parser, fieldName, display_name); break;
                         case FM_country: country = JsonReader.StringReader.readField(parser, fieldName, country); break;
                         case FM_referral_link: referral_link = JsonReader.StringReader.readField(parser, fieldName, referral_link); break;
@@ -160,11 +165,12 @@ public class DbxAccountInfo extends Dumpable
 
             if (uid < 0) throw new JsonReadException("missing field \"uid\"", top);
             if (display_name == null) throw new JsonReadException("missing field \"display_name\"", top);
+            if (email == null) throw new JsonReadException("missing field \"email\"", top);
             if (country == null) throw new JsonReadException("missing field \"country\"", top);
             if (referral_link == null) throw new JsonReadException("missing field \"referral_link\"", top);
             if (quota_info == null) throw new JsonReadException("missing field \"quota_info\"", top);
 
-            return new DbxAccountInfo(uid, display_name, country, referral_link, quota_info);
+            return new DbxAccountInfo(uid, email, display_name, country, referral_link, quota_info);
         }
     };
 
@@ -173,6 +179,7 @@ public class DbxAccountInfo extends Dumpable
     private static final int FM_country = 2;
     private static final int FM_referral_link = 3;
     private static final int FM_quota_info = 4;
+    private static final int FM_email = 5;
     private static final JsonReader.FieldMapping FM;
 
     static {
@@ -182,6 +189,7 @@ public class DbxAccountInfo extends Dumpable
         b.add("country", FM_country);
         b.add("referral_link", FM_referral_link);
         b.add("quota_info", FM_quota_info);
+        b.add("email", FM_email);
         FM = b.build();
     }
 }

--- a/src/com/dropbox/core/DbxAuthFinish.java
+++ b/src/com/dropbox/core/DbxAuthFinish.java
@@ -38,17 +38,21 @@ public final class DbxAuthFinish implements java.io.Serializable
      * in, or you used {@link DbxWebAuthNoRedirect}, this will be {@code null}.
      */
     public final /*@Nullable*/String urlState;
+    
+    /** The team id. */
+    public final /*@Nullable*/String teamId;
 
     /**
      * @param accessToken {@link #accessToken}
      * @param userId {@link #userId}
      * @param urlState {@link #urlState}
      */
-    public DbxAuthFinish(String accessToken, String userId, /*@Nullable*/String urlState)
+    public DbxAuthFinish(String accessToken, String userId, /*@Nullable*/String urlState, /*@Nullable*/String teamId)
     {
         this.accessToken = accessToken;
         this.userId = userId;
         this.urlState = urlState;
+        this.teamId = teamId;
     }
 
     /**
@@ -63,6 +67,7 @@ public final class DbxAuthFinish implements java.io.Serializable
             String accessToken = null;
             String tokenType = null;
             String userId = null;
+            String teamId = null;
 
             while (parser.getCurrentToken() == JsonToken.FIELD_NAME) {
                 String fieldName = parser.getCurrentName();
@@ -77,6 +82,9 @@ public final class DbxAuthFinish implements java.io.Serializable
                     }
                     else if (fieldName.equals("uid")) {
                         userId = JsonReader.StringReader.readField(parser, fieldName, userId);
+                    }
+                    else if (fieldName.equals("team_id")) {
+                        teamId = JsonReader.StringReader.readField(parser, fieldName, teamId);
                     }
                     else {
                         // Unknown field.  Skip over it.
@@ -94,7 +102,7 @@ public final class DbxAuthFinish implements java.io.Serializable
             if (accessToken == null) throw new JsonReadException("missing field \"access_token\"", top);
             if (userId == null) throw new JsonReadException("missing field \"uid\"", top);
 
-            return new DbxAuthFinish(accessToken, userId, null);
+            return new DbxAuthFinish(accessToken, userId, null, teamId);
         }
     };
 

--- a/src/com/dropbox/core/DbxMember.java
+++ b/src/com/dropbox/core/DbxMember.java
@@ -1,0 +1,104 @@
+package com.dropbox.core;
+
+import java.io.IOException;
+
+import com.dropbox.core.json.JsonReadException;
+import com.dropbox.core.json.JsonReader;
+import com.dropbox.core.util.DumpWriter;
+import com.dropbox.core.util.Dumpable;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+/*>>> import checkers.nullness.quals.Nullable; */
+
+public class DbxMember extends Dumpable implements java.io.Serializable
+{
+    public static final long serialVersionUID = 0;
+
+    public final String memberId;
+
+    /**
+     * This is almost always {@link DbxHost#Default}.  This is only set differently for testing
+     * purposes.
+     */
+    public final DbxHost host;
+
+    public DbxMember(String memberId)
+    {
+    	this.memberId = memberId;
+        this.host = DbxHost.Default;
+    }
+
+    public DbxMember(String memberId, DbxHost host)
+    {
+    	this.memberId = memberId;
+        this.host = host;
+    }
+
+    @Override
+    protected void dumpFields(DumpWriter out)
+    {
+        out.field("member_id", memberId);
+    }
+
+
+    // ------------------------------------------------------
+    // JSON parsing
+
+    public static final JsonReader<DbxMember> Reader = new JsonReader<DbxMember>()
+    {
+        @Override
+        public final DbxMember read(JsonParser parser)
+            throws IOException, JsonReadException
+        {
+            JsonLocation top = JsonReader.expectObjectStart(parser);
+
+            String memberId = null;
+
+            while (parser.getCurrentToken() == JsonToken.FIELD_NAME) {
+                String fieldName = parser.getCurrentName();
+                parser.nextToken();
+
+                try {
+                    if (fieldName.equals("memeber_id")) {
+                    	memberId = MemberIdReader.readField(parser, fieldName, memberId);
+                    }
+                    else {
+                        // Unknown field.  Skip over it.
+                        JsonReader.skipValue(parser);
+                    }
+                }
+                catch (JsonReadException ex) {
+                    throw ex.addFieldContext(fieldName);
+                }
+            }
+
+            JsonReader.expectObjectEnd(parser);
+
+            if (memberId == null) throw new JsonReadException("missing field \"member_id\"", top);
+
+            return new DbxMember(memberId);
+        }
+    };
+
+    public static final JsonReader<String> MemberIdReader = new JsonReader<String>()
+    {
+        @Override
+        public String read(JsonParser parser) throws IOException, JsonReadException
+        {
+            try {
+                String v = parser.getText();
+                parser.nextToken();
+                return v;
+            }
+            catch (JsonParseException ex) {
+                throw JsonReadException.fromJackson(ex);
+            }
+        }
+    };
+
+
+ 
+}

--- a/src/com/dropbox/core/DbxRequestConfig.java
+++ b/src/com/dropbox/core/DbxRequestConfig.java
@@ -48,6 +48,9 @@ public class DbxRequestConfig
      * </p>
      */
 	public final /*@Nullable*/String userLocale;
+	
+	/** The as member id. */
+	public final /*@Nullable*/String asMemberId; 
 
     /**
      * The {@link HttpRequestor} implementation to use when making
@@ -61,14 +64,15 @@ public class DbxRequestConfig
      * @param userLocale {@link #userLocale}
      * @param httpRequestor {@link #httpRequestor}
      */
-    public DbxRequestConfig(String clientIdentifier, /*@Nullable*/String userLocale, HttpRequestor httpRequestor)
+    public DbxRequestConfig(String clientIdentifier, /*@Nullable*/String userLocale, /*@Nullable*/String asMemberId, HttpRequestor httpRequestor)
     {
-        if (clientIdentifier == null) throw new IllegalArgumentException("'clientIdentifier' should not be null");
+		if (clientIdentifier == null) throw new IllegalArgumentException("'clientIdentifier' should not be null");
         if (httpRequestor == null) throw new IllegalArgumentException("'httpRequestor' should not be null");
 
         this.clientIdentifier = clientIdentifier;
         this.userLocale = userLocale;
         this.httpRequestor = httpRequestor;
+        this.asMemberId = asMemberId;
     }
 
     /**
@@ -77,6 +81,26 @@ public class DbxRequestConfig
      */
     public DbxRequestConfig(String clientIdentifier, String userLocale)
     {
-        this(clientIdentifier, userLocale, StandardHttpRequestor.Instance);
+        this(clientIdentifier, userLocale, null, StandardHttpRequestor.Instance);
     }
+
+	/**
+	 * Instantiates a new dbx request config.
+	 *
+	 * @param clientIdentifier the client identifier
+	 * @param memberId the member id
+	 * @param userLocale the user locale
+	 */
+	public DbxRequestConfig(String clientIdentifier, String memberId, String userLocale) {
+		this(clientIdentifier, userLocale, memberId, StandardHttpRequestor.Instance);
+	}
+
+	/**
+	 * Member id present.
+	 *
+	 * @return true, if successful
+	 */
+	public boolean memberIdPresent() {
+		return asMemberId != null && asMemberId.length() > 0;
+	}
 }

--- a/src/com/dropbox/core/DbxRequestUtil.java
+++ b/src/com/dropbox/core/DbxRequestUtil.java
@@ -15,6 +15,7 @@ import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
 import com.dropbox.core.util.IOUtil;
 import com.dropbox.core.util.StringUtil;
+
 import static com.dropbox.core.util.StringUtil.jq;
 import static com.dropbox.core.util.LangUtil.mkAssert;
 
@@ -86,6 +87,15 @@ public class DbxRequestUtil
         headers.add(new HttpRequestor.Header("Authorization", "Bearer " + accessToken));
         return headers;
     }
+    
+	private static ArrayList<HttpRequestor.Header> addAsMemberHeader(
+			/*@Nullable*/ArrayList<HttpRequestor.Header> headers, DbxRequestConfig requestConfig) {
+		if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
+		if(requestConfig.memberIdPresent()){
+			headers.add(new HttpRequestor.Header("X-Dropbox-Perform-As-Team-Member", requestConfig.asMemberId));
+    	}
+		return headers;
+	}
 
     public static ArrayList<HttpRequestor.Header> addUserAgentHeader(/*@Nullable*/ArrayList<HttpRequestor.Header> headers,
                                                                      DbxRequestConfig requestConfig)
@@ -110,6 +120,7 @@ public class DbxRequestUtil
     {
         headers = addUserAgentHeader(headers, requestConfig);
         headers = addAuthHeader(headers, accessToken);
+        headers = addAsMemberHeader(headers, requestConfig);
 
         String url = buildUrlWithParams(requestConfig.userLocale, host, path, params);
         try {
@@ -131,6 +142,7 @@ public class DbxRequestUtil
     {
         headers = addUserAgentHeader(headers, requestConfig);
         headers = addAuthHeader(headers, accessToken);
+        headers = addAsMemberHeader(headers, requestConfig);
 
         String url = buildUrlWithParams(requestConfig.userLocale, host, path, params);
         try {

--- a/src/com/dropbox/core/DbxWebAuth.java
+++ b/src/com/dropbox/core/DbxWebAuth.java
@@ -1,10 +1,11 @@
 package com.dropbox.core;
 
-import com.dropbox.core.util.StringUtil;
 import static com.dropbox.core.util.StringUtil.jq;
 
 import java.security.SecureRandom;
 import java.util.Map;
+
+import com.dropbox.core.util.StringUtil;
 
 /*>>> import checkers.nullness.quals.Nullable; */
 
@@ -241,7 +242,7 @@ public class DbxWebAuth
         assert code != null : "@AssumeAssertion(nullness)";
 
         DbxAuthFinish finish = DbxWebAuthHelper.finish(this.appInfo, this.requestConfig, code, this.redirectUri);
-        return new DbxAuthFinish(finish.accessToken, finish.userId, givenUrlState);
+        return new DbxAuthFinish(finish.accessToken, finish.userId, givenUrlState, finish.teamId);
     }
 
     private static /*@Nullable*/String getParam(Map<String,String[]> params, String name)


### PR DESCRIPTION
Since Authorization response in Business API it is a little different, in order to get team_id field i have added that field to DbxAuthFinish object. I would like to ask you if you could merge this into main dropbox-sdk-java repo and release new version into maven repo.

Thanks,
