### PR TITLE
Upgrade Jackson to 2.7.9.1 to provide a fix for Jackson Deserializer security vulnerability via default typing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ repositories {
 dependencies {
     // Important: Jackson 2.8+ will be free to use JDK7 features and no longer guarantees JDK6
     //            compatibility
-    compile 'com.fasterxml.jackson.core:jackson-core:2.7.4'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.7.9.1'
 
     compileOnly 'javax.servlet:servlet-api:2.5'
     compileOnly 'com.squareup.okhttp:okhttp:2.7.5'  // support both v2 and v3 to avoid

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ repositories {
 dependencies {
     // Important: Jackson 2.8+ will be free to use JDK7 features and no longer guarantees JDK6
     //            compatibility
-    compile 'com.fasterxml.jackson.core:jackson-core:2.7.9.1'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.9.1'
 
     compileOnly 'javax.servlet:servlet-api:2.5'
     compileOnly 'com.squareup.okhttp:okhttp:2.7.5'  // support both v2 and v3 to avoid


### PR DESCRIPTION
Upgrade Jackson to 2.7.9.1 to provide a fix for "Jackson Deserializer security vulnerability via default typing" described [here](https://adamcaudill.com/2017/10/04/exploiting-jackson-rce-cve-2017-7525/) and fixed in Jackson v2.7.9.1 as described in [related issues](https://github.com/FasterXML/jackson-databind/issues/1599) and [changelog](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.7). There are another to v2.7.9.* minor releases (2.7.9.2 and 2.7.9.3), but I'm not sure does any of them bring any value to dropbox-sdk-java, but correct me if I'm wrong.

Note:
I wasn't able to build project after this change because of missing python dependencies.