### PR TITLE
Add route whitelisting to the Java SDK

### DIFF
--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -1736,7 +1736,7 @@ class JavaApi(object):
         return visibility
 
     @staticmethod
-    def _get_data_types_from_doc_ref(api, doc, namespace_context, dummy):
+    def _get_data_types_from_doc_ref(api, doc, namespace_context):
         """
         Given a documentation string, parse it and return all references to other
         data types. If there are references to routes, include also the data types of
@@ -1749,7 +1749,7 @@ class JavaApi(object):
         """
         output = []
         data_types, routes_by_ns = JavaApi._get_data_types_and_routes_from_doc_ref(
-            api, doc, namespace_context, dummy)
+            api, doc, namespace_context)
         for d in data_types:
             output.append(d)
         for ns_name, routes in routes_by_ns.items():
@@ -1760,7 +1760,7 @@ class JavaApi(object):
         return output
 
     @staticmethod
-    def _get_data_types_and_routes_from_doc_ref(api, doc, namespace_context, dummy):
+    def _get_data_types_and_routes_from_doc_ref(api, doc, namespace_context):
         """
         Given a documentation string, parse it and return all references to other
         data types and routes.

--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -1775,33 +1775,39 @@ class JavaApi(object):
         routes = defaultdict(set)
 
         for match in doc_ref_re.finditer(doc):
-            tag = match.group('tag')
-            val = match.group('val')
-            supplied_namespace = api.namespaces[namespace_context]
-            if tag == 'field':
-                if '.' in val:
-                    type_name, __ = val.split('.', 1)
-                    doc_type = supplied_namespace.data_type_by_name[type_name]
-                    data_types.add(doc_type)
-                else:
-                    pass  # no action required, because we must be referencing the same object
-            elif tag == 'route':
-                if '.' in val:
-                    namespace_name, val = val.split('.', 1)
-                    namespace = api.namespaces[namespace_name]
-                    route = namespace.route_by_name[val]
-                    routes[namespace_name].add(route)
-                else:
-                    route = supplied_namespace.route_by_name[val]
-                    routes[supplied_namespace.name].add(route)
-            elif tag == 'type':
-                if '.' in val:
-                    namespace_name, val = val.split('.', 1)
-                    doc_type = api.namespaces[namespace_name].data_type_by_name[val]
-                    data_types.add(doc_type)
-                else:
-                    doc_type = supplied_namespace.data_type_by_name[val]
-                    data_types.add(doc_type)
+            try:
+                tag = match.group('tag')
+                val = match.group('val')
+                supplied_namespace = api.namespaces[namespace_context]
+                if tag == 'field':
+                    if '.' in val:
+                        type_name, __ = val.split('.', 1)
+                        doc_type = supplied_namespace.data_type_by_name[type_name]
+                        data_types.add(doc_type)
+                    else:
+                        pass  # no action required, because we must be referencing the same object
+                elif tag == 'route':
+                    if '.' in val:
+                        namespace_name, val = val.split('.', 1)
+                        namespace = api.namespaces[namespace_name]
+                        route = namespace.route_by_name[val]
+                        routes[namespace_name].add(route)
+                    else:
+                        route = supplied_namespace.route_by_name[val]
+                        routes[supplied_namespace.name].add(route)
+                elif tag == 'type':
+                    if '.' in val:
+                        namespace_name, val = val.split('.', 1)
+                        doc_type = api.namespaces[namespace_name].data_type_by_name[val]
+                        data_types.add(doc_type)
+                    else:
+                        doc_type = supplied_namespace.data_type_by_name[val]
+                        data_types.add(doc_type)
+            except KeyError:
+                # We may reference a datatype or route that was filtered out, in which
+                # case just skip it and continue. We rely on the Stone layer to ensure
+                # that all these docrefs are valid to begin with.
+                continue
         return data_types, routes
 
     @staticmethod

--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -47,6 +47,7 @@ from stone.ir import (
     Void,
 )
 from stone.backend import CodeBackend
+from stone.frontend.ir_generator import doc_ref_re
 
 @six.add_metaclass(abc.ABCMeta)
 class StoneType:
@@ -1623,9 +1624,18 @@ class JavaApi(object):
         cur_state = visibility.copy()
         while prev_state != cur_state:
             for namespace in api.namespaces.values():
+                if namespace.doc is not None:
+                    data_types = JavaApi._get_data_types_from_doc_ref(api, namespace.doc, namespace.name, data_type)
+                    for d in data_types:
+                        update_by_reference(d, namespace)
                 for data_type in namespace.data_types:
                     if not visibility[data_type].is_visible:
                         continue
+
+                    if data_type.doc is not None:
+                        data_types = JavaApi._get_data_types_from_doc_ref(api, data_type.doc, namespace.name, data_type)
+                        for d in data_types:
+                            update_by_reference(d, namespace)
 
                     for field in data_type.all_fields:
                         field_data_type = get_underlying_type(field.data_type)
@@ -1638,6 +1648,11 @@ class JavaApi(object):
                                 # otherwise, just update visibility so this class can properly reference
                                 # the field data type
                                 update_by_reference(field_data_type, namespace)
+
+                        if field.doc is not None:
+                            data_types = JavaApi._get_data_types_from_doc_ref(api, field.doc, namespace.name, data_type)
+                        for d in data_types:
+                            update_by_reference(d, namespace)
 
                     if is_struct_type(data_type):
                         if data_type.parent_type:
@@ -1687,14 +1702,28 @@ class JavaApi(object):
         cur_state = visibility.copy()
         while prev_state != cur_state:
             for namespace in api.namespaces.values():
+                if namespace.doc is not None:
+                    data_types = JavaApi._get_data_types_from_doc_ref(api, namespace.doc, namespace.name, data_type)
+                    for d in data_types:
+                        update_by_reference(d, namespace)
                 for data_type in namespace.data_types:
                     if not visibility[data_type].is_visible:
                         continue
+
+                    if data_type.doc is not None:
+                        data_types = JavaApi._get_data_types_from_doc_ref(api, data_type.doc, namespace.name, data_type)
+                        for d in data_types:
+                            update_by_reference(d, namespace)
 
                     for field in data_type.all_fields:
                         field_data_type = get_underlying_type(field.data_type)
                         if is_user_defined_type(field_data_type):
                             update_by_reference(field_data_type, namespace)
+
+                        if field.doc is not None:
+                            data_types = JavaApi._get_data_types_from_doc_ref(api, field.doc, namespace.name, data_type)
+                        for d in data_types:
+                            update_by_reference(d, namespace)
 
                     # parents need access to their enumerated subtype serializers
                     if is_struct_type(data_type) and data_type.has_enumerated_subtypes():
@@ -1705,6 +1734,75 @@ class JavaApi(object):
             cur_state = visibility.copy()
 
         return visibility
+
+    @staticmethod
+    def _get_data_types_from_doc_ref(api, doc, namespace_context, dummy):
+        """
+        Given a documentation string, parse it and return all references to other
+        data types. If there are references to routes, include also the data types of
+        those routes.
+        Args:
+        - doc: The documentation string to parse.
+        - namespace_context: The namespace name relative to this documentation.
+        Returns:
+        - a list of referenced data types
+        """
+        output = []
+        data_types, routes_by_ns = JavaApi._get_data_types_and_routes_from_doc_ref(
+            api, doc, namespace_context, dummy)
+        for d in data_types:
+            output.append(d)
+        for ns_name, routes in routes_by_ns.items():
+            ns = api.namespaces[ns_name]
+            for r in routes:
+                for d in ns.get_route_io_data_types_for_route(r):
+                    output.append(d)
+        return output
+
+    @staticmethod
+    def _get_data_types_and_routes_from_doc_ref(api, doc, namespace_context, dummy):
+        """
+        Given a documentation string, parse it and return all references to other
+        data types and routes.
+        Args:
+        - doc: The documentation string to parse.
+        - namespace_context: The namespace name relative to this documentation.
+        Returns:
+        - a tuple of referenced data types and routes
+        """
+        assert doc is not None
+        data_types = set()
+        routes = defaultdict(set)
+
+        for match in doc_ref_re.finditer(doc):
+            tag = match.group('tag')
+            val = match.group('val')
+            supplied_namespace = api.namespaces[namespace_context]
+            if tag == 'field':
+                if '.' in val:
+                    type_name, __ = val.split('.', 1)
+                    doc_type = supplied_namespace.data_type_by_name[type_name]
+                    data_types.add(doc_type)
+                else:
+                    pass  # no action required, because we must be referencing the same object
+            elif tag == 'route':
+                if '.' in val:
+                    namespace_name, val = val.split('.', 1)
+                    namespace = api.namespaces[namespace_name]
+                    route = namespace.route_by_name[val]
+                    routes[namespace_name].add(route)
+                else:
+                    route = supplied_namespace.route_by_name[val]
+                    routes[supplied_namespace.name].add(route)
+            elif tag == 'type':
+                if '.' in val:
+                    namespace_name, val = val.split('.', 1)
+                    doc_type = api.namespaces[namespace_name].data_type_by_name[val]
+                    data_types.add(doc_type)
+                else:
+                    doc_type = supplied_namespace.data_type_by_name[val]
+                    data_types.add(doc_type)
+        return data_types, routes
 
     @staticmethod
     def get_spec_filename(element):

--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -1625,7 +1625,7 @@ class JavaApi(object):
         while prev_state != cur_state:
             for namespace in api.namespaces.values():
                 if namespace.doc is not None:
-                    data_types = JavaApi._get_data_types_from_doc_ref(api, namespace.doc, namespace.name, data_type)
+                    data_types = JavaApi._get_data_types_from_doc_ref(api, namespace.doc, namespace.name)
                     for d in data_types:
                         update_by_reference(d, namespace)
                 for data_type in namespace.data_types:
@@ -1633,7 +1633,7 @@ class JavaApi(object):
                         continue
 
                     if data_type.doc is not None:
-                        data_types = JavaApi._get_data_types_from_doc_ref(api, data_type.doc, namespace.name, data_type)
+                        data_types = JavaApi._get_data_types_from_doc_ref(api, data_type.doc, namespace.name)
                         for d in data_types:
                             update_by_reference(d, namespace)
 
@@ -1650,7 +1650,7 @@ class JavaApi(object):
                                 update_by_reference(field_data_type, namespace)
 
                         if field.doc is not None:
-                            data_types = JavaApi._get_data_types_from_doc_ref(api, field.doc, namespace.name, data_type)
+                            data_types = JavaApi._get_data_types_from_doc_ref(api, field.doc, namespace.name)
                         for d in data_types:
                             update_by_reference(d, namespace)
 
@@ -1703,7 +1703,7 @@ class JavaApi(object):
         while prev_state != cur_state:
             for namespace in api.namespaces.values():
                 if namespace.doc is not None:
-                    data_types = JavaApi._get_data_types_from_doc_ref(api, namespace.doc, namespace.name, data_type)
+                    data_types = JavaApi._get_data_types_from_doc_ref(api, namespace.doc, namespace.name)
                     for d in data_types:
                         update_by_reference(d, namespace)
                 for data_type in namespace.data_types:
@@ -1711,7 +1711,7 @@ class JavaApi(object):
                         continue
 
                     if data_type.doc is not None:
-                        data_types = JavaApi._get_data_types_from_doc_ref(api, data_type.doc, namespace.name, data_type)
+                        data_types = JavaApi._get_data_types_from_doc_ref(api, data_type.doc, namespace.name)
                         for d in data_types:
                             update_by_reference(d, namespace)
 
@@ -1721,7 +1721,7 @@ class JavaApi(object):
                             update_by_reference(field_data_type, namespace)
 
                         if field.doc is not None:
-                            data_types = JavaApi._get_data_types_from_doc_ref(api, field.doc, namespace.name, data_type)
+                            data_types = JavaApi._get_data_types_from_doc_ref(api, field.doc, namespace.name)
                         for d in data_types:
                             update_by_reference(d, namespace)
 

--- a/stone.gradle
+++ b/stone.gradle
@@ -6,6 +6,7 @@ class StoneConfig {
     String globalRouteFilter = null
     boolean dataTypesOnly = false
     List<ClientSpec> clients = []
+    String routeWhitelistFilter = null
 }
 
 class ClientSpec {
@@ -48,6 +49,9 @@ def runStoneGenerator(StoneConfig config,
 
             environment PYTHONPATH: stoneDir.absolutePath
             args "--clean-build"
+            if (config.routeWhitelistFilter) {
+                args "--route-whitelist-filter", config.routeWhitelistFilter
+            }
             args generatorFile.absolutePath
             args srcOutputDir.absolutePath
             args specFiles.collect({ f -> f.absolutePath })
@@ -81,6 +85,9 @@ def runStoneGenerator(StoneConfig config,
             if (routeFilter) {
                 args "--filter-by-route-attr", routeFilter
             }
+            if (config.routeWhitelistFilter) {
+                args "--route-whitelist-filter", config.routeWhitelistFilter
+            }
             args generatorFile.absolutePath
             args srcOutputDir.absolutePath
             args specFiles.collect({ f -> f.absolutePath })
@@ -113,6 +120,7 @@ project.sourceSets.all { SourceSet sourceSet ->
         description "Generate Stone Java source files for ${sourceSet.name}."
 
         def specDirPropName = "com.dropbox.api.${sourceSet.name}.specDir".toString()
+        def routeWhitelistFilterPropName = "com.dropbox.api.${sourceSet.name}.routeWhitelistFilter".toString()
 
         ext {
             config = new StoneConfig()
@@ -120,6 +128,7 @@ project.sourceSets.all { SourceSet sourceSet ->
             stoneDir = 'stone'
             specDir = project.properties.get(specDirPropName, "src/${sourceSet.name}/stone")
             outputDir = "${project.buildDir}/generated/source/stone/${sourceSet.name}"
+            routeWhitelistFilter = project.properties.get(routeWhitelistFilterPropName, null)
         }
 
         def getSpecFiles = { fileTree(dir: specDir, include: '**/*.stone') }
@@ -132,6 +141,7 @@ project.sourceSets.all { SourceSet sourceSet ->
         doLast {
             def generatorFile = fileTree(dir: generatorDir, include: '**/*stoneg.py').getSingleFile()
             def specFiles = getSpecFiles().getFiles()
+            config.routeWhitelistFilter = routeWhitelistFilter
             runStoneGenerator config, file(stoneDir), generatorFile, specFiles, file(outputDir)
         }
     }


### PR DESCRIPTION
Adds route whitelisting to the Java SDK by making the following changes:
- Edit stone.gradle to take in a JSON whitelist, and pass that into stone
- Bring stone submodule to the version that supports route whitelisting
- Add java.stoneg.py so that it parses docrefs and extends visibility the referenced datatypes and serializers.

I tested the route whitelisting path by building and running our app. I tested the old code path by running ./gradlew build in this repo.