### PR TITLE
Fixed Picaso Client intialization issue for null pointer while intial…

### DIFF
--- a/examples/android/src/main/java/com/dropbox/core/examples/android/FilesActivity.java
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/FilesActivity.java
@@ -70,7 +70,8 @@ public class FilesActivity extends DropboxActivity {
                 performWithPermissions(FileAction.UPLOAD);
             }
         });
-
+        //init picaso client
+        PicassoClient.init(this,DropboxClientFactory.getClient());
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.files_list);
         mFilesAdapter = new FilesAdapter(PicassoClient.getPicasso(), new FilesAdapter.Callback() {
             @Override


### PR DESCRIPTION
While testing example code for android i figure out that PicasoClient is not initialised. Due to this reason it was failed to use mPicaso member on FilesAdapter.java . At the moment i have added PicasoClient initialisation.