### PR TITLE
Adding email, email_verified and name_details to the AccountInfo response

### DIFF
--- a/src/com/dropbox/core/DbxAccountInfo.java
+++ b/src/com/dropbox/core/DbxAccountInfo.java
@@ -20,11 +20,11 @@ public class DbxAccountInfo extends Dumpable
     public final Quota quota;
     public final String email;
     public final NameDetails nameDetails;
-    public final Boolean emailVerified;
+    public final boolean emailVerified;
 
 
     public DbxAccountInfo(long userId, String displayName, String country, String referralLink, Quota quota, String email,
-                          NameDetails nameDetails, Boolean emailVerified)
+                          NameDetails nameDetails, boolean emailVerified)
     {
         this.userId = userId;
         this.displayName = displayName;


### PR DESCRIPTION
We require the user's name and email address. We can get this information via the /account/info API but these fields are not available when using the Java SDK. Ideally we would like to use the Java SDK for all our dropbox needs. 