### PR TITLE
Encode userLocale before opening auth webpage

### DIFF
--- a/src/main/java/com/dropbox/core/DbxRequestUtil.java
+++ b/src/main/java/com/dropbox/core/DbxRequestUtil.java
@@ -75,7 +75,7 @@ public final class DbxRequestUtil {
         StringBuilder buf = new StringBuilder();
         String sep = "";
         if (userLocale != null) {
-            buf.append("locale=").append(userLocale);
+            buf.append("locale=").append(encodeUrlParam(userLocale));
             sep = "&";
         }
 


### PR DESCRIPTION
Sometimes Locale#toString() returns a string that has a '#' character.
Without URL-encoding it, the string will act as page hash when the 
auth URL is opened in the user's web browser.

As reported in issue #115