### PR TITLE
Made OSGi bundle usable with arbitrary JRE version for OSGi Subsystems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,14 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <version>2.5.0</version>
                 <extensions>true</extensions>
+                <!-- Bnd tool generates Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))", 
+		        which expresses the base JRE requirement of the bundle. This is an issue, 
+		        when working with OSGi subsystems. -->
+                <configuration>
+		            <instructions>
+			            <_noee>true</_noee>
+		            </instructions>
+	            </configuration>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>


### PR DESCRIPTION
As discussed in https://github.com/dropbox/dropbox-sdk-java/issues/19, the dropbox sdk java currently uses the "maven-bundle-plugin", which automatically generates an OSGi-Subsystem compatible "Require-Capability" that expresses the base JRE requirement of the bundle: Require-Capability: "osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))".

When using an OSGi container, e.g., equinox >= v3.8.2 + aries.subsystem, and packaging the dropbox sdk java bundle into a subsystem on a more recent JRE, the subsystem cannot start because of the (fixed and outdated?) required JRE capability.

Hence, to make the bundle usable in an OSGi subsystem with arbitrary JRE version I added an additional BND instruction in the "maven-bundle-plugin", which prevents the plugin to generate the "Require-Capability".