### PR TITLE
video_info duration can be null

### DIFF
--- a/src/com/dropbox/core/DbxEntry.java
+++ b/src/com/dropbox/core/DbxEntry.java
@@ -483,7 +483,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                     JsonReader.expectObjectStart(parser);
                     File.Location location = null;
                     Date time_taken = null;
-                    long duration = 0;
+                    Long duration = null;
                     while (parser.getCurrentToken() == JsonToken.FIELD_NAME) {
                         String fieldName = parser.getCurrentName();
                         JsonReader.nextToken(parser);
@@ -492,7 +492,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                         } else if (fieldName.equals("time_taken")) {
                             time_taken = JsonDateReader.Dropbox.readOptional(parser);
                         } else if (fieldName.equals("duration")) {
-                            duration = JsonReader.readUnsignedLong(parser);
+                            duration = JsonReader.readOptionalUnsignedLong(parser);
                         } else {
                             JsonReader.skipValue(parser);
                         }

--- a/src/com/dropbox/core/json/JsonReader.java
+++ b/src/com/dropbox/core/json/JsonReader.java
@@ -147,6 +147,16 @@ public abstract class JsonReader<T>
         }
     }
 
+    public static Long readOptionalUnsignedLong(JsonParser parser)
+        throws IOException, JsonReadException
+    {
+        if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            parser.nextToken();
+            return null;
+        }
+        return readUnsignedLong(parser);
+    }
+
     public static long readUnsignedLongField(JsonParser parser, String fieldName, long v)
         throws IOException, JsonReadException
     {

--- a/test/com/dropbox/core/DbxEntryTest.java
+++ b/test/com/dropbox/core/DbxEntryTest.java
@@ -72,6 +72,7 @@ public class DbxEntryTest
     public void parseFileWithVideoInfoNullFields() throws Exception
     {
         DbxEntry.File f = loadJsonResource(DbxEntry.Reader, "file-with-video-info-null-fields.json").asFile();
+        assertNull(f.videoInfo.duration);
         assertNull(f.videoInfo.location);
         assertNull(f.videoInfo.timeTaken);
     }

--- a/test/com/dropbox/core/file-with-video-info-null-fields.json
+++ b/test/com/dropbox/core/file-with-video-info-null-fields.json
@@ -10,7 +10,7 @@
   "bytes": 802996,
   "modified": "Fri, 20 Mar 2015 17:45:56 +0000",
   "video_info": {
-    "duration": 1000,
+    "duration": null,
     "lat_long": null,
     "time_taken": null
   },


### PR DESCRIPTION
I had a case where the duration in video_info was null. This commit fixes the issue