### PR TITLE
Fix serialization of Map types

### DIFF
--- a/src/main/java/com/dropbox/core/stone/StoneSerializers.java
+++ b/src/main/java/com/dropbox/core/stone/StoneSerializers.java
@@ -334,7 +334,12 @@ public final class StoneSerializers {
 
         @Override
         public void serialize(Map<String, T> value, JsonGenerator g) throws IOException, JsonGenerationException {
-            g.writeString(value.toString());
+            g.writeStartObject();
+            for (Map.Entry<String, T> e : value.entrySet()) {
+                g.writeFieldName(e.getKey());
+                g.writeRawValue(underlying.serialize(e.getValue()));
+            }
+            g.writeEndObject();
         }
 
         @Override


### PR DESCRIPTION
Maps are being serialized incorrectly, e.g. as `{key=value}` instead of `{"key":"value"}`.