### PR TITLE
Allow generation of observable routes via Rx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     compileOnly 'com.squareup.okhttp3:okhttp:3.5.0' // method count bloat
     compileOnly 'com.google.android:android:4.1.1.4'
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.38'
+    compileOnly 'io.reactivex.rxjava2:rxjava:2.2.3'
 
     testCompile 'org.testng:testng:6.9.10'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/stone.gradle
+++ b/stone.gradle
@@ -6,6 +6,7 @@ class StoneConfig {
     boolean dataTypesOnly = false
     ClientSpec client = null
     String routeWhitelistFilter = null
+    boolean observableRoutes = false
 }
 
 class ClientSpec {
@@ -109,6 +110,10 @@ def runStoneGenerator(List<StoneConfig> configs,
                 if (client.unusedClassesToGenerate != null) {
                     args "--unused-classes-to-generate", client.unusedClassesToGenerate
                 }
+
+                if (c.observableRoutes) {
+                    args "--observable-routes"
+                }
             }
         }
         isFirst = false
@@ -125,6 +130,7 @@ project.sourceSets.all { SourceSet sourceSet ->
 
         def specDirPropName = "com.dropbox.api.${sourceSet.name}.specDir".toString()
         def routeWhitelistFilterPropName = "com.dropbox.api.${sourceSet.name}.routeWhitelistFilter".toString()
+        def observableRoutesPropName = "com.dropbox.api.${sourceSet.name}.observableRoutes".toString()
 
         ext {
             configs = []
@@ -133,6 +139,7 @@ project.sourceSets.all { SourceSet sourceSet ->
             specDir = project.properties.get(specDirPropName, "src/${sourceSet.name}/stone")
             outputDir = "${project.buildDir}/generated/source/stone/${sourceSet.name}"
             routeWhitelistFilter = project.properties.get(routeWhitelistFilterPropName, null)
+            observableRoutes = project.properties.get(observableRoutesPropName, false)
         }
 
         def getSpecFiles = { fileTree(dir: specDir, include: '**/*.stone') }
@@ -147,6 +154,7 @@ project.sourceSets.all { SourceSet sourceSet ->
             def specFiles = getSpecFiles().getFiles()
             for (StoneConfig config in configs) {
                 config.routeWhitelistFilter = routeWhitelistFilter
+                config.observableRoutes = observableRoutes
             }
             runStoneGenerator configs, file(stoneDir), generatorFile, specFiles, file(outputDir)
         }


### PR DESCRIPTION
Summary:

Adds a new flag (--observable-routes) to java.stoneg.py that causes
it to generate (currently only for rpc routes) methods that return Singles
and Completables allowing for interop with Rx.

It does this by wrapping calls to the non-rx methods so the total
amount of change in the generate isn't too large.

Test Plan:

Test with an example version of account-info. Integrate with the Dropbox
Android app and test an end to end flow. The logic is guarded by a flag
and so users that don't opt in should not be affected.