### PR TITLE
Support generating code for multi auth type endpoints

### DIFF
--- a/stone.gradle
+++ b/stone.gradle
@@ -170,7 +170,7 @@ generateStone {
                     name: 'DbxClientV2Base',
                     javadoc: 'Base class for user auth clients.',
                     requestsClassnamePrefix: "DbxUser",
-                    routeFilter: 'auth="user" or auth="noauth"',
+                    routeFilter: 'auth="user" or auth="noauth" or auth="app, user"',
                     unusedClassesToGenerate: unusedClassesToGenerate,
                 ),
             ),
@@ -191,7 +191,7 @@ generateStone {
                     name: 'DbxAppClientV2Base',
                     javadoc: 'Base class for app auth clients.',
                     requestsClassnamePrefix: "DbxApp",
-                    routeFilter: 'auth="app"',
+                    routeFilter: 'auth="app" or auth="app, user"',
                 )
             ),
 


### PR DESCRIPTION
Right now endpoints that have multiple auth types will not have any code generated for them at all since they get completely filtered out as the value in the "auth" field is not recognized when it is a comma separated list

This is a minimal workaround for this issue to make it possible to generate code for endpoints that are app + user auth