### PR TITLE
Workaround BadRequestException on  devices with locale whose numeric character is non-ascii (#119)

### DIFF
--- a/src/main/java/com/dropbox/core/stone/Util.java
+++ b/src/main/java/com/dropbox/core/stone/Util.java
@@ -5,6 +5,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -19,7 +20,7 @@ final class Util {
     private static final int SHORT_FORMAT_LENGTH = DATE_FORMAT.replace("'", "").length();
 
     public static String formatTimestamp(Date timestamp) {
-        DateFormat format = new SimpleDateFormat(DATE_TIME_FORMAT);
+        DateFormat format = new SimpleDateFormat(DATE_TIME_FORMAT, Locale.ENGLISH);
         format.setCalendar(new GregorianCalendar(UTC));
         return format.format(timestamp);
     }
@@ -29,9 +30,9 @@ final class Util {
 
         DateFormat format = null;
         if (length == LONG_FORMAT_LENGTH) {
-            format = new SimpleDateFormat(DATE_TIME_FORMAT);
+            format = new SimpleDateFormat(DATE_TIME_FORMAT, Locale.ENGLISH);
         } else if (length == SHORT_FORMAT_LENGTH) {
-            format = new SimpleDateFormat(DATE_FORMAT);
+            format = new SimpleDateFormat(DATE_FORMAT, Locale.ENGLISH);
         } else {
             throw new ParseException("timestamp has unexpected format: '" + timestamp + "'", 0);
         }


### PR DESCRIPTION
Workaround #119 

Force using `Locale.English` for `SimpleDateFormat` to avoid generate the string which DropBox server can not interpret.

For example
2017-06-20T12:37:46Z
for
٢٠T١٢:٣٧:٤٦Z  in Arabic
