### PR TITLE
Make build and helper script work under Python 3.

### DIFF
--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -48,8 +48,9 @@ from stone.ir import (
 )
 from stone.backend import CodeBackend
 
+@six.add_metaclass(abc.ABCMeta)
 class StoneType:
-    __metaclass__ = abc.ABCMeta
+    pass
 
 StoneType.register(ApiNamespace)
 StoneType.register(ApiRoute)
@@ -2265,7 +2266,7 @@ class JavaReference(object):
 
     def _as_json(self):
         dct = {}
-        for k, v in self.__dict__.iteritems():
+        for k, v in self.__dict__.items():
             # avoid cyclic references issue
             if isinstance(v, JavaReference):
                 dct[k] = v.fq_name

--- a/scripts/export-generated
+++ b/scripts/export-generated
@@ -79,7 +79,7 @@ def get_files_in_repo(repo_path, exclude_ignored_files=False):
         ignored_files = subprocess.check_output(command, cwd=repo_path).split()
     else:
         ignored_files = []
-    return [file for file in files_list if file not in ignored_files]
+    return [file.decode('utf8') for file in files_list if file not in ignored_files]
 
 def strip_private_sections(path):
     """Delete everything in the file between the private repo tags"""
@@ -121,7 +121,7 @@ def main():
     """The entry point for the program."""
 
     args = _cmdline_parser.parse_args()
-    cwd = os.path.dirname(os.path.dirname(__file__))
+    cwd = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     repo_path = args.repo_path
     def log(msg):
         if args.verbose:


### PR DESCRIPTION
I'm pretty sure we want the build to work under Python 2 and Python 3 because some users only have one or the other.

This is less important for the `export-generated` script, since that's only used by maintainers, but it was pretty easy to get it running under Python 3 so I did.