### PR TITLE
User newer APIs for specifying the source dir

### DIFF
--- a/stone.gradle
+++ b/stone.gradle
@@ -125,7 +125,7 @@ project.sourceSets.all { SourceSet sourceSet ->
         def getSpecFiles = { fileTree(dir: specDir, include: '**/*.stone') }
 
         inputs.dir { project.fileTree(dir: generatorDir, exclude: '**/*.pyc') }
-        inputs.sourceDir getSpecFiles
+        inputs.dir(getSpecFiles).skipWhenEmpty = true
         inputs.property "config", { new groovy.json.JsonBuilder(config).toString() }
         outputs.dir { outputDir }
 


### PR DESCRIPTION
The sourceDir property was deprecated in 3.0 and removed in 4.0. This updates
it to use the newer property as described in the documentation:
https://docs.gradle.org/3.4/javadoc/org/gradle/api/tasks/TaskInputs.html#sourceDir(java.lang.Object)