### PR TITLE
update-submodules: Do not pull the latest code for each submodule.

### DIFF
--- a/update-submodules
+++ b/update-submodules
@@ -4,4 +4,3 @@ set -euo pipefail
 git submodule sync
 git submodule update --init
 git submodule foreach --recursive "git submodule sync ; git submodule update --init"
-git submodule foreach git pull origin master


### PR DESCRIPTION
The point of "update-submodules" is to update the submodules checkouts
to be in sync with what the base repo expects.

9f0b03ff84dcc7e7 changed it to also pull the latest code for each
submodule, which breaks that.

(Maybe "sync-submodules" is a clearer name for this file?)