### PR TITLE
Update gradle wrapper to 6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 apply plugin: 'java'
-apply plugin: 'osgi'
+apply plugin: 'com.github.blindpirate.osgi'
 apply plugin: 'maven'
 apply plugin: 'com.github.ben-manes.versions' // dependencyUpdates task
 
@@ -58,11 +58,13 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        maven { url 'https://plugins.gradle.org/m2/' }
     }
 
     dependencies {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
         classpath 'com.dropbox.maven:pem-converter-maven-plugin:1.0'
+        classpath 'gradle.plugin.com.github.blindpirate:gradle-legacy-osgi-plugin:0.0.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip


### PR DESCRIPTION
Osgi plugin was deprecated, so I used a legacy one that supports gradle 6.3
