### PR TITLE
Update OKHttp to v3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,14 @@
 
         <!-- A "soft" dependency on OkHttp. -->
         <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>2.7.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- A "soft" dependency on OkHttp3. -->
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>3.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
 
         <!-- A "soft" dependency on OkHttp. -->
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>2.7.4</version>
+            <version>3.3.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
+++ b/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
@@ -1,19 +1,17 @@
 package com.dropbox.core.http;
 
-import com.squareup.okhttp.Call;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.internal.Util;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.internal.Util;
 import okio.Buffer;
 import okio.BufferedSink;
 
@@ -27,26 +25,27 @@ import okio.BufferedSink;
  * To use this, pass {@link #INSTANCE} to the {@link com.dropbox.core.DbxRequestConfig} constructor.
  * </p>
  */
-public class OkHttpRequestor extends HttpRequestor
+public class OkHttp3Requestor extends HttpRequestor
 {
     /**
      * A thread-safe instance of {@code OkHttpRequestor} that connects directly
      * (as opposed to using a proxy).
      */
-    public static final OkHttpRequestor INSTANCE = new OkHttpRequestor(defaultOkHttpClient());
+    public static final OkHttp3Requestor INSTANCE = new OkHttp3Requestor(defaultOkHttpClient());
 
     private final OkHttpClient client;
 
     private static OkHttpClient defaultOkHttpClient()
     {
-        OkHttpClient client = new OkHttpClient();
-        client.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-        client.setReadTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-        client.setWriteTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        OkHttpClient client = new OkHttpClient.Builder()
+            .connectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            .readTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            .writeTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            .build();
         return client;
     }
 
-    public OkHttpRequestor(OkHttpClient client)
+    public OkHttp3Requestor(OkHttpClient client)
     {
         this.client = client;
     }
@@ -57,7 +56,7 @@ public class OkHttpRequestor extends HttpRequestor
     {
         Request.Builder builder = new Request.Builder().get().url(url);
         toOkHttpHeaders(headers, builder);
-        com.squareup.okhttp.Response response = client.newCall(builder.build()).execute();
+        okhttp3.Response response = client.newCall(builder.build()).execute();
         Map<String, List<String>> responseHeaders = fromOkHttpHeaders(response.headers());
         return new Response(response.code(), response.body().byteStream(), responseHeaders);
     }
@@ -102,11 +101,11 @@ public class OkHttpRequestor extends HttpRequestor
     }
 
     /**
-     * Implementation of {@link com.dropbox.core.http.HttpRequestor.Uploader} that exposes
+     * Implementation of {@link Uploader} that exposes
      * the {@link java.io.OutputStream} from an Okio {@link Buffer} that is connected to an OkHttp
      * {@link RequestBody}.  Calling {@link #finish()} will execute the request with OkHttp
      */
-    private static class BufferUploader extends HttpRequestor.Uploader
+    private static class BufferUploader extends Uploader
     {
         private final Call call;
         private final Buffer requestBuffer;
@@ -134,7 +133,7 @@ public class OkHttpRequestor extends HttpRequestor
         public Response finish()
             throws IOException
         {
-            com.squareup.okhttp.Response response = call.execute();
+            okhttp3.Response response = call.execute();
             Map<String, List<String>> responseHeaders = fromOkHttpHeaders(response.headers());
             return new Response(response.code(), response.body().byteStream(), responseHeaders);
         }

--- a/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
+++ b/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
@@ -1,12 +1,12 @@
 package com.dropbox.core.http;
 
-import com.squareup.okhttp.Call;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.internal.Util;
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.internal.Util;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -39,10 +39,11 @@ public class OkHttpRequestor extends HttpRequestor
 
     private static OkHttpClient defaultOkHttpClient()
     {
-        OkHttpClient client = new OkHttpClient();
-        client.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-        client.setReadTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-        client.setWriteTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        OkHttpClient client = new OkHttpClient.Builder()
+            .connectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            .readTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            .writeTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            .build();
         return client;
     }
 
@@ -57,7 +58,7 @@ public class OkHttpRequestor extends HttpRequestor
     {
         Request.Builder builder = new Request.Builder().get().url(url);
         toOkHttpHeaders(headers, builder);
-        com.squareup.okhttp.Response response = client.newCall(builder.build()).execute();
+        okhttp3.Response response = client.newCall(builder.build()).execute();
         Map<String, List<String>> responseHeaders = fromOkHttpHeaders(response.headers());
         return new Response(response.code(), response.body().byteStream(), responseHeaders);
     }
@@ -134,7 +135,7 @@ public class OkHttpRequestor extends HttpRequestor
         public Response finish()
             throws IOException
         {
-            com.squareup.okhttp.Response response = call.execute();
+            okhttp3.Response response = call.execute();
             Map<String, List<String>> responseHeaders = fromOkHttpHeaders(response.headers());
             return new Response(response.code(), response.body().byteStream(), responseHeaders);
         }


### PR DESCRIPTION
I'm running a project that already has OkHTTP as a dependency, but version 3. I wasn't sure if replacing the `OkHttpRequestor` with a new one using OkHTTP3 or create a new one (the packages are different), such as `OkHttp3Requestor`

I ended up creating an additional `OkHttp3Requestor` to avoid backwards incompatibility