### PR TITLE
Add prefix to distinguish multiple auth variants of builders

### DIFF
--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -2010,12 +2010,15 @@ class JavaApi(object):
 
         if isinstance(stone_elem, ApiRoute):
             route = stone_elem
-            # Use prefix here because multiple builders may be generated
-            # if the endpoint has multiple auth types
-            prefix = self._args.requests_classname_prefix or self._args.client_class
+
+            if ',' in self.auth_style(route):
+                # Use prefix here because multiple builders may be generated
+                # if the endpoint has multiple auth types
+                prefix = (self._args.requests_classname_prefix or self._args.client_class) + "_"
+            else:
+                prefix = ""
             package = self.java_class(route).package
-            return JavaClass(package + '.' + classname(
-                '{}_{}_builder'.format(prefix, format_func_name(route))))
+            return JavaClass(package + '.' + classname('%s%s_builder' % (prefix, format_func_name(route))))
         else:
             data_type = stone_elem
             assert is_user_defined_type(data_type), repr(data_type)

--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -768,7 +768,6 @@ class JavaImporter(object):
         self._add_imports_for_data_type_exception(route.error_data_type)
 
         namespace = j.route_namespace(route)
-        route_auth = j.auth_style(route) if j.auth_style(route) != 'noauth' else 'user'
         self.add_imports(
             j.java_class(namespace),
             'com.dropbox.core.DbxException',
@@ -2011,8 +2010,12 @@ class JavaApi(object):
 
         if isinstance(stone_elem, ApiRoute):
             route = stone_elem
+            # Use prefix here because multiple builders may be generated
+            # if the endpoint has multiple auth types
+            prefix = self._args.requests_classname_prefix or self._args.client_class
             package = self.java_class(route).package
-            return JavaClass(package + '.' + classname(format_func_name(route) + '_builder'))
+            return JavaClass(package + '.' + classname(
+                '{}_{}_builder'.format(prefix, format_func_name(route))))
         else:
             data_type = stone_elem
             assert is_user_defined_type(data_type), repr(data_type)

--- a/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
+++ b/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
@@ -29,17 +29,19 @@ public class RouteVersionTest {
         Method v1 = c.getDeclaredMethod("testUpload", UninitializedReason.class, String.class);
         Method v2NoBuilder = c.getDeclaredMethod("testUploadV2", String.class, String.class);
         Method v2Builder = c.getDeclaredMethod("testUploadV2Builder", String.class, String.class);
+        Method v3Builder = c.getDeclaredMethod("testUploadV3Builder", String.class, String.class);
 
         // Test return value
         assertEquals(v1.getReturnType(), TestUploadUploader.class);
         assertEquals(v2NoBuilder.getReturnType(), TestUploadV2Uploader.class);
-        assertEquals(v2Builder.getReturnType(), DbxTestTestUploadV2Builder.class);
+        assertEquals(v2Builder.getReturnType(), TestUploadV2Builder.class);
+        assertEquals(v3Builder.getReturnType(), DbxTestTestUploadV3Builder.class);
 
         // Test builder
-        DbxTestTestUploadV2Builder.class.getDeclaredMethod("withBorn", Date.class);
-        DbxTestTestUploadV2Builder.class.getDeclaredMethod("withSize", DogSize.class);
-        Method start = DbxTestTestUploadV2Builder.class.getDeclaredMethod("start");
-        assertTrue(Arrays.asList(start.getExceptionTypes()).contains(ParentUnionException.class));
+        TestUploadV2Builder.class.getDeclaredMethod("withBorn", Date.class);
+        TestUploadV2Builder.class.getDeclaredMethod("withSize", DogSize.class);
+        Method start2 = TestUploadV2Builder.class.getDeclaredMethod("start");
+        assertTrue(Arrays.asList(start2.getExceptionTypes()).contains(ParentUnionException.class));
 
         // Test return value of uploader from generic type
         ParameterizedType genericV1 = (ParameterizedType)TestUploadUploader.class.getGenericSuperclass();
@@ -50,6 +52,12 @@ public class RouteVersionTest {
         // Test exception from generic type
         assertEquals(genericV1.getActualTypeArguments()[1], Void.class);
         assertEquals(genericV2.getActualTypeArguments()[1], ParentUnion.class);
+
+        // Test builder with multiple auth types has prefix
+        DbxTestTestUploadV3Builder.class.getDeclaredMethod("withBorn", Date.class);
+        DbxTestTestUploadV3Builder.class.getDeclaredMethod("withSize", DogSize.class);
+        Method start3 = DbxTestTestUploadV3Builder.class.getDeclaredMethod("start");
+        assertTrue(Arrays.asList(start3.getExceptionTypes()).contains(ParentUnionException.class));
     }
 
     @Test
@@ -61,13 +69,13 @@ public class RouteVersionTest {
         Method v2Builder = c.getDeclaredMethod("testDownloadV2Builder", UninitializedReason.class, String.class);
 
         // Test return type
-        assertEquals(v1Builder.getReturnType(), DbxTestTestDownloadBuilder.class);
-        assertEquals(v2Builder.getReturnType(), DbxTestTestDownloadV2Builder.class);
+        assertEquals(v1Builder.getReturnType(), TestDownloadBuilder.class);
+        assertEquals(v2Builder.getReturnType(), TestDownloadV2Builder.class);
 
         // Test return type from generic type
-        ParameterizedType genericV1 = (ParameterizedType)DbxTestTestDownloadBuilder.class.getGenericSuperclass();
+        ParameterizedType genericV1 = (ParameterizedType)TestDownloadBuilder.class.getGenericSuperclass();
         assertEquals(genericV1.getActualTypeArguments()[0], Fish.class);
-        ParameterizedType genericV2 = (ParameterizedType)DbxTestTestDownloadV2Builder.class.getGenericSuperclass();
+        ParameterizedType genericV2 = (ParameterizedType)TestDownloadV2Builder.class.getGenericSuperclass();
         assertEquals(genericV2.getActualTypeArguments()[0], Fish.class);
 
 

--- a/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
+++ b/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
@@ -33,12 +33,12 @@ public class RouteVersionTest {
         // Test return value
         assertEquals(v1.getReturnType(), TestUploadUploader.class);
         assertEquals(v2NoBuilder.getReturnType(), TestUploadV2Uploader.class);
-        assertEquals(v2Builder.getReturnType(), TestUploadV2Builder.class);
+        assertEquals(v2Builder.getReturnType(), DbxTestTestUploadV2Builder.class);
 
         // Test builder
-        TestUploadV2Builder.class.getDeclaredMethod("withBorn", Date.class);
-        TestUploadV2Builder.class.getDeclaredMethod("withSize", DogSize.class);
-        Method start = TestUploadV2Builder.class.getDeclaredMethod("start");
+        DbxTestTestUploadV2Builder.class.getDeclaredMethod("withBorn", Date.class);
+        DbxTestTestUploadV2Builder.class.getDeclaredMethod("withSize", DogSize.class);
+        Method start = DbxTestTestUploadV2Builder.class.getDeclaredMethod("start");
         assertTrue(Arrays.asList(start.getExceptionTypes()).contains(ParentUnionException.class));
 
         // Test return value of uploader from generic type
@@ -61,13 +61,13 @@ public class RouteVersionTest {
         Method v2Builder = c.getDeclaredMethod("testDownloadV2Builder", UninitializedReason.class, String.class);
 
         // Test return type
-        assertEquals(v1Builder.getReturnType(), TestDownloadBuilder.class);
-        assertEquals(v2Builder.getReturnType(), TestDownloadV2Builder.class);
+        assertEquals(v1Builder.getReturnType(), DbxTestTestDownloadBuilder.class);
+        assertEquals(v2Builder.getReturnType(), DbxTestTestDownloadV2Builder.class);
 
         // Test return type from generic type
-        ParameterizedType genericV1 = (ParameterizedType)TestDownloadBuilder.class.getGenericSuperclass();
+        ParameterizedType genericV1 = (ParameterizedType)DbxTestTestDownloadBuilder.class.getGenericSuperclass();
         assertEquals(genericV1.getActualTypeArguments()[0], Fish.class);
-        ParameterizedType genericV2 = (ParameterizedType)TestDownloadV2Builder.class.getGenericSuperclass();
+        ParameterizedType genericV2 = (ParameterizedType)DbxTestTestDownloadV2Builder.class.getGenericSuperclass();
         assertEquals(genericV2.getActualTypeArguments()[0], Fish.class);
 
 

--- a/src/test/stone/stone_cfg.stone
+++ b/src/test/stone/stone_cfg.stone
@@ -7,3 +7,5 @@ struct Route
     style String = "rpc"
         "The RPC format to use for the request. Valid values: rpc, download,
         and upload."
+    auth String = "auth"
+        "Auth mode for the route."

--- a/src/test/stone/test.stone
+++ b/src/test/stone/test.stone
@@ -86,6 +86,11 @@ route test_upload:2 (Dog, Void, ParentUnion)
     attrs
         style = "upload"
 
+route test_upload:3 (Dog, Void, ParentUnion)
+    attrs
+        style = "upload"
+        auth = "app, user"
+
 route test_download(Dog, Fish, Void)
     attrs
         host = "content"


### PR DESCRIPTION
Following the previous change, code may now be generated for endpoints with multiple authentication types. If an endpoint with multiple authentication types generates a `Builder`, this causes a naming collision and compilation error as we attempt to generate multiple builders with the same name

This change uses the existing prefix that was already applied to the `Requests` classes to `Builder`s to avoid this issue

It is a breaking change for existing consumers though the effect is minimal as it only affects places where the calling code makes explicit reference to the builder's type


