### PR TITLE
Update examples location in ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -46,9 +46,9 @@ Save the API key to a JSON file called, say, "test.app":
 ## Using the Dropbox API
 
 Before your app can access a Dropbox user's files, the user must authorize your application using OAuth 2.  Successfully completing this authorization flow gives you an _access token_ for the user's Dropbox account, which grants you the ability to make Dropbox API calls to access their files.
-  * Example for a simple web app: [Web File Browser example](examples/web-file-browser/src/com/dropbox/core/examples/web_file_browser/DropboxAuth.java)
+  * Example for a simple web app: [Web File Browser example](examples/web-file-browser/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxAuth.java)
   * Example for an Android app: [Android example](examples/android/src/main/java/com/dropbox/core/examples/android/UserActivity.java)
-  * Example for a command-line tool: [Command-Line Authorization example](examples/authorize/src/com/dropbox/core/examples/authorize/Main.java)
+  * Example for a command-line tool: [Command-Line Authorization example](examples/authorize/src/main/java/com/dropbox/core/examples/authorize/Main.java)
 
 Once you have an access token, create a [`DbxClientV2`](https://dropbox.github.io/dropbox-sdk-java/api-docs/v2.0.x/com/dropbox/core/v2/DbxClientV2.html) and start making API calls.
 


### PR DESCRIPTION
While reading through your docs I noticed the Web File Browser and Command-Line Authorization examples were dead. It looks like they got moved in 3cfa878e5d73f06ed4782c8833b229838fd21472 but the readme wasn't updated to reflect their new location. This pull request contains an update to the readme so it reflects their new location.