### PR TITLE
Fix generated Java source path

### DIFF
--- a/stone.gradle
+++ b/stone.gradle
@@ -136,7 +136,7 @@ project.sourceSets.all { SourceSet sourceSet ->
         }
     }
 
-    sourceSet.java.srcDir project.tasks."${taskName}".outputDir
+    sourceSet.java.srcDir project.tasks."${taskName}".outputDir + "/src"
     Task compile = project.tasks.getByName(sourceSet.getCompileTaskName("java"))
     compile.dependsOn project.tasks."${taskName}"
 }


### PR DESCRIPTION
Gradle is happy with being given the wrong `srcDir`, but IntelliJ is not. We set the source directory to `.../generated/source/stone/{main,test}`, but it should be `.../{main,test}/src` because Stone creates an extra `src` directory. This makes IntelliJ unable to find the relevant classes.