### PR TITLE
examples/web-file-browser: Fix slurpUtf8Part.

### DIFF
--- a/examples/web-file-browser/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxBrowse.java
+++ b/examples/web-file-browser/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxBrowse.java
@@ -327,7 +327,7 @@ public class DropboxBrowse
         InputStream in = part.getInputStream();
         int bytesRead = in.read(bytes);
 
-        if (in.read() == -1) {
+        if (bytesRead == -1) {
             return "";
         }
 


### PR DESCRIPTION
This was calling in.read() twice.  The second time it would always be
-1, so the function would always return the empty string.