### PR TITLE
Add StoneDeserializerLogger to debug DBApp android NPE.

### DIFF
--- a/examples/account-info/src/main/java/com/dropbox/core/examples/account_info/Main.java
+++ b/examples/account-info/src/main/java/com/dropbox/core/examples/account_info/Main.java
@@ -5,8 +5,10 @@ import com.dropbox.core.DbxException;
 import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.DbxWebAuth;
 import com.dropbox.core.json.JsonReader;
+import com.dropbox.core.stone.StoneDeserializerLogger;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.users.FullAccount;
+import com.dropbox.core.v2.users.Name;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -48,9 +50,15 @@ public class Main
             System.exit(1); return;
         }
 
-        // Create a DbxClientV1, which is what you use to make API calls.
+        // Create a DbxClientV2, which is what you use to make API calls.
         DbxRequestConfig requestConfig = new DbxRequestConfig("examples-account-info");
         DbxClientV2 dbxClient = new DbxClientV2(requestConfig, authInfo.getAccessToken(), authInfo.getHost());
+
+        StoneDeserializerLogger.LoggerCallback callback = (o, s) -> {
+            System.out.println("This is from StoneDeserializerLogger: ");
+            System.out.println(s);
+        };
+        StoneDeserializerLogger.registerCallback(Name.class, callback);
 
         // Make the /account/info API call.
         FullAccount dbxAccountInfo;
@@ -63,6 +71,7 @@ public class Main
             System.exit(1); return;
         }
 
+        System.out.println("This is from main: ");
         System.out.print(dbxAccountInfo.toStringMultiline());
     }
 }

--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -873,6 +873,7 @@ class JavaImporter(object):
             'com.fasterxml.jackson.core.JsonParser',
             'com.fasterxml.jackson.core.JsonToken',
             'com.dropbox.core.stone.StoneSerializers',
+            'com.dropbox.core.stone.StoneDeserializerLogger',
         )
         if is_struct_type(data_type):
             self.add_imports('com.dropbox.core.stone.StructSerializer')
@@ -4002,6 +4003,7 @@ class JavaCodeGenerationInstance(object):
             with w.block('if (!collapsed)'):
                 w.out('expectEndObject(p);')
 
+            w.out('StoneDeserializerLogger.log(value, value.toStringMultiline());')
             w.out('return value;')
 
     def generate_union_serialize(self, data_type):

--- a/src/main/java/com/dropbox/core/stone/StoneDeserializerLogger.java
+++ b/src/main/java/com/dropbox/core/stone/StoneDeserializerLogger.java
@@ -1,0 +1,26 @@
+package com.dropbox.core.stone;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StoneDeserializerLogger {
+    public static Map<Class, LoggerCallback> LOGGER_MAP =
+            new HashMap<Class, LoggerCallback>();
+
+    public static void registerCallback(Class c, LoggerCallback callback) {
+        LOGGER_MAP.put(c, callback);
+    }
+
+    public static void log(Object value, String multiLineLog) {
+        Class c = value.getClass();
+
+        if (LOGGER_MAP.containsKey(c)) {
+            LoggerCallback callback = LOGGER_MAP.get(c);
+            callback.invoke(value, multiLineLog);
+        }
+    }
+
+    public interface LoggerCallback {
+        public void invoke(Object value, String multiLineLog);
+    }
+}


### PR DESCRIPTION
This StoneDeserializerLogger will get called in every struct deserializer.

I used a Map<Class, StoneDeserializerLogger> to register callback.

This is just helping DBApp to debug the recent mystery NPE issue. Should be revoked shortly.