### PR TITLE
SSLConfig: Fix protocol and ciphersuite selection

### DIFF
--- a/src/main/java/com/dropbox/core/http/SSLConfig.java
+++ b/src/main/java/com/dropbox/core/http/SSLConfig.java
@@ -2,10 +2,10 @@ package com.dropbox.core.http;
 
 import com.dropbox.core.util.IOUtil;
 import static com.dropbox.core.util.LangUtil.mkAssert;
+import static com.dropbox.core.util.StringUtil.jq;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -61,7 +61,7 @@ public class SSLConfig {
     private static final SSLSocketFactory SSL_SOCKET_FACTORY = createSSLSocketFactory();
 
     private static final String[] PROTOCOL_LIST_TLS_V1_2 = {"TLSv1.2"};
-    private static final String[] PROTOCOL_LIST_TLS_V1_0 = {"TLSv1.0"};
+    private static final String[] PROTOCOL_LIST_TLS_V1_1 = {"TLSv1.1"};
     private static final String[] PROTOCOL_LIST_TLS_V1 = {"TLSv1"};
 
     private static /*@MonotonicNonNull*/CipherSuiteFilterationResults CACHED_CIPHER_SUITE_FILTERATION_RESULTS;
@@ -151,70 +151,62 @@ public class SSLConfig {
         return SSL_SOCKET_FACTORY;
     }
 
-    private static void limitProtocolsAndCiphers(SSLSocket socket) throws SSLException
-    {
-        // Set TLS protocol version
-        outer: {
-            for (String protocol : socket.getSupportedProtocols()) {
-                if (protocol.equals("TLSv1.2")) {
-                    socket.setEnabledProtocols(PROTOCOL_LIST_TLS_V1_2);
-                    break outer;
-                }
-                if (protocol.equals("TLSv1.0")) {
-                    socket.setEnabledProtocols(PROTOCOL_LIST_TLS_V1_0);
-                    break outer;
-                }
-                if (protocol.equals("TLSv1")) {
-                    socket.setEnabledProtocols(PROTOCOL_LIST_TLS_V1);
-                    break outer;
-                }
-            }
-            throw new SSLException("Socket doesn't support protocols \"TLSv1.2\", \"TLSv1.0\" or \"TLSv1\".");
-        }
-
-        socket.setEnabledCipherSuites(getFilteredCipherSuites(socket.getSupportedCipherSuites()));
+    private static void limitProtocolsAndCiphers(SSLSocket socket) throws SSLException {
+        socket.setEnabledProtocols(getFilteredProtocols(socket.getEnabledProtocols()));
+        socket.setEnabledCipherSuites(getFilteredCipherSuites(socket.getEnabledCipherSuites()));
     }
 
-    private static String[] getFilteredCipherSuites(String[] supportedCipherSuites) {
-        // Since the supported cipher suites probably won't change, try to reuse the
+    private static String[] getFilteredProtocols(String[] availableProtocols) throws SSLException {
+        boolean haveTls1_2 = false;
+        boolean haveTls1_1 = false;
+        boolean haveTls1 = false;
+
+        for (String protocol : availableProtocols) {
+            if (protocol.equals("TLSv1.2")) {
+                haveTls1_2 = true;
+            } else if (protocol.equals("TLSv1.1")) {
+                haveTls1_1 = true;
+            } else if (protocol.equals("TLSv1")) {
+                haveTls1 = true;
+            }
+        }
+
+        if (haveTls1_2) return PROTOCOL_LIST_TLS_V1_2;
+        if (haveTls1_1) return PROTOCOL_LIST_TLS_V1_1;
+        if (haveTls1) return PROTOCOL_LIST_TLS_V1;
+        throw new SSLException("Socket's available protocols doesn't overlap with our allowed protocols: " + jq(availableProtocols) + ".");
+    }
+
+    private static String[] getFilteredCipherSuites(String[] availableCipherSuites) {
+        // Since the available cipher suites probably won't change, try to reuse the
         // result of the last filteration.
         CipherSuiteFilterationResults cached = CACHED_CIPHER_SUITE_FILTERATION_RESULTS;
         if (cached != null) {
-            if (Arrays.equals(cached.supported, supportedCipherSuites)) {
-                return cached.enabled;
+            if (Arrays.equals(cached.available, availableCipherSuites)) {
+                return cached.filtered;
             }
         }
 
-        // Filter the 'supported' list to yield the 'enabled' list.
-        ArrayList<String> enabled = new ArrayList<String>(ALLOWED_CIPHER_SUITES.size());
-        for (String supported : supportedCipherSuites) {
-            if (ALLOWED_CIPHER_SUITES.contains(supported)) {
-                enabled.add(supported);
+        // Filter the 'available' list to yield the 'filtered' list.
+        ArrayList<String> filtered = new ArrayList<String>(ALLOWED_CIPHER_SUITES.size());
+        for (String available : availableCipherSuites) {
+            if (ALLOWED_CIPHER_SUITES.contains(available)) {
+                filtered.add(available);
             }
         }
 
-        String[] filteredArray = enabled.toArray(new String[enabled.size()]);
-        CACHED_CIPHER_SUITE_FILTERATION_RESULTS = new CipherSuiteFilterationResults(supportedCipherSuites, filteredArray);
+        String[] filteredArray = filtered.toArray(new String[filtered.size()]);
+        CACHED_CIPHER_SUITE_FILTERATION_RESULTS = new CipherSuiteFilterationResults(availableCipherSuites, filteredArray);
         return filteredArray;
     }
 
     private static final class CipherSuiteFilterationResults {
-        private final String[] supported;
-        private final String[] enabled;
+        private final String[] available;
+        private final String[] filtered;
 
-        public CipherSuiteFilterationResults(String[] supported, String[] enabled) {
-            this.supported = supported;
-            this.enabled = enabled;
-        }
-
-        // The ciphersuites supported by the underlying library.
-        public String [] getSupported() {
-            return supported;
-        }
-
-        // The subset of 'supported' that we allow to be used.
-        public String [] getEnabled() {
-            return enabled;
+        public CipherSuiteFilterationResults(String[] available, String[] filtered) {
+            this.available = available;
+            this.filtered = filtered;
         }
     }
 

--- a/src/main/java/com/dropbox/core/util/StringUtil.java
+++ b/src/main/java/com/dropbox/core/util/StringUtil.java
@@ -9,6 +9,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.Arrays;
 
 public class StringUtil
 {
@@ -83,8 +84,27 @@ public class StringUtil
         return b.toString();
     }
 
+    public static String javaQuotedLiterals(String[] value) {
+        return javaQuotedLiterals(Arrays.asList(value));
+    }
+
+    public static String javaQuotedLiterals(Iterable<String> value) {
+        StringBuilder b = new StringBuilder();
+        String sep = "";
+        for (String element : value) {
+            b.append(sep);
+            sep = ", ";
+            b.append(javaQuotedLiteral(element));
+        }
+        return b.toString();
+    }
+
     /** Shorthand for {@link #javaQuotedLiteral}. */
     public static String jq(String value) { return javaQuotedLiteral(value); }
+    /** Shorthand for {@link #javaQuotedLiterals}. */
+    public static String jq(String[] value) { return javaQuotedLiterals(value); }
+    /** Shorthand for {@link #javaQuotedLiterals}. */
+    public static String jq(Iterable<String> value) { return javaQuotedLiterals(value); }
 
     public static String binaryToHex(byte[] data)
     {


### PR DESCRIPTION
- From the list of available protocols, we selected the first one that
  we whitelisted instead of the best one.  If TLSv1 appears first in the
  list (which seems to be standard) we end up selecting that instead of
  TLSv1.2.  (Sadly, this will draw out the TLSv1 deprecation process for
  the Dropbox API, since clients using this SDK will insist on TLSv1).
- We selected from getSupportedProtocols(), which includes ones that
  have been disabled via "java.security" settings.  Switched to
  getEnabledProtocols() (and getEnabledCipherSuites()).
- We had an entry named "TLSv1.0", but the standard name is "TLSv1" and
  we already had an entry for that.  Probably just a typo for "TLSv1.1".

Fixes #239