### PR TITLE
update tests to use google truth assertThat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     testCompile 'com.squareup.okhttp:okhttp:2.7.5'
     testCompile 'com.squareup.okhttp3:okhttp:3.5.0'
     testCompile 'com.google.guava:guava:19.0'
+    testCompile "com.google.truth:truth:1.1.2"
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ description = 'Official Java client library for the Dropbox API.'
 group = 'com.dropbox.core'
 archivesBaseName = 'dropbox-core-sdk'
 version = '0-SNAPSHOT'
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 // needed before we define the pom
 conf2ScopeMappings.addMapping(1, configurations.compileOnly, 'provided')

--- a/src/test/java/com/dropbox/core/DbxAppInfoTest.java
+++ b/src/test/java/com/dropbox/core/DbxAppInfoTest.java
@@ -4,8 +4,7 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static com.google.common.truth.Truth.assertThat;
 
 public class DbxAppInfoTest {
     @Test
@@ -20,8 +19,8 @@ public class DbxAppInfoTest {
         );
 
         DbxAppInfo appInfo = DbxAppInfo.Reader.readFully(responseStream);
-        assertEquals(appInfo.getKey(), "aaaaa");
-        assertEquals(appInfo.getSecret(), "aaaaa");
+        assertThat(appInfo.getKey()).isEqualTo("aaaaa");
+        assertThat(appInfo.getSecret()).isEqualTo("aaaaa");
     }
 
     @Test
@@ -40,7 +39,7 @@ public class DbxAppInfoTest {
         );
 
         DbxAppInfo appInfo = DbxAppInfo.Reader.readFully(responseStream);
-        assertEquals(appInfo.getKey(), "aaaaa");
-        assertFalse(appInfo.hasSecret());
+        assertThat(appInfo.getKey()).isEqualTo("aaaaa");
+        assertThat(appInfo.hasSecret()).isFalse();
     }
 }

--- a/src/test/java/com/dropbox/core/DbxAuthFinishTest.java
+++ b/src/test/java/com/dropbox/core/DbxAuthFinishTest.java
@@ -10,13 +10,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 
 public class DbxAuthFinishTest extends DbxOAuthTestBase {
     private static final DbxRequestConfig CONFIG = DbxRequestConfig.newBuilder("DbxWebAuthTest/1.0")
@@ -42,13 +40,13 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
         );
 
         DbxAuthFinish actual = DbxAuthFinish.Reader.readFully(responseStream);
-        assertEquals(actual.getAccessToken(), expected.getAccessToken());
-        assertEquals(actual.getAccountId(), expected.getAccountId());
-        assertEquals(actual.getRefreshToken(), expected.getRefreshToken());
-        assertEquals(actual.getExpiresAt(), expected.getExpiresAt());
-        assertEquals(actual.getTeamId(), expected.getTeamId());
-        assertEquals(actual.getUserId(), expected.getUserId());
-        assertEquals(actual.getUrlState(), expected.getUrlState());
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+        assertThat(actual.getAccountId()).isEqualTo(expected.getAccountId());
+        assertThat(actual.getRefreshToken()).isEqualTo(expected.getRefreshToken());
+        assertThat(actual.getExpiresAt()).isEqualTo(expected.getExpiresAt());
+        assertThat(actual.getTeamId()).isEqualTo(expected.getTeamId());
+        assertThat(actual.getUserId()).isEqualTo(expected.getUserId());
+        assertThat(actual.getUrlState()).isEqualTo(expected.getUrlState());
     }
 
     @Test
@@ -75,13 +73,13 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
 
         DbxAuthFinish actual = DbxAuthFinish.Reader.readFully(responseStream);
         actual.setIssueTime(now);
-        assertEquals(actual.getAccessToken(), expected.getAccessToken());
-        assertEquals(actual.getAccountId(), expected.getAccountId());
-        assertEquals(actual.getRefreshToken(), expected.getRefreshToken());
-        assertEquals(actual.getExpiresAt(), expected.getExpiresAt());
-        assertEquals(actual.getTeamId(), expected.getTeamId());
-        assertEquals(actual.getUserId(), expected.getUserId());
-        assertEquals(actual.getUrlState(), expected.getUrlState());
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+        assertThat(actual.getAccountId()).isEqualTo(expected.getAccountId());
+        assertThat(actual.getRefreshToken()).isEqualTo(expected.getRefreshToken());
+        assertThat(actual.getExpiresAt()).isEqualTo(expected.getExpiresAt());
+        assertThat(actual.getTeamId()).isEqualTo(expected.getTeamId());
+        assertThat(actual.getUserId()).isEqualTo(expected.getUserId());
+        assertThat(actual.getUrlState()).isEqualTo(expected.getUrlState());
     }
 
     @Test
@@ -110,13 +108,13 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
 
         DbxAuthFinish actual = DbxAuthFinish.Reader.readFully(responseStream);
         actual.setIssueTime(now);
-        assertEquals(actual.getAccessToken(), expected.getAccessToken());
-        assertEquals(actual.getAccountId(), expected.getAccountId());
-        assertEquals(actual.getRefreshToken(), expected.getRefreshToken());
-        assertEquals(actual.getExpiresAt(), expected.getExpiresAt());
-        assertEquals(actual.getTeamId(), expected.getTeamId());
-        assertEquals(actual.getUserId(), expected.getUserId());
-        assertEquals(actual.getUrlState(), expected.getUrlState());
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+        assertThat(actual.getAccountId()).isEqualTo(expected.getAccountId());
+        assertThat(actual.getRefreshToken()).isEqualTo(expected.getRefreshToken());
+        assertThat(actual.getExpiresAt()).isEqualTo(expected.getExpiresAt());
+        assertThat(actual.getTeamId()).isEqualTo(expected.getTeamId());
+        assertThat(actual.getUserId()).isEqualTo(expected.getUserId());
+        assertThat(actual.getUrlState()).isEqualTo(expected.getUrlState());
     }
 
     @Test
@@ -146,14 +144,14 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
 
         DbxAuthFinish actual = DbxAuthFinish.Reader.readFully(responseStream);
         actual.setIssueTime(now);
-        assertEquals(actual.getAccessToken(), expected.getAccessToken());
-        assertEquals(actual.getAccountId(), expected.getAccountId());
-        assertEquals(actual.getRefreshToken(), expected.getRefreshToken());
-        assertEquals(actual.getExpiresAt(), expected.getExpiresAt());
-        assertEquals(actual.getTeamId(), expected.getTeamId());
-        assertEquals(actual.getUserId(), expected.getUserId());
-        assertEquals(actual.getUrlState(), expected.getUrlState());
-        assertEquals(actual.getScope(), expected.getScope());
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+        assertThat(actual.getAccountId()).isEqualTo(expected.getAccountId());
+        assertThat(actual.getRefreshToken()).isEqualTo(expected.getRefreshToken());
+        assertThat(actual.getExpiresAt()).isEqualTo(expected.getExpiresAt());
+        assertThat(actual.getTeamId()).isEqualTo(expected.getTeamId());
+        assertThat(actual.getUserId()).isEqualTo(expected.getUserId());
+        assertThat(actual.getUrlState()).isEqualTo(expected.getUrlState());
+        assertThat(actual.getScope()).isEqualTo(expected.getScope());
     }
 
     @Test
@@ -165,13 +163,13 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
 
         DbxAuthFinish actual = expected.withUrlState("testState");
 
-        assertEquals(actual.getAccessToken(), expected.getAccessToken());
-        assertEquals(actual.getAccountId(), expected.getAccountId());
-        assertEquals(actual.getRefreshToken(), expected.getRefreshToken());
-        assertEquals(actual.getExpiresAt(), expected.getExpiresAt());
-        assertEquals(actual.getTeamId(), expected.getTeamId());
-        assertEquals(actual.getUserId(), expected.getUserId());
-        assertEquals(actual.getUrlState(), "testState");
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+        assertThat(actual.getAccountId()).isEqualTo(expected.getAccountId());
+        assertThat(actual.getRefreshToken()).isEqualTo(expected.getRefreshToken());
+        assertThat(actual.getExpiresAt()).isEqualTo(expected.getExpiresAt());
+        assertThat(actual.getTeamId()).isEqualTo(expected.getTeamId());
+        assertThat(actual.getUserId()).isEqualTo(expected.getUserId());
+        assertThat(actual.getUrlState()).isEqualTo("testState");
     }
 
     @Test
@@ -190,7 +188,7 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
         String authorizationUrl = new DbxWebAuth(CONFIG, APP).authorize(request);
         String code = "test-code";
 
-        assertNotNull(sessionStore.get());
+        assertThat(sessionStore.get()).isNotNull();
 
         DbxAuthFinish expected = new DbxAuthFinish(
                 "test-access-token", null, null, "test-user-id", null, "test", state, null
@@ -232,11 +230,11 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
 
         // verify the state param isn't send to the 'oauth2/token' endpoint
         String finishParams = new String(body.toByteArray(), "UTF-8");
-        assertNull(toParamsMap(finishParams).get("state"));
+        assertThat(toParamsMap(finishParams).get("state")).isNull();
 
-        assertNotNull(actual);
-        assertEquals(actual.getAccessToken(), expected.getAccessToken());
-        assertEquals(actual.getUserId(), expected.getUserId());
-        assertEquals(actual.getUrlState(), expected.getUrlState());
+        assertThat(actual).isNotNull();
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+        assertThat(actual.getUserId()).isEqualTo(expected.getUserId());
+        assertThat(actual.getUrlState()).isEqualTo(expected.getUrlState());
     }
 }

--- a/src/test/java/com/dropbox/core/DbxEntryTest.java
+++ b/src/test/java/com/dropbox/core/DbxEntryTest.java
@@ -7,7 +7,9 @@ import com.dropbox.core.util.LangUtil;
 import com.dropbox.core.util.StringUtil;
 import com.dropbox.core.v1.DbxEntry;
 import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,50 +41,50 @@ public class DbxEntryTest
     public void parseFile() throws Exception
     {
         DbxEntry.File f = loadJsonResource(DbxEntry.Reader, "/file.json").asFile();
-        assertEquals(f.path, "/Photos/Sample Album/Boston City Flow.jpg");
-        assertEquals(f.numBytes, 339773);
-        assertEquals(f.mightHaveThumbnail, true);
-        assertEquals(f.rev, "400113f659");
-        assertEquals(f.humanSize, "331.8 KB");
+        assertThat(f.path).isEqualTo("/Photos/Sample Album/Boston City Flow.jpg");
+        assertThat(f.numBytes).isEqualTo(339773);
+        assertThat(f.mightHaveThumbnail).isEqualTo(true);
+        assertThat(f.rev).isEqualTo("400113f659");
+        assertThat(f.humanSize).isEqualTo("331.8 KB");
 
         GregorianCalendar c = new GregorianCalendar(2013, GregorianCalendar.APRIL, 11, 17, 5, 17);
         c.setTimeZone(TimeZone.getTimeZone("UTC"));
-        assertEquals(f.lastModified, c.getTime());
+        assertThat(f.lastModified).isEqualTo(c.getTime());
     }
 
     @Test
     public void parseFileWithPhotoInfo() throws Exception
     {
         DbxEntry.File f = loadJsonResource(DbxEntry.Reader, "/file-with-photo-info.json").asFile();
-        assertNotNull(f.photoInfo, "Expected entry to have a photo info");
-        assertNotNull(f.photoInfo.timeTaken, "Expected entry to have a time taken");
-        assertNotNull(f.photoInfo.location, "Expected entry to have a location");
+        assertWithMessage("Expected entry to have a photo info").that(f.photoInfo).isNotNull();
+        assertWithMessage("Expected entry to have a time taken").that(f.photoInfo.timeTaken).isNotNull();
+        assertWithMessage("Expected entry to have a location").that(f.photoInfo.location).isNotNull();
     }
 
     @Test
     public void parseFileWithVideoInfo() throws Exception
     {
         DbxEntry.File f = loadJsonResource(DbxEntry.Reader, "/file-with-video-info.json").asFile();
-        assertNotNull(f.videoInfo, "Expected entry to have a video info");
-        assertNotNull(f.videoInfo.timeTaken, "Expected entry to have a time taken");
-        assertNotNull(f.videoInfo.location, "Expected entry to have a location");
-        assertEquals(f.videoInfo.duration, Long.valueOf(666), "Expected to have a duration");
+        assertWithMessage("Expected entry to have a video info").that(f.videoInfo).isNotNull();
+        assertWithMessage("Expected entry to have a time taken").that(f.videoInfo.timeTaken).isNotNull();
+        assertWithMessage("Expected entry to have a location").that(f.videoInfo.location).isNotNull();
+        assertWithMessage("Expected to have a duration").that(f.videoInfo.duration).isEqualTo(Long.valueOf(666));
     }
 
     @Test
     public void parseFileWithVideoInfoNullFields() throws Exception
     {
         DbxEntry.File f = loadJsonResource(DbxEntry.Reader, "/file-with-video-info-null-fields.json").asFile();
-        assertNull(f.videoInfo.duration);
-        assertNull(f.videoInfo.location);
-        assertNull(f.videoInfo.timeTaken);
+        assertThat(f.videoInfo.duration).isNull();
+        assertThat(f.videoInfo.location).isNull();
+        assertThat(f.videoInfo.timeTaken).isNull();
     }
 
     @Test
     public void parseWithMediaInfoPending() throws Exception
     {
         DbxEntry.File f = loadJsonResource(DbxEntry.Reader, "/file-with-media-info-pending.json").asFile();
-        assertTrue(f.videoInfo == DbxEntry.File.VideoInfo.PENDING);
-        assertTrue(f.photoInfo == DbxEntry.File.PhotoInfo.PENDING);
+        assertThat(f.videoInfo == DbxEntry.File.VideoInfo.PENDING).isTrue();
+        assertThat(f.photoInfo == DbxEntry.File.PhotoInfo.PENDING).isTrue();
     }
 }

--- a/src/test/java/com/dropbox/core/DbxOAuthTestBase.java
+++ b/src/test/java/com/dropbox/core/DbxOAuthTestBase.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
+import static com.google.common.truth.Truth.assertThat;
 import static org.testng.Assert.fail;
 
 public class DbxOAuthTestBase {
@@ -34,20 +34,20 @@ public class DbxOAuthTestBase {
             URL a = new URL(actual);
             URL b = new URL(expected);
 
-            assertEquals(a.getProtocol(), b.getProtocol());
-            assertEquals(a.getAuthority(), b.getAuthority());
-            assertEquals(a.getPath(), b.getPath());
-            assertEquals(a.getRef(), b.getRef());
+            assertThat(a.getProtocol()).isEqualTo(b.getProtocol());
+            assertThat(a.getAuthority()).isEqualTo(b.getAuthority());
+            assertThat(a.getPath()).isEqualTo(b.getPath());
+            assertThat(a.getRef()).isEqualTo(b.getRef());
 
             Map<String, List<String>> pa = toParamsMap(new URL(actual));
             Map<String, List<String>> pb = toParamsMap(new URL(actual));
 
-            assertEquals(pa.keySet(), pb.keySet());
+            assertThat(pa.keySet()).isEqualTo(pb.keySet());
             for (String key : pa.keySet()) {
                 if ("state".equals(key)) {
                     continue;
                 }
-                assertEquals(pa.get(key), pb.get(key));
+                assertThat(pa.get(key)).isEqualTo(pb.get(key));
             }
         } catch (Exception ex) {
             fail("Couldn't compare authorization URLs", ex);

--- a/src/test/java/com/dropbox/core/DbxPKCEWebAuthTest.java
+++ b/src/test/java/com/dropbox/core/DbxPKCEWebAuthTest.java
@@ -2,6 +2,7 @@ package com.dropbox.core;
 
 import com.dropbox.core.http.HttpRequestor;
 import org.mockito.ArgumentCaptor;
+import org.testng.Assert.ThrowingRunnable;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -14,12 +15,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertThrows;
 
 public class DbxPKCEWebAuthTest extends DbxOAuthTestBase {
     private static final DbxRequestConfig CONFIG = DbxRequestConfig.newBuilder("DbxWebAuthTest/1.0")
@@ -45,12 +48,12 @@ public class DbxPKCEWebAuthTest extends DbxOAuthTestBase {
 
 
         Map<String, List<String>> params = toParamsMap(new URL(authUrl));
-        assertTrue(params.containsKey("code_challenge"));
+        assertThat(params.containsKey("code_challenge")).isTrue();
         String codeChallenge = params.get("code_challenge").get(0);
-        assertTrue(Pattern.matches(PKCE_REGEX, codeChallenge), codeChallenge);
+        assertWithMessage(codeChallenge).that(Pattern.matches(PKCE_REGEX, codeChallenge)).isTrue();
 
-        assertTrue(params.containsKey("code_challenge_method"));
-        assertEquals(params.get("code_challenge_method").get(0), "S256");
+        assertThat(params.containsKey("code_challenge_method")).isTrue();
+        assertThat(params.get("code_challenge_method").get(0)).isEqualTo("S256");
     }
 
     @Test
@@ -108,7 +111,7 @@ public class DbxPKCEWebAuthTest extends DbxOAuthTestBase {
         verify(mockUploader).upload(argumentCaptor.capture());
         Map<String, List<String>> finishParams = toParamsMap(new String(argumentCaptor.getValue(), "UTF-8"));
         String code_verifier = finishParams.get("code_verifier").get(0);
-        assertEquals(code_challenge, DbxPKCEManager.generateCodeChallenge(code_verifier));
+        assertThat(code_challenge).isEqualTo(DbxPKCEManager.generateCodeChallenge(code_verifier));
     }
 
     @Test
@@ -144,7 +147,7 @@ public class DbxPKCEWebAuthTest extends DbxOAuthTestBase {
         );
 
         Map<String, List<String>> params = toParamsMap(new URL(authUrl));
-        assertEquals(params.get("scope"), Collections.singletonList("account.info.read"));
+        assertThat(params.get("scope")).isEqualTo(Collections.singletonList("account.info.read"));
     }
 
     @Test
@@ -160,18 +163,18 @@ public class DbxPKCEWebAuthTest extends DbxOAuthTestBase {
         );
 
         Map<String, List<String>> params = toParamsMap(new URL(authUrl));
-        assertEquals(params.get("client_id"), Collections.singletonList(APP.getKey()));
-        assertEquals(params.get("response_type"), Collections.singletonList("code"));
-        assertEquals(params.get("scope"), Collections.singletonList("account.info.read"));
-        assertEquals(params.get("include_granted_scopes"), Collections.singletonList("user"));
-        assertFalse(params.containsKey("redirect_uri"));
-        assertFalse(params.containsKey("state"));
-        assertFalse(params.containsKey("require_role"));
-        assertFalse(params.containsKey("force_reapprove"));
-        assertFalse(params.containsKey("disable_signup"));
-        assertFalse(params.containsKey("token_access_type"));
-        assertNotNull(params.get("code_challenge"));
-        assertEquals(params.get("code_challenge_method"), Collections.singletonList("S256"));
+        assertThat(params.get("client_id")).isEqualTo(Collections.singletonList(APP.getKey()));
+        assertThat(params.get("response_type")).isEqualTo(Collections.singletonList("code"));
+        assertThat(params.get("scope")).isEqualTo(Collections.singletonList("account.info.read"));
+        assertThat(params.get("include_granted_scopes")).isEqualTo(Collections.singletonList("user"));
+        assertThat(params.containsKey("redirect_uri")).isFalse();
+        assertThat(params.containsKey("state")).isFalse();
+        assertThat(params.containsKey("require_role")).isFalse();
+        assertThat(params.containsKey("force_reapprove")).isFalse();
+        assertThat(params.containsKey("disable_signup")).isFalse();
+        assertThat(params.containsKey("token_access_type")).isFalse();
+        assertThat(params.get("code_challenge")).isNotNull();
+        assertThat(params.get("code_challenge_method")).isEqualTo(Collections.singletonList("S256"));
     }
 
     @Test

--- a/src/test/java/com/dropbox/core/DbxRequestConfigTest.java
+++ b/src/test/java/com/dropbox/core/DbxRequestConfigTest.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import static org.testng.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Locale;
 
@@ -17,42 +17,42 @@ public class DbxRequestConfigTest {
         // all non-standard locale formats to IETF BCP 47 Language Tags for APIv2.
 
         // default should not be "en"
-        assertEquals(new DbxRequestConfig(clientId).getUserLocale(), null);
-        assertEquals(newConfigBuilder(clientId)
-                     .withUserLocaleFromPreferences().build().getUserLocale(), null);
-        assertEquals(newConfig(clientId, (String) null).getUserLocale(), null);
-        assertEquals(newConfig(clientId, (Locale) null).getUserLocale(), null);
+        assertThat(new DbxRequestConfig(clientId).getUserLocale()).isNull();
+        assertThat(newConfigBuilder(clientId)
+                     .withUserLocaleFromPreferences().build().getUserLocale()).isNull();
+        assertThat(newConfig(clientId, (String) null).getUserLocale()).isNull();
+        assertThat(newConfig(clientId, (Locale) null).getUserLocale()).isNull();
 
         // basic english
-        assertEquals(new DbxRequestConfig(clientId, "en").getUserLocale(), "en");
-        assertEquals(newConfig(clientId, "en").getUserLocale(), "en");
-        assertEquals(newConfig(clientId, Locale.ENGLISH).getUserLocale(), "en");
+        assertThat(new DbxRequestConfig(clientId, "en").getUserLocale()).isEqualTo("en");
+        assertThat(newConfig(clientId, "en").getUserLocale()).isEqualTo("en");
+        assertThat(newConfig(clientId, Locale.ENGLISH).getUserLocale()).isEqualTo("en");
 
         // UK english
-        assertEquals(new DbxRequestConfig(clientId, "en_GB").getUserLocale(), "en-GB");
-        assertEquals(newConfig(clientId, "en_GB").getUserLocale(), "en-GB");
-        assertEquals(newConfig(clientId, "en-GB").getUserLocale(), "en-GB");
-        assertEquals(newConfig(clientId, Locale.UK).getUserLocale(), "en-GB");
+        assertThat(new DbxRequestConfig(clientId, "en_GB").getUserLocale()).isEqualTo("en-GB");
+        assertThat(newConfig(clientId, "en_GB").getUserLocale()).isEqualTo("en-GB");
+        assertThat(newConfig(clientId, "en-GB").getUserLocale()).isEqualTo("en-GB");
+        assertThat(newConfig(clientId, Locale.UK).getUserLocale()).isEqualTo("en-GB");
 
         // Custom, variant gets truncated
         Locale custom = new Locale("ko", "KR", "dropbox_variant");
-        assertEquals(new DbxRequestConfig(clientId, custom.toString()).getUserLocale(), "ko-KR");
-        assertEquals(newConfig(clientId, custom.toString()).getUserLocale(), "ko-KR");
-        assertEquals(newConfig(clientId, "ko-KR-Dropbox-x-lvariant-foo").getUserLocale(), "ko-KR-Dropbox-x-lvariant-foo");
-        assertEquals(newConfig(clientId, "ko_KR_Dropbox_foo").getUserLocale(), "ko-KR");
-        assertEquals(newConfig(clientId, custom).getUserLocale(), "ko-KR");
+        assertThat(new DbxRequestConfig(clientId, custom.toString()).getUserLocale()).isEqualTo("ko-KR");
+        assertThat(newConfig(clientId, custom.toString()).getUserLocale()).isEqualTo("ko-KR");
+        assertThat(newConfig(clientId, "ko-KR-Dropbox-x-lvariant-foo").getUserLocale()).isEqualTo("ko-KR-Dropbox-x-lvariant-foo");
+        assertThat(newConfig(clientId, "ko_KR_Dropbox_foo").getUserLocale()).isEqualTo("ko-KR");
+        assertThat(newConfig(clientId, custom).getUserLocale()).isEqualTo("ko-KR");
 
         // Casing
-        assertEquals(new DbxRequestConfig(clientId, "FR_CA").getUserLocale(), "fr-CA");
-        assertEquals(newConfig(clientId, "FR_CA").getUserLocale(), "fr-CA");
+        assertThat(new DbxRequestConfig(clientId, "FR_CA").getUserLocale()).isEqualTo("fr-CA");
+        assertThat(newConfig(clientId, "FR_CA").getUserLocale()).isEqualTo("fr-CA");
 
         // Missing lang (no translation is done)
-        assertEquals(new DbxRequestConfig(clientId, "_FR").getUserLocale(), "_FR");
-        assertEquals(newConfig(clientId, "_FR").getUserLocale(), "_FR");
+        assertThat(new DbxRequestConfig(clientId, "_FR").getUserLocale()).isEqualTo("_FR");
+        assertThat(newConfig(clientId, "_FR").getUserLocale()).isEqualTo("_FR");
 
         // Missing region
-        assertEquals(new DbxRequestConfig(clientId, "de__POSIX").getUserLocale(), "de");
-        assertEquals(newConfig(clientId, "de__POSIX").getUserLocale(), "de");
+        assertThat(new DbxRequestConfig(clientId, "de__POSIX").getUserLocale()).isEqualTo("de");
+        assertThat(newConfig(clientId, "de__POSIX").getUserLocale()).isEqualTo("de");
     }
 
     private static DbxRequestConfig.Builder newConfigBuilder(String clientId) {

--- a/src/test/java/com/dropbox/core/DbxWebAuthTest.java
+++ b/src/test/java/com/dropbox/core/DbxWebAuthTest.java
@@ -6,7 +6,8 @@ import org.testng.annotations.Test;
 import java.net.URL;
 import java.util.*;
 
-import static org.testng.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
+import static org.testng.Assert.fail;
 
 public class DbxWebAuthTest extends DbxOAuthTestBase {
     private static final DbxRequestConfig CONFIG = DbxRequestConfig.newBuilder("DbxWebAuthTest/1.0")
@@ -46,7 +47,7 @@ public class DbxWebAuthTest extends DbxOAuthTestBase {
 
         // assert token access type is empty
         Map<String, List<String>> params = toParamsMap(new URL(authUrl));
-        assertFalse(params.containsKey("token_access_type"));
+        assertThat(params.containsKey("token_access_type")).isFalse();
     }
 
     @Test(expectedExceptions={IllegalArgumentException.class})
@@ -120,7 +121,7 @@ public class DbxWebAuthTest extends DbxOAuthTestBase {
                 .build();
         String urlString = dbxWebAuth.authorize(request);
         Map<String, List<String>> params = toParamsMap(new URL(urlString));
-        assertEquals(params.get("token_access_type"), Collections.singletonList("online"));
+        assertThat(params.get("token_access_type")).isEqualTo(Collections.singletonList("online"));
 
         request = DbxWebAuth.newRequestBuilder()
                 .withNoRedirect()
@@ -128,7 +129,7 @@ public class DbxWebAuthTest extends DbxOAuthTestBase {
                 .build();
         urlString = dbxWebAuth.authorize(request);
         params = toParamsMap(new URL(urlString));
-        assertEquals(params.get("token_access_type"), Collections.singletonList("offline"));
+        assertThat(params.get("token_access_type")).isEqualTo(Collections.singletonList("offline"));
     }
 
     @Test(expectedExceptions={DbxWebAuth.CsrfException.class})
@@ -164,8 +165,8 @@ public class DbxWebAuthTest extends DbxOAuthTestBase {
             .build();
         String urlString = dbxWebAuth.authorize(request);
         Map<String, List<String>> params = toParamsMap(new URL(urlString));
-        assertEquals(params.get("scope"), Collections.singletonList("account.info.read"));
-        assertNull(params.get("include_granted_scopes"));
+        assertThat(params.get("scope")).isEqualTo(Collections.singletonList("account.info.read"));
+        assertThat(params.get("include_granted_scopes")).isNull();
     }
 
     @Test
@@ -178,16 +179,16 @@ public class DbxWebAuthTest extends DbxOAuthTestBase {
             .build();
         String urlString = dbxWebAuth.authorize(request);
         Map<String, List<String>> params = toParamsMap(new URL(urlString));
-        assertEquals(params.get("client_id"), Collections.singletonList(APP.getKey()));
-        assertEquals(params.get("response_type"), Collections.singletonList("code"));
-        assertEquals(params.get("scope"), Collections.singletonList("account.info.read"));
-        assertEquals(params.get("include_granted_scopes"), Collections.singletonList("user"));
-        assertFalse(params.containsKey("redirect_uri"));
-        assertFalse(params.containsKey("state"));
-        assertFalse(params.containsKey("require_role"));
-        assertFalse(params.containsKey("force_reapprove"));
-        assertFalse(params.containsKey("disable_signup"));
-        assertFalse(params.containsKey("token_access_type"));
+        assertThat(params.get("client_id")).isEqualTo(Collections.singletonList(APP.getKey()));
+        assertThat(params.get("response_type")).isEqualTo(Collections.singletonList("code"));
+        assertThat(params.get("scope")).isEqualTo(Collections.singletonList("account.info.read"));
+        assertThat(params.get("include_granted_scopes")).isEqualTo(Collections.singletonList("user"));
+        assertThat(params.containsKey("redirect_uri")).isFalse();
+        assertThat(params.containsKey("state")).isFalse();
+        assertThat(params.containsKey("require_role")).isFalse();
+        assertThat(params.containsKey("force_reapprove")).isFalse();
+        assertThat(params.containsKey("disable_signup")).isFalse();
+        assertThat(params.containsKey("token_access_type")).isFalse();
 
     }
 }

--- a/src/test/java/com/dropbox/core/ITUtil.java
+++ b/src/test/java/com/dropbox/core/ITUtil.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.fail;
 
 import java.nio.charset.Charset;
 import java.text.DateFormat;

--- a/src/test/java/com/dropbox/core/oauth/DbxCredentialTest.java
+++ b/src/test/java/com/dropbox/core/oauth/DbxCredentialTest.java
@@ -5,10 +5,7 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.AssertJUnit.assertFalse;
+import static com.google.common.truth.Truth.assertThat;
 
 public class DbxCredentialTest {
     @Test
@@ -22,12 +19,12 @@ public class DbxCredentialTest {
         );
 
         DbxCredential credential = DbxCredential.Reader.readFully(responseStream);
-        assertEquals(credential.getAccessToken(), "aaaaa");
-        assertFalse(credential.aboutToExpire());
-        assertNull(credential.getRefreshToken());
-        assertNull(credential.getExpiresAt());
-        assertNull(credential.getAppKey());
-        assertNull(credential.getAppSecret());
+        assertThat(credential.getAccessToken()).isEqualTo("aaaaa");
+        assertThat(credential.aboutToExpire()).isFalse();
+        assertThat(credential.getRefreshToken()).isNull();
+        assertThat(credential.getExpiresAt()).isNull();
+        assertThat(credential.getAppKey()).isNull();
+        assertThat(credential.getAppSecret()).isNull();
     }
 
     @Test
@@ -45,12 +42,12 @@ public class DbxCredentialTest {
         );
 
         DbxCredential credential = DbxCredential.Reader.readFully(responseStream);
-        assertEquals(credential.getAccessToken(), "aaaaa");
-        assertEquals(credential.getExpiresAt(), new Long(10));
-        assertEquals(credential.getRefreshToken(), "bbbbb");
-        assertEquals(credential.getAppKey(), "ccccc");
-        assertEquals(credential.getAppSecret(), "ddddd");
-        assertTrue(credential.aboutToExpire());
+        assertThat(credential.getAccessToken()).isEqualTo("aaaaa");
+        assertThat(credential.getExpiresAt()).isEqualTo(new Long(10));
+        assertThat(credential.getRefreshToken()).isEqualTo("bbbbb");
+        assertThat(credential.getAppKey()).isEqualTo("ccccc");
+        assertThat(credential.getAppSecret()).isEqualTo("ddddd");
+        assertThat(credential.aboutToExpire()).isTrue();
     }
 
     @Test(expectedExceptions={JsonReadException.class})
@@ -71,10 +68,10 @@ public class DbxCredentialTest {
 
         String data = DbxCredential.Writer.writeToString(credential);
         DbxCredential afterRead = DbxCredential.Reader.readFully(data);
-        assertEquals(afterRead.getAccessToken(), credential.getAccessToken());
-        assertEquals(afterRead.getExpiresAt(), credential.getExpiresAt());
-        assertEquals(afterRead.getRefreshToken(), credential.getRefreshToken());
-        assertEquals(afterRead.getAppKey(), credential.getAppKey());
-        assertEquals(afterRead.getAppSecret(), credential.getAppSecret());
+        assertThat(afterRead.getAccessToken()).isEqualTo(credential.getAccessToken());
+        assertThat(afterRead.getExpiresAt()).isEqualTo(credential.getExpiresAt());
+        assertThat(afterRead.getRefreshToken()).isEqualTo(credential.getRefreshToken());
+        assertThat(afterRead.getAppKey()).isEqualTo(credential.getAppKey());
+        assertThat(afterRead.getAppSecret()).isEqualTo(credential.getAppSecret());
     }
 }

--- a/src/test/java/com/dropbox/core/oauth/DbxRefershTest.java
+++ b/src/test/java/com/dropbox/core/oauth/DbxRefershTest.java
@@ -117,8 +117,8 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         Map<String, List<String>> refreshParams = toParamsMap(new String(paramCaptor.getValue(), "UTF-8"));
 
         // Verification
-        assertThat(refreshParams.get("grant_type").get(0).isEqualTo("refresh_token");
-        assertThat(refreshParams.get("refresh_token").get(0).isEqualTo(REFRESH_TOKEN);
+        assertThat(refreshParams.get("grant_type").get(0)).isEqualTo("refresh_token");
+        assertThat(refreshParams.get("refresh_token").get(0)).isEqualTo(REFRESH_TOKEN);
         assertThat(refreshParams.containsKey("client_id")).isFalse();
         assertThat(credential.getAccessToken()).isEqualTo(NEW_TOKEN);
         assertThat(currentMilllis + EXPIRES_IN < credential.getExpiresAt()).isTrue();
@@ -155,10 +155,10 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         Map<String, List<String>> refreshParams = toParamsMap(new String(paramCaptor.getValue(), "UTF-8"));
 
         // Verification
-        assertThat(refreshParams.get("grant_type").get(0).isEqualTo("refresh_token");
-        assertThat(refreshParams.get("refresh_token").get(0).isEqualTo(REFRESH_TOKEN);
+        assertThat(refreshParams.get("grant_type").get(0)).isEqualTo("refresh_token");
+        assertThat(refreshParams.get("refresh_token").get(0)).isEqualTo(REFRESH_TOKEN);
         assertThat(refreshParams.containsKey("client_id")).isFalse();
-        assertThat(credential.getAccessToken().isEqualTo(NEW_TOKEN);
+        assertThat(credential.getAccessToken()).isEqualTo(NEW_TOKEN);
         assertThat(currentMilllis + EXPIRES_IN < credential.getExpiresAt()).isTrue();
     }
 

--- a/src/test/java/com/dropbox/core/oauth/DbxRefershTest.java
+++ b/src/test/java/com/dropbox/core/oauth/DbxRefershTest.java
@@ -18,14 +18,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class DbxRefershTest extends DbxOAuthTestBase {
@@ -54,19 +53,19 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         DbxRefreshResult actual = DbxRefreshResult.Reader.readFully(responseStream);
         actual.setIssueTime(0);
 
-        assertEquals(actual.getAccessToken(), NEW_TOKEN);
-        assertEquals(actual.getExpiresAt(), new Long(EXPIRES_IN * 1000));
+        assertThat(actual.getAccessToken()).isEqualTo(NEW_TOKEN);
+        assertThat(actual.getExpiresAt()).isEqualTo(new Long(EXPIRES_IN * 1000));
     }
 
     @Test
     public void testExpire() {
         Long now = System.currentTimeMillis();
-        assertTrue(new DbxCredential(EXPIRED_TOKEN, 0L, REFRESH_TOKEN, APP.getKey(), APP
-            .getSecret()).aboutToExpire());
-        assertTrue(new DbxCredential(EXPIRED_TOKEN, now, REFRESH_TOKEN, APP.getKey(), APP
-            .getSecret()).aboutToExpire());
-        assertTrue(new DbxCredential(EXPIRED_TOKEN, now + EXPIRES_IN, REFRESH_TOKEN, APP.getKey()
-            , APP.getSecret()).aboutToExpire());
+        assertThat(new DbxCredential(EXPIRED_TOKEN, 0L, REFRESH_TOKEN, APP.getKey(), APP
+            .getSecret()).aboutToExpire()).isTrue();
+        assertThat(new DbxCredential(EXPIRED_TOKEN, now, REFRESH_TOKEN, APP.getKey(), APP
+            .getSecret()).aboutToExpire()).isTrue();
+        assertThat(new DbxCredential(EXPIRED_TOKEN, now + EXPIRES_IN, REFRESH_TOKEN, APP.getKey()
+            , APP.getSecret()).aboutToExpire()).isTrue();
         try {
             new DbxCredential(EXPIRED_TOKEN, null, "refresh", "appkey", null).aboutToExpire();
         } catch (IllegalArgumentException ex) {
@@ -118,11 +117,11 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         Map<String, List<String>> refreshParams = toParamsMap(new String(paramCaptor.getValue(), "UTF-8"));
 
         // Verification
-        assertEquals(refreshParams.get("grant_type").get(0), "refresh_token");
-        assertEquals(refreshParams.get("refresh_token").get(0), REFRESH_TOKEN);
-        assertFalse(refreshParams.containsKey("client_id"));
-        assertEquals(credential.getAccessToken(), NEW_TOKEN);
-        assertTrue(currentMilllis + EXPIRES_IN < credential.getExpiresAt());
+        assertThat(refreshParams.get("grant_type").get(0).isEqualTo("refresh_token");
+        assertThat(refreshParams.get("refresh_token").get(0).isEqualTo(REFRESH_TOKEN);
+        assertThat(refreshParams.containsKey("client_id")).isFalse();
+        assertThat(credential.getAccessToken()).isEqualTo(NEW_TOKEN);
+        assertThat(currentMilllis + EXPIRES_IN < credential.getExpiresAt()).isTrue();
     }
 
     @Test
@@ -156,11 +155,11 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         Map<String, List<String>> refreshParams = toParamsMap(new String(paramCaptor.getValue(), "UTF-8"));
 
         // Verification
-        assertEquals(refreshParams.get("grant_type").get(0), "refresh_token");
-        assertEquals(refreshParams.get("refresh_token").get(0), REFRESH_TOKEN);
-        assertFalse(refreshParams.containsKey("client_id"));
-        assertEquals(credential.getAccessToken(), NEW_TOKEN);
-        assertTrue(currentMilllis + EXPIRES_IN < credential.getExpiresAt());
+        assertThat(refreshParams.get("grant_type").get(0).isEqualTo("refresh_token");
+        assertThat(refreshParams.get("refresh_token").get(0).isEqualTo(REFRESH_TOKEN);
+        assertThat(refreshParams.containsKey("client_id")).isFalse();
+        assertThat(credential.getAccessToken().isEqualTo(NEW_TOKEN);
+        assertThat(currentMilllis + EXPIRES_IN < credential.getExpiresAt()).isTrue();
     }
 
     @Test
@@ -193,11 +192,11 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         Map<String, List<String>> refreshParams = toParamsMap(new String(paramCaptor.getValue(), "UTF-8"));
 
         // Verification
-        assertEquals(refreshParams.get("grant_type").get(0), "refresh_token");
-        assertEquals(refreshParams.get("refresh_token").get(0), REFRESH_TOKEN);
-        assertEquals(refreshParams.get("client_id").get(0), APP.getKey());
-        assertEquals(credential.getAccessToken(), NEW_TOKEN);
-        assertTrue(currentMilllis + EXPIRES_IN < credential.getExpiresAt());
+        assertThat(refreshParams.get("grant_type").get(0)).isEqualTo("refresh_token");
+        assertThat(refreshParams.get("refresh_token").get(0)).isEqualTo(REFRESH_TOKEN);
+        assertThat(refreshParams.get("client_id").get(0)).isEqualTo(APP.getKey());
+        assertThat(credential.getAccessToken()).isEqualTo(NEW_TOKEN);
+        assertThat(currentMilllis + EXPIRES_IN < credential.getExpiresAt()).isTrue();
     }
 
     @Test
@@ -231,13 +230,13 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         Map<String, List<String>> refreshParams = toParamsMap(new String(paramCaptor.getValue(), "UTF-8"));
 
         // Verification
-        assertEquals(refreshParams.get("grant_type").get(0), "refresh_token");
-        assertEquals(refreshParams.get("refresh_token").get(0), REFRESH_TOKEN);
-        assertEquals(refreshParams.get("client_id").get(0), APP.getKey());
-        assertEquals(refreshParams.get("scope").get(0), "myscope1 myscope2");
-        assertEquals(credential.getAccessToken(), NEW_TOKEN);
-        assertTrue(currentMilllis + EXPIRES_IN < credential.getExpiresAt());
-        assertEquals(refreshResult.getScope(), "myscope1");
+        assertThat(refreshParams.get("grant_type").get(0)).isEqualTo("refresh_token");
+        assertThat(refreshParams.get("refresh_token").get(0)).isEqualTo(REFRESH_TOKEN);
+        assertThat(refreshParams.get("client_id").get(0)).isEqualTo(APP.getKey());
+        assertThat(refreshParams.get("scope").get(0)).isEqualTo("myscope1 myscope2");
+        assertThat(credential.getAccessToken()).isEqualTo(NEW_TOKEN);
+        assertThat(currentMilllis + EXPIRES_IN < credential.getExpiresAt()).isTrue();
+        assertThat(refreshResult.getScope()).isEqualTo("myscope1");
     }
 
     @Test
@@ -265,7 +264,7 @@ public class DbxRefershTest extends DbxOAuthTestBase {
         try {
             client.refreshAccessToken();
         } catch (DbxOAuthException e) {
-            assertEquals(e.getDbxOAuthError().getError(), "invalid_grant");
+            assertThat(e.getDbxOAuthError().getError()).isEqualTo("invalid_grant");
             return;
         }
 
@@ -298,9 +297,9 @@ public class DbxRefershTest extends DbxOAuthTestBase {
             client.users().getCurrentAccount();
             fail("Should raise exception before reaching here");
         } catch (InvalidAccessTokenException ex) {
-            assertTrue(ex.getAuthError().isMissingScope());
+            assertThat(ex.getAuthError().isMissingScope()).isTrue();
             String missingScope = ex.getAuthError().getMissingScopeValue().getRequiredScope();
-            assertEquals("account.info.read", missingScope, "expect account.info.read, get " + missingScope);
+            assertWithMessage("expect account.info.read, get " + missingScope).that("account.info.read").isEqualTo(missingScope);
         }
     }
 }

--- a/src/test/java/com/dropbox/core/stone/StoneSerializersTest.java
+++ b/src/test/java/com/dropbox/core/stone/StoneSerializersTest.java
@@ -1,6 +1,7 @@
 package com.dropbox.core.stone;
 
-import static org.testng.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
+import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -31,26 +32,26 @@ public class StoneSerializersTest {
         Date expected = fromTimestampString(expectedTimestamp);
         Date actual = StoneSerializers.timestamp().deserialize(quoted(expectedTimestamp));
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         // LONG FORMAT SERIALIZATION
         String actualTimestamp = StoneSerializers.timestamp().serialize(expected);
 
-        assertEquals(actualTimestamp, quoted(expectedTimestamp));
+        assertThat(actualTimestamp).isEqualTo(quoted(expectedTimestamp));
 
         // SHORT FORMAT DESERIALIZATION
         String shortTimestamp = "2011-02-03";
         expected = fromTimestampString(shortTimestamp);
         actual = StoneSerializers.timestamp().deserialize(quoted(shortTimestamp));
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         // SHORT FORMAT SERIALIZATION
         actualTimestamp = StoneSerializers.timestamp().serialize(expected);
 
         // we always format to long-form
         expectedTimestamp = toTimestampString(expected);
-        assertEquals(actualTimestamp, quoted(expectedTimestamp));
+        assertThat(actualTimestamp).isEqualTo(quoted(expectedTimestamp));
     }
 
     @Test(expectedExceptions = JsonProcessingException.class)
@@ -75,8 +76,8 @@ public class StoneSerializersTest {
         String serialized = "{}";
 
         StoneSerializer<Map<String, Integer>> serializer = StoneSerializers.map(StoneSerializers.int32());
-        assertEquals(serializer.serialize(map), serialized);
-        assertEquals(serializer.deserialize(serialized), map);
+        assertThat(serializer.serialize(map)).isEqualTo(serialized);
+        assertThat(serializer.deserialize(serialized)).isEqualTo(map);
     }
 
     @Test
@@ -88,8 +89,8 @@ public class StoneSerializersTest {
         String serialized = "{\"a\":1,\"b\":2}";
 
         StoneSerializer<Map<String, Integer>> serializer = StoneSerializers.map(StoneSerializers.int32());
-        assertEquals(serializer.serialize(map), serialized);
-        assertEquals(serializer.deserialize(serialized), map);
+        assertThat(serializer.serialize(map)).isEqualTo(serialized);
+        assertThat(serializer.deserialize(serialized)).isEqualTo(map);
     }
 
     @Test
@@ -106,8 +107,8 @@ public class StoneSerializersTest {
 
         StoneSerializer<Map<String, Map<String, Integer>>> serializer =
                 StoneSerializers.map(StoneSerializers.map(StoneSerializers.int32()));
-        assertEquals(serializer.serialize(map), serialized);
-        assertEquals(serializer.deserialize(serialized), map);
+        assertThat(serializer.serialize(map)).isEqualTo(serialized);
+        assertThat(serializer.deserialize(serialized)).isEqualTo(map);
     }
 
     @Test
@@ -119,8 +120,8 @@ public class StoneSerializersTest {
 
         StoneSerializer<Map<String, String>> serializer =
                 StoneSerializers.map(StoneSerializers.nullable(StoneSerializers.string()));
-        assertEquals(serializer.serialize(map), serialized);
-        assertEquals(serializer.deserialize(serialized), map);
+        assertThat(serializer.serialize(map)).isEqualTo(serialized);
+        assertThat(serializer.deserialize(serialized)).isEqualTo(map);
     }
 
     private static String quoted(String value) {

--- a/src/test/java/com/dropbox/core/stone/test/DataTypeSerializationTest.java
+++ b/src/test/java/com/dropbox/core/stone/test/DataTypeSerializationTest.java
@@ -63,7 +63,7 @@ public class DataTypeSerializationTest {
     @Test
     public void testUnknownStructFields() throws Exception {
         String json = "{\"height\":768,\"alpha\":0.5,\"width\":1024,\"foo\":{\"bar\":[1, 2, 3],\"baz\":false}}";
-        Dimensions expected = new Dimensions(1024).isEqualTo(768);
+        Dimensions expected = new Dimensions(1024, 768);
         Dimensions actual = Dimensions.Serializer.INSTANCE.deserialize(json);
 
         assertThat(actual).isEqualTo(expected);

--- a/src/test/java/com/dropbox/core/stone/test/DataTypeSerializationTest.java
+++ b/src/test/java/com/dropbox/core/stone/test/DataTypeSerializationTest.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.stone.test;
 
-import static org.testng.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
 
@@ -16,27 +16,27 @@ public class DataTypeSerializationTest {
         // (e.g. no instances or fields have been accessed for this class yet)
         String json = "{\"reason\":{\".tag\":\"bad_feels\",\"bad_feels\":\"meh\"},\"session_id\":\"2\"}";
         Uninitialized actual = Uninitialized.Serializer.INSTANCE.deserialize(json);
-        assertEquals(actual.getSessionId(), "2");
-        assertEquals(actual.getReason().tag(), UninitializedReason.Tag.BAD_FEELS);
-        assertEquals(actual.getReason().getBadFeelsValue(), BadFeel.MEH);
+        assertThat(actual.getSessionId()).isEqualTo("2");
+        assertThat(actual.getReason().tag()).isEqualTo(UninitializedReason.Tag.BAD_FEELS);
+        assertThat(actual.getReason().getBadFeelsValue()).isEqualTo(BadFeel.MEH);
     }
 
     @Test
     public void testCatchAllDeserialization() throws Exception {
         String json = "{\".tag\":\"catch_all\",\"catch_all\":\"test_unknown_tag\"}";
         NestingUnion actual = NestingUnion.Serializer.INSTANCE.deserialize(json);
-        assertEquals(actual.tag(), NestingUnion.Tag.CATCH_ALL);
-        assertEquals(actual.getCatchAllValue(), CatchAllUnion.OTHER);
+        assertThat(actual.tag()).isEqualTo(NestingUnion.Tag.CATCH_ALL);
+        assertThat(actual.getCatchAllValue()).isEqualTo(CatchAllUnion.OTHER);
 
         json = "{\".tag\":\"catch_all\",\"catch_all\":{\".tag\":\"test_unknown_tag\",\"test\":true}}";
         actual = NestingUnion.Serializer.INSTANCE.deserialize(json);
-        assertEquals(actual.tag(), NestingUnion.Tag.CATCH_ALL);
-        assertEquals(actual.getCatchAllValue(), CatchAllUnion.OTHER);
+        assertThat(actual.tag()).isEqualTo(NestingUnion.Tag.CATCH_ALL);
+        assertThat(actual.getCatchAllValue()).isEqualTo(CatchAllUnion.OTHER);
 
         json = "\"test_unknown_tag\"";
         actual = NestingUnion.Serializer.INSTANCE.deserialize(json);
-        assertNotNull(actual);
-        assertEquals(actual.tag(), NestingUnion.Tag.OTHER);
+        assertThat(actual).isNotNull();
+        assertThat(actual.tag()).isEqualTo(NestingUnion.Tag.OTHER);
     }
 
     @Test(expectedExceptions={IOException.class})
@@ -52,28 +52,28 @@ public class DataTypeSerializationTest {
         Dimensions expected = new Dimensions(1024, 768);
         Dimensions actual = Dimensions.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         json = "{\"width\":1024,\"height\":768}";
         actual = Dimensions.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void testUnknownStructFields() throws Exception {
         String json = "{\"height\":768,\"alpha\":0.5,\"width\":1024,\"foo\":{\"bar\":[1, 2, 3],\"baz\":false}}";
-        Dimensions expected = new Dimensions(1024, 768);
+        Dimensions expected = new Dimensions(1024).isEqualTo(768);
         Dimensions actual = Dimensions.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         // sometimes the order can matter. Add an unknown struct field early to see if we skip it properly
         json = "{\"height\":768,\"foo\":{\"bar\":[1, 2, 3],\"baz\":false},\"alpha\":0.5,\"width\":1024}";
         expected = new Dimensions(1024, 768);
         actual = Dimensions.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -86,19 +86,19 @@ public class DataTypeSerializationTest {
         String json = Cat.Serializer.INSTANCE.serialize(expected);
         Cat actual = Cat.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         // explicitly use long date
         json = "{\".tag\":\"cat\",\"name\":\"Mimi\",\"born\":\"2016-01-15T00:00:00Z\"}";
         actual = Cat.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         // use short date
         json = "{\".tag\":\"cat\",\"name\":\"Mimi\",\"born\":\"2016-01-15\"}";
         actual = Cat.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -117,33 +117,33 @@ public class DataTypeSerializationTest {
         String json = Dog.Serializer.INSTANCE.serialize(dog);
         Pet actual = Pet.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual.getClass(), Dog.class);
-        assertEquals(actual, dog);
+        assertThat(actual.getClass()).isEqualTo(Dog.class);
+        assertThat(actual).isEqualTo(dog);
 
         json = Cat.Serializer.INSTANCE.serialize(cat);
         actual = Pet.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual.getClass(), Cat.class);
-        assertEquals(actual, cat);
+        assertThat(actual.getClass()).isEqualTo(Cat.class);
+        assertThat(actual).isEqualTo(cat);
 
         json = Fish.Serializer.INSTANCE.serialize(fish);
         actual = Pet.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual.getClass(), Fish.class);
-        assertEquals(actual, fish);
+        assertThat(actual.getClass()).isEqualTo(Fish.class);
+        assertThat(actual).isEqualTo(fish);
 
         json = Pet.Serializer.INSTANCE.serialize(pet);
         actual = Pet.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual.getClass(), Pet.class);
-        assertEquals(actual, pet);
+        assertThat(actual.getClass()).isEqualTo(Pet.class);
+        assertThat(actual).isEqualTo(pet);
 
         // check that we can deserialize as the specific type if necessary.
         json = Dog.Serializer.INSTANCE.serialize(dog);
         actual = Dog.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual.getClass(), Dog.class);
-        assertEquals(actual, dog);
+        assertThat(actual.getClass()).isEqualTo(Dog.class);
+        assertThat(actual).isEqualTo(dog);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class DataTypeSerializationTest {
         String json = "{\".tag\":\"cat\",\"name\":\"Pusheen\"}";
         Cat actual = Cat.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         // set the optional fields
         expected = Cat.newBuilder("Pusheen")
@@ -166,20 +166,20 @@ public class DataTypeSerializationTest {
         json = Cat.Serializer.INSTANCE.serialize(expected);
         actual = Cat.Serializer.INSTANCE.deserialize(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void testUnionInheritanceSerialization() throws Exception {
         String actual = ChildUnion.Serializer.INSTANCE.serialize(ChildUnion.ALPHA);
-        assertEquals(actual, "\"alpha\"");
+        assertThat(actual).isEqualTo("\"alpha\"");
     }
 
     @Test
     public void testUnionInheritanceDeserialization() throws Exception {
         String json = "\"alpha\"";
         ChildUnion actual = ChildUnion.Serializer.INSTANCE.deserialize(json);
-        assertEquals(actual, ChildUnion.ALPHA);
+        assertThat(actual).isEqualTo(ChildUnion.ALPHA);
     }
 
 }

--- a/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
+++ b/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.stone.test;
 
-import static org.testng.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.testng.annotations.Test;
 
@@ -18,9 +18,9 @@ public class RouteVersionTest {
         Method v2Option = c.getDeclaredMethod("testRouteV2", String.class, Date.class);
 
         // Test exception
-        assertFalse(Arrays.asList(v1.getExceptionTypes()).contains(ParentUnionException.class));
-        assertTrue(Arrays.asList(v2NoOpition.getExceptionTypes()).contains(ParentUnionException.class));
-        assertTrue(Arrays.asList(v2Option.getExceptionTypes()).contains(ParentUnionException.class));
+        assertThat(Arrays.asList(v1.getExceptionTypes()).contains(ParentUnionException.class)).isFalse();
+        assertThat(Arrays.asList(v2NoOpition.getExceptionTypes()).contains(ParentUnionException.class)).isTrue();
+        assertThat(Arrays.asList(v2Option.getExceptionTypes()).contains(ParentUnionException.class)).isTrue();
     }
 
     @Test
@@ -32,32 +32,32 @@ public class RouteVersionTest {
         Method v3Builder = c.getDeclaredMethod("testUploadV3Builder", String.class, String.class);
 
         // Test return value
-        assertEquals(v1.getReturnType(), TestUploadUploader.class);
-        assertEquals(v2NoBuilder.getReturnType(), TestUploadV2Uploader.class);
-        assertEquals(v2Builder.getReturnType(), TestUploadV2Builder.class);
-        assertEquals(v3Builder.getReturnType(), DbxTestTestUploadV3Builder.class);
+        assertThat(v1.getReturnType(), TestUploadUploader.class);
+        assertThat(v2NoBuilder.getReturnType()).isEqualTo(TestUploadV2Uploader.class);
+        assertThat(v2Builder.getReturnType()).isEqualTo(TestUploadV2Builder.class);
+        assertThat(v3Builder.getReturnType()).isEqualTo(DbxTestTestUploadV3Builder.class);
 
         // Test builder
         TestUploadV2Builder.class.getDeclaredMethod("withBorn", Date.class);
         TestUploadV2Builder.class.getDeclaredMethod("withSize", DogSize.class);
         Method start2 = TestUploadV2Builder.class.getDeclaredMethod("start");
-        assertTrue(Arrays.asList(start2.getExceptionTypes()).contains(ParentUnionException.class));
+        assertThat(Arrays.asList(start2.getExceptionTypes())).contains(ParentUnionException.class);
 
         // Test return value of uploader from generic type
         ParameterizedType genericV1 = (ParameterizedType)TestUploadUploader.class.getGenericSuperclass();
-        assertEquals(genericV1.getActualTypeArguments()[1], Void.class);
+        assertThat(genericV1.getActualTypeArguments()[1]).isEqualTo(Void.class);
         ParameterizedType genericV2 = (ParameterizedType)TestUploadV2Uploader.class.getGenericSuperclass();
-        assertEquals(genericV2.getActualTypeArguments()[1], ParentUnion.class);
+        assertThat(genericV2.getActualTypeArguments()[1]).isEqualTo(ParentUnion.class);
 
         // Test exception from generic type
-        assertEquals(genericV1.getActualTypeArguments()[1], Void.class);
-        assertEquals(genericV2.getActualTypeArguments()[1], ParentUnion.class);
+        assertThat(genericV1.getActualTypeArguments()[1]).isEqualTo(Void.class);
+        assertThat(genericV2.getActualTypeArguments()[1]).isEqualTo(ParentUnion.class);
 
         // Test builder with multiple auth types has prefix
         DbxTestTestUploadV3Builder.class.getDeclaredMethod("withBorn", Date.class);
         DbxTestTestUploadV3Builder.class.getDeclaredMethod("withSize", DogSize.class);
         Method start3 = DbxTestTestUploadV3Builder.class.getDeclaredMethod("start");
-        assertTrue(Arrays.asList(start3.getExceptionTypes()).contains(ParentUnionException.class));
+        assertThat(Arrays.asList(start3.getExceptionTypes())).contains(ParentUnionException.class);
     }
 
     @Test
@@ -69,18 +69,18 @@ public class RouteVersionTest {
         Method v2Builder = c.getDeclaredMethod("testDownloadV2Builder", UninitializedReason.class, String.class);
 
         // Test return type
-        assertEquals(v1Builder.getReturnType(), TestDownloadBuilder.class);
-        assertEquals(v2Builder.getReturnType(), TestDownloadV2Builder.class);
+        assertThat(v1Builder.getReturnType()).isEqualTo(TestDownloadBuilder.class);
+        assertThat(v2Builder.getReturnType()).isEqualTo(TestDownloadV2Builder.class);
 
         // Test return type from generic type
         ParameterizedType genericV1 = (ParameterizedType)TestDownloadBuilder.class.getGenericSuperclass();
-        assertEquals(genericV1.getActualTypeArguments()[0], Fish.class);
+        assertThat(genericV1.getActualTypeArguments()[0]).isEqualTo(Fish.class);
         ParameterizedType genericV2 = (ParameterizedType)TestDownloadV2Builder.class.getGenericSuperclass();
-        assertEquals(genericV2.getActualTypeArguments()[0], Fish.class);
+        assertThat(genericV2.getActualTypeArguments()[0]).isEqualTo(Fish.class);
 
 
         // Test exception type
-        assertFalse(Arrays.asList(v1NoBuilder.getExceptionTypes()).contains(ParentUnionException.class));
-        assertTrue(Arrays.asList(v2NoBuilder.getExceptionTypes()).contains(ParentUnionException.class));
+        assertThat(Arrays.asList(v1NoBuilder.getExceptionTypes())).doesNotContain(ParentUnionException.class);
+        assertThat(Arrays.asList(v2NoBuilder.getExceptionTypes())).contains(ParentUnionException.class);
     }
 }

--- a/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
+++ b/src/test/java/com/dropbox/core/stone/test/RouteVersionTest.java
@@ -32,7 +32,7 @@ public class RouteVersionTest {
         Method v3Builder = c.getDeclaredMethod("testUploadV3Builder", String.class, String.class);
 
         // Test return value
-        assertThat(v1.getReturnType(), TestUploadUploader.class);
+        assertThat(v1.getReturnType()).isEqualTo(TestUploadUploader.class);
         assertThat(v2NoBuilder.getReturnType()).isEqualTo(TestUploadV2Uploader.class);
         assertThat(v2Builder.getReturnType()).isEqualTo(TestUploadV2Builder.class);
         assertThat(v3Builder.getReturnType()).isEqualTo(DbxTestTestUploadV3Builder.class);

--- a/src/test/java/com/dropbox/core/v1/DbxClientV1IT.java
+++ b/src/test/java/com/dropbox/core/v1/DbxClientV1IT.java
@@ -1,7 +1,8 @@
 package com.dropbox.core.v1;
 
-import static org.testng.Assert.*;
 import static com.dropbox.core.util.StringUtil.jq;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.dropbox.core.DbxStreamWriter;
 import com.dropbox.core.ITUtil;
@@ -36,7 +37,7 @@ public class DbxClientV1IT {
     private void setup() throws Exception {
         this.client = ITUtil.newClientV1();
         this.testFolder = ITUtil.root(DbxClientV1IT.class);
-        assertNotNull(client.createFolder(testFolder));
+        assertThat(client.createFolder(testFolder)).isNotNull();
     }
 
     @AfterMethod
@@ -70,15 +71,15 @@ public class DbxClientV1IT {
         String remotePath = p("test-fil" + E_ACCENT + ".txt");
 
         DbxEntry.File up = client.uploadFile(remotePath, DbxWriteMode.add(), contents.length, new ByteArrayInputStream(contents));
-        assertEquals(up.path, remotePath);
-        assertEquals(up.numBytes, contents.length);
+        assertThat(up.path).isEqualTo(remotePath);
+        assertThat(up.numBytes).isEqualTo(contents.length);
 
         ByteArrayOutputStream downBodyStream = new ByteArrayOutputStream();
         DbxEntry.File down = client.getFile(remotePath, null, downBodyStream);
         byte[] downBody = downBodyStream.toByteArray();
 
-        assertEquals(up.numBytes, down.numBytes);
-        assertEquals(up.numBytes, downBody.length);
+        assertThat(up.numBytes).isEqualTo(down.numBytes);
+        assertThat(up.numBytes).isEqualTo(downBody.length);
     }
 
     private DbxEntry.File addFile(String path, int length) throws Exception {
@@ -105,32 +106,32 @@ public class DbxClientV1IT {
 
         {
             DbxEntry entry = client.getMetadata(p("a.txt"));
-            assertEquals(entry.path, p("a.txt"));
-            assertTrue(entry instanceof DbxEntry.File);
+            assertThat(entry.path).isEqualTo(p("a.txt"));
+            assertThat(entry instanceof DbxEntry.File).isTrue();
             DbxEntry.File f = (DbxEntry.File) entry;
-            assertEquals(f.numBytes, 100);
+            assertThat(f.numBytes).isEqualTo(100);
 
             DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p("a.txt"));
-            assertEquals(mwc.entry, entry);
+            assertThat(mwc.entry).isEqualTo(entry);
         }
 
         // Containing folder.
         {
             DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p());
-            assertEquals(mwc.children.size(), 1);
+            assertThat(mwc.children.size()).isEqualTo(1);
 
             // Folder metadata should be the same if we call /metadata again.
             Maybe<DbxEntry.WithChildren> r2 = client.getMetadataWithChildrenIfChanged(p(), mwc.hash);
-            assertTrue(r2.isNothing());
+            assertThat(r2.isNothing()).isTrue();
         }
 
         // File not found.
         {
             DbxEntry entry = client.getMetadata(p("does not exists.txt"));
-            assertNull(entry);
+            assertThat(entry).isNull();
 
             DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p("does not exist.txt"));
-            assertNull(mwc);
+            assertThat(mwc).isNull();
         }
     }
 
@@ -145,8 +146,8 @@ public class DbxClientV1IT {
         // Get latest cursors before modifying dropbox folders
         String latestCursor = client.getDeltaLatestCursor();
         String latestCursorWithPath = client.getDeltaLatestCursorWithPathPrefix(p("b"));
-        assertNotNull(latestCursor);
-        assertNotNull(latestCursorWithPath);
+        assertThat(latestCursor).isNotNull();
+        assertThat(latestCursorWithPath).isNotNull();
 
         DbxEntry.Folder top = (DbxEntry.Folder) client.getMetadata(p());
         DbxEntry.File a = addFile(p("a.txt"), 10);
@@ -167,16 +168,16 @@ public class DbxClientV1IT {
                 DbxDelta<DbxEntry> d = client.getDelta(cursor);
                 for (DbxDelta.Entry<DbxEntry> e : d.entries) {
                     if (e.lcPath.startsWith(lcPrefix+"/") || e.lcPath.equals(lcPrefix)) {
-                        assertNotNull(e.metadata);  // We shouldn't see deletes in our test folder.
+                        assertThat(e.metadata).isNotNull();  // We shouldn't see deletes in our test folder.
                         boolean removed = expected.remove(e.metadata);
-                        assertTrue(removed);
+                        assertThat(removed).isTrue();
                     }
                 }
                 cursor = d.cursor;
                 if (!d.hasMore) break;
             }
 
-            assertEquals(expected.size(), 0);
+            assertThat(expected.size()).isEqualTo(0);
         }
 
         // getDeltaWithPathPrefix
@@ -189,16 +190,16 @@ public class DbxClientV1IT {
             while (true) {
                 DbxDelta<DbxEntry> d = client.getDeltaWithPathPrefix(cursor, prefix);
                 for (DbxDelta.Entry<DbxEntry> e : d.entries) {
-                    assertTrue(e.lcPath.startsWith(lcPrefix+"/") || e.lcPath.equals(lcPrefix));
-                    assertNotNull(e.metadata);  // We should never see deletes.
+                    assertThat(e.lcPath.startsWith(lcPrefix+"/") || e.lcPath.equals(lcPrefix)).isTrue();
+                    assertThat(e.metadata).isNotNull();  // We should never see deletes.
                     boolean removed = expected.remove(e.metadata);
-                    assertTrue(removed);
+                    assertThat(removed).isTrue();
                 }
                 cursor = d.cursor;
                 if (!d.hasMore) break;
             }
 
-            assertEquals(expected.size(), 0);
+            assertThat(expected.size()).isEqualTo(0);
         }
 
         // Test latest cursor responses
@@ -209,16 +210,16 @@ public class DbxClientV1IT {
             while (true) {
                 DbxDelta<DbxEntry> d = client.getDelta(cursor);
                 for (DbxDelta.Entry<DbxEntry> e : d.entries) {
-                    assertTrue(e.lcPath.startsWith(lcPrefix+"/") || e.lcPath.equals(lcPrefix));
-                    assertNotNull(e.metadata);  // We shouldn't see deletes in our test folder.
+                    assertThat(e.lcPath.startsWith(lcPrefix+"/") || e.lcPath.equals(lcPrefix)).isTrue();
+                    assertThat(e.metadata).isNotNull();  // We shouldn't see deletes in our test folder.
                     boolean removed = expected.remove(e.metadata);
-                    assertTrue(removed);
+                    assertThat(removed).isTrue();
                 }
                 cursor = d.cursor;
                 if (!d.hasMore) break;
             }
 
-            assertEquals(expected.size(), 0);
+            assertThat(expected.size()).isEqualTo(0);
         }
 
         // Test latest cursor with path prefix
@@ -231,22 +232,22 @@ public class DbxClientV1IT {
             while (true) {
                 DbxDelta<DbxEntry> d = client.getDeltaWithPathPrefix(cursor, prefix);
                 for (DbxDelta.Entry<DbxEntry> e : d.entries) {
-                    assertTrue(e.lcPath.startsWith(lcPrefix+"/") || e.lcPath.equals(lcPrefix));
-                    assertNotNull(e.metadata);  // We should never see deletes.
+                    assertThat(e.lcPath.startsWith(lcPrefix+"/") || e.lcPath.equals(lcPrefix)).isTrue();
+                    assertThat(e.metadata).isNotNull();  // We should never see deletes.
                     boolean removed = expected.remove(e.metadata);
-                    assertTrue(removed);
+                    assertThat(removed).isTrue();
                 }
                 cursor = d.cursor;
                 if (!d.hasMore) break;
             }
 
-            assertEquals(expected.size(), 0);
+            assertThat(expected.size()).isEqualTo(0);
         }
 
         // Test longpoll_delta
         {
             DbxLongpollDeltaResult longpollDelta = client.getLongpollDelta(latestCursor, 30);
-            assertTrue(longpollDelta.mightHaveChanges);
+            assertThat(longpollDelta.mightHaveChanges).isTrue();
         }
     }
 
@@ -255,23 +256,23 @@ public class DbxClientV1IT {
         String path = p("r"+E_ACCENT+"visions.txt");
 
         DbxEntry.File e2 = uploadFile(path, 100, DbxWriteMode.force());
-        assertEquals(client.getRevisions(path).size(), 1);
+        assertThat(client.getRevisions(path).size()).isEqualTo(1);
         client.delete(path);
-        assertEquals(client.getRevisions(path).size(), 1);
+        assertThat(client.getRevisions(path).size(), 1);
         DbxEntry.File e1 = uploadFile(path, 200, DbxWriteMode.force());
         DbxEntry.File e0 = uploadFile(path, 300, DbxWriteMode.force());
 
         List<DbxEntry.File> mds = client.getRevisions(path);
-        assertEquals(mds.size(), 3);
+        assertThat(mds.size()).isEqualTo(3);
 
-        assertEquals(mds.get(0), e0);
-        assertEquals(mds.get(1), e1);
-        assertEquals(mds.get(2), e2);
+        assertThat(mds.get(0)).isEqualTo(e0);
+        assertThat(mds.get(1)).isEqualTo(e1);
+        assertThat(mds.get(2)).isEqualTo(e2);
 
         DbxEntry.File r1 = client.restoreFile(path, e1.rev);
-        assertEquals(r1.numBytes, e1.numBytes);
+        assertThat(r1.numBytes).isEqualTo(e1.numBytes);
         DbxEntry.File r2 = client.restoreFile(path, e2.rev);
-        assertEquals(r2.numBytes, e2.numBytes);
+        assertThat(r2.numBytes).isEqualTo(e2.numBytes);
     }
 
     @Test
@@ -283,14 +284,14 @@ public class DbxClientV1IT {
         List<DbxEntry> results;
 
         results = client.searchFileAndFolderNames(p(), "search");
-        assertEquals(results.size(), 2);
+        assertThat(results.size()).isEqualTo(2);
 
         results = client.searchFileAndFolderNames(p("sub"), "search");
-        assertEquals(results.size(), 1);
+        assertThat(results.size()).isEqualTo(1);
 
         results = client.searchFileAndFolderNames(p(), "a.txt");
-        assertEquals(results.size(), 1);
-        assertEquals(results.get(0).name, "search - a.txt");
+        assertThat(results.size()).isEqualTo(1);
+        assertThat(results.get(0).name).isEqualTo("search - a.txt");
     }
 
     private static byte[] downloadUrl(String urlS) throws Exception {
@@ -314,7 +315,7 @@ public class DbxClientV1IT {
 
         // Preview page should be larger than the original content.
         byte[] previewPage = downloadUrl(previewUrl.toString());
-        assertTrue(previewPage.length > contents.length);
+        assertThat(previewPage.length > contents.length).isTrue();
 
         // Direct download should match exactly.
         URL directUrl = new URL(
@@ -324,7 +325,7 @@ public class DbxClientV1IT {
             previewUrl.getFile()
         );
         byte[] directContents = downloadUrl(directUrl.toString());
-        assertEquals(directContents, contents);
+        assertThat(directContents).isEqualTo(contents);
     }
 
     @Test
@@ -336,7 +337,7 @@ public class DbxClientV1IT {
         DbxUrlWithExpiration uwe = client.createTemporaryDirectUrl(path);
 
         byte[] downloadedContents = downloadUrl(uwe.url);
-        assertEquals(downloadedContents, contents);
+        assertThat(downloadedContents).isEqualTo(contents);
     }
 
     @Test
@@ -349,10 +350,10 @@ public class DbxClientV1IT {
         String copyRef = client.createCopyRef(source);
 
         DbxEntry.File destMd = client.copyFromCopyRef(copyRef, dest).asFile();
-        assertEquals(size, destMd.numBytes);
+        assertThat(size).isEqualTo(destMd.numBytes);
 
         DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p());
-        assertEquals(mwc.children.size(), 2);
+        assertThat(mwc.children.size()).isEqualTo(2);
     }
 
     @Test
@@ -366,11 +367,11 @@ public class DbxClientV1IT {
         String copyRef = client.createCopyRef(source);
         DbxEntry r = client.copyFromCopyRef(copyRef, dest);
 
-        assertTrue(r.isFolder());
-        assertEquals(r.path, dest);
+        assertThat(r.isFolder()).isTrue();
+        assertThat(r.path).isEqualTo(dest);
 
         DbxEntry.WithChildren c = client.getMetadataWithChildren(dest);
-        assertEquals(c.children.size(), 2);
+        assertThat(c.children.size()).isEqualTo(2);
     }
 
     @Test
@@ -382,11 +383,11 @@ public class DbxClientV1IT {
         String copyRef = client.createCopyRef(source);
         DbxEntry r = client.copyFromCopyRef(copyRef, dest);
 
-        assertTrue(r.isFolder());
-        assertEquals(r.path, dest);
+        assertThat(r.isFolder()).isTrue();
+        assertThat(r.path).isEqualTo(dest);
 
         DbxEntry.WithChildren c = client.getMetadataWithChildren(dest);
-        assertEquals(c.children.size(), 0);
+        assertThat(c.children.size()).isEqualTo(0);
     }
 
     @Test
@@ -406,7 +407,7 @@ public class DbxClientV1IT {
         finally {
             IOUtil.closeInput(in);
         }
-        assertEquals(uploadEntry.path.toLowerCase(), orig.toLowerCase());
+        assertThat(uploadEntry.path.toLowerCase()).isEqualTo(orig.toLowerCase());
 
         // Get metadata with photo info (keep trying until photo info is available)
         int maxTries = 30;
@@ -422,12 +423,12 @@ public class DbxClientV1IT {
             if (origEntry.photoInfo == DbxEntry.File.PhotoInfo.PENDING) break;
         }
 
-        assertEquals(origEntry.path.toLowerCase(), orig.toLowerCase());
-        assertNotNull(origEntry.photoInfo);
+        assertThat(origEntry.path.toLowerCase()).isEqualTo(orig.toLowerCase());
+        assertThat(origEntry.photoInfo).isNotNull();
 
         // List folder with photo info.
         DbxEntry.File childEntry = client.getMetadataWithChildren(folder, true).children.get(0).asFile();
-        assertEquals(childEntry, origEntry);
+        assertThat(childEntry).isEqualTo(origEntry);
     }
 
     @Test
@@ -470,19 +471,19 @@ public class DbxClientV1IT {
                 DbxEntry.File md = client.getThumbnail(size, format, orig, null, out);
                 byte[] data = out.toByteArray();
 
-                assertEquals(removeMediaInfo(origMD), removeMediaInfo(md));
+                assertThat(removeMediaInfo(origMD)).isEqualTo(removeMediaInfo(md));
 
                 // We're getting bigger and bigger thumbnails, so they should have more bytes
                 // than the previous ones.
-                assertTrue(data.length > prevSize);
+                assertThat(data.length > prevSize).isTrue();
 
                 reader.setInput(new MemoryCacheImageInputStream(new ByteArrayInputStream(data)));
                 int w = reader.getWidth(0);
                 int h = reader.getHeight(0);
                 int expectedW = Math.min(size.width, origW);
                 int expectedH = Math.min(size.width, origH);
-                assertTrue((w == expectedW && h <= expectedH) || (h == expectedH && w <= expectedW),
-                    "expected = " + expectedW + "x" + expectedH + ", got = " + w + "x" + h);
+                assertWithMessage("expected = " + expectedW + "x" + expectedH + ", got = " + w + "x" + h)
+                        .that((w == expectedW && h <= expectedH) || (h == expectedH && w <= expectedW)).isTrue();
             }
         }
     }
@@ -509,7 +510,7 @@ public class DbxClientV1IT {
     public void testChunkedUpload() throws Exception {
         byte[] contents = StringUtil.stringToUtf8("A simple test file");
         int chunkSize = 7;
-        assertNotEquals(contents.length % chunkSize, 0);  // Make sure the last chunk is not full-sized.
+        assertThat(contents.length % chunkSize).isNotEqualTo(0);  // Make sure the last chunk is not full-sized.
 
 
         // Pass in the correct file size.
@@ -517,15 +518,15 @@ public class DbxClientV1IT {
             String remotePath = p("test-fil" + E_ACCENT + ".txt");
             DbxEntry.File up = client.uploadFileChunked(chunkSize, remotePath, DbxWriteMode.add(),
                                                         contents.length, new DbxStreamWriter.ByteArrayCopier(contents));
-            assertEquals(up.path, remotePath);
-            assertEquals(up.numBytes, contents.length);
+            assertThat(up.path).isEqualTo(remotePath);
+            assertThat(up.numBytes).isEqualTo(contents.length);
 
             ByteArrayOutputStream downBodyStream = new ByteArrayOutputStream();
             DbxEntry.File down = client.getFile(remotePath, null, downBodyStream);
             byte[] downBody = downBodyStream.toByteArray();
 
-            assertEquals(up.numBytes, down.numBytes);
-            assertEquals(downBody, contents);
+            assertThat(up.numBytes).isEqualTo(down.numBytes);
+            assertThat(downBody).isEqualTo(contents);
         }
 
         // Pass in "-1" for file size.
@@ -533,15 +534,15 @@ public class DbxClientV1IT {
             String remotePath = p("test-fil" + E_ACCENT + "-2.txt");
             DbxEntry.File up = client.uploadFileChunked(chunkSize, remotePath, DbxWriteMode.add(),
                                                         -1, new DbxStreamWriter.ByteArrayCopier(contents));
-            assertEquals(up.path, remotePath);
-            assertEquals(up.numBytes, contents.length);
+            assertThat(up.path).isEqualTo(remotePath);
+            assertThat(up.numBytes).isEqualTo(contents.length);
 
             ByteArrayOutputStream downBodyStream = new ByteArrayOutputStream();
             DbxEntry.File down = client.getFile(remotePath, null, downBodyStream);
             byte[] downBody = downBodyStream.toByteArray();
 
-            assertEquals(up.numBytes, down.numBytes);
-            assertEquals(downBody, contents);
+            assertThat(up.numBytes).isEqualTo(down.numBytes);
+            assertThat(downBody).isEqualTo(contents);
         }
 
         // Try uploading a file that is smaller than the first chunk.
@@ -549,15 +550,15 @@ public class DbxClientV1IT {
             String remotePath = p("test-fil" + E_ACCENT + "-3.txt");
             DbxEntry.File up = client.uploadFileChunked(contents.length + 2, remotePath, DbxWriteMode.add(),
                                                         -1, new DbxStreamWriter.ByteArrayCopier(contents));
-            assertEquals(up.path, remotePath);
-            assertEquals(up.numBytes, contents.length);
+            assertThat(up.path).isEqualTo(remotePath);
+            assertThat(up.numBytes).isEqualTo(contents.length);
 
             ByteArrayOutputStream downBodyStream = new ByteArrayOutputStream();
             DbxEntry.File down = client.getFile(remotePath, null, downBodyStream);
             byte[] downBody = downBodyStream.toByteArray();
 
-            assertEquals(up.numBytes, down.numBytes);
-            assertEquals(downBody, contents);
+            assertThat(up.numBytes).isEqualTo(down.numBytes);
+            assertThat(downBody).isEqualTo(contents);
         }
     }
 
@@ -569,11 +570,11 @@ public class DbxClientV1IT {
 
         addFile(source, size);
         DbxEntry.File md = client.copy(source, dest).asFile();
-        assertEquals(md.numBytes, size);
-        assertEquals(md.path, dest);
+        assertThat(md.numBytes).isEqualTo(size);
+        assertThat(md.path).isEqualTo(dest);
 
         DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p());
-        assertEquals(mwc.children.size(), 2);
+        assertThat(mwc.children.size()).isEqualTo(2);
     }
 
     @Test
@@ -586,11 +587,11 @@ public class DbxClientV1IT {
         String dest = p("copied folder");
         DbxEntry r = client.copy(source, dest);
 
-        assertTrue(r.isFolder());
-        assertEquals(r.path, dest);
+        assertThat(r.isFolder()).isTrue();
+        assertThat(r.path).isEqualTo(dest);
 
         DbxEntry.WithChildren c = client.getMetadataWithChildren(dest);
-        assertEquals(c.children.size(), 2);
+        assertThat(c.children.size()).isEqualTo(2);
     }
 
     @Test
@@ -601,24 +602,24 @@ public class DbxClientV1IT {
         String dest = p("copied empty folder");
         DbxEntry r = client.copy(source, dest);
 
-        assertTrue(r.isFolder());
-        assertEquals(r.path, dest);
+        assertThat(r.isFolder()).isTrue();
+        assertThat(r.path).isEqualTo(dest);
 
         DbxEntry.WithChildren c = client.getMetadataWithChildren(dest);
-        assertEquals(c.children.size(), 0);
+        assertThat(c.children.size()).isEqualTo(0);
     }
 
     @Test
     public void testCreateFolder() throws Exception {
         DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p());
-        assertEquals(mwc.children.size(), 0);
+        assertThat(mwc.children.size()).isEqualTo(0);
 
         client.createFolder(p("a"));
         mwc = client.getMetadataWithChildren(p());
-        assertEquals(mwc.children.size(), 1);
+        assertThat(mwc.children.size()).isEqualTo(1);
 
         DbxEntry folderMd = client.getMetadata(p("a"));
-        assertTrue(folderMd.isFolder());
+        assertThat(folderMd.isFolder()).isTrue();
     }
 
     @Test
@@ -630,7 +631,7 @@ public class DbxClientV1IT {
         client.delete(path);
 
         DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p());
-        assertEquals(mwc.children.size(), 0);
+        assertThat(mwc.children.size()).isEqualTo(0);
     }
 
     @Test
@@ -641,13 +642,13 @@ public class DbxClientV1IT {
 
         addFile(source, size);
         DbxEntry.WithChildren mwc = client.getMetadataWithChildren(p());
-        assertEquals(mwc.children.size(), 1);
+        assertThat(mwc.children.size()).isEqualTo(1);
 
         DbxEntry.File destMd = client.move(source, dest).asFile();
-        assertEquals(destMd.numBytes, size);
+        assertThat(destMd.numBytes).isEqualTo(size);
 
         mwc = client.getMetadataWithChildren(p());
-        assertEquals(mwc.children.size(), 1);
+        assertThat(mwc.children.size()).isEqualTo(1);
     }
 
     @Test
@@ -660,15 +661,15 @@ public class DbxClientV1IT {
         String dest = p("moved folder");
         DbxEntry r = client.move(source, dest);
 
-        assertTrue(r.isFolder());
-        assertEquals(r.path, dest);
+        assertThat(r.isFolder()).isTrue();
+        assertThat(r.path).isEqualTo(dest);
 
         DbxEntry.WithChildren c = client.getMetadataWithChildren(dest);
-        assertEquals(c.children.size(), 2);
+        assertThat(c.children.size()).isEqualTo(2);
 
         // Make sure source is now gone.
         DbxEntry deleted = client.getMetadata(source);
-        assertTrue(deleted == null);
+        assertThat(deleted == null).isTrue();
     }
 
     @Test
@@ -679,14 +680,14 @@ public class DbxClientV1IT {
         String dest = p("moved empty folder");
         DbxEntry r = client.move(source, dest);
 
-        assertTrue(r.isFolder());
-        assertEquals(r.path, dest);
+        assertThat(r.isFolder()).isTrue();
+        assertThat(r.path).isEqualTo(dest);
 
         DbxEntry.WithChildren c = client.getMetadataWithChildren(dest);
-        assertEquals(c.children.size(), 0);
+        assertThat(c.children.size()).isEqualTo(0);
 
         // Make sure source is now gone.
         DbxEntry deleted = client.getMetadata(source);
-        assertTrue(deleted == null);
+        assertThat(deleted == null).isTrue();
     }
 }

--- a/src/test/java/com/dropbox/core/v1/DbxClientV1IT.java
+++ b/src/test/java/com/dropbox/core/v1/DbxClientV1IT.java
@@ -258,7 +258,7 @@ public class DbxClientV1IT {
         DbxEntry.File e2 = uploadFile(path, 100, DbxWriteMode.force());
         assertThat(client.getRevisions(path).size()).isEqualTo(1);
         client.delete(path);
-        assertThat(client.getRevisions(path).size(), 1);
+        assertThat(client.getRevisions(path).size()).isEqualTo(1);
         DbxEntry.File e1 = uploadFile(path, 200, DbxWriteMode.force());
         DbxEntry.File e0 = uploadFile(path, 300, DbxWriteMode.force());
 

--- a/src/test/java/com/dropbox/core/v1/DbxClientV1Test.java
+++ b/src/test/java/com/dropbox/core/v1/DbxClientV1Test.java
@@ -1,7 +1,8 @@
 package com.dropbox.core.v1;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
 import static com.dropbox.core.v1.DbxClientV1.Downloader;
 
 import com.dropbox.core.http.HttpRequestor;
@@ -84,13 +85,13 @@ public class DbxClientV1Test {
 
         // no way easy way to properly test this, but request should
         // have taken AT LEAST 3 seconds due to backoff.
-        assertTrue((end - start) >= 3000L, "duration: " + (end - start) + " millis");
+        assertWithMessage("duration: " + (end - start) + " millis").that((end - start) >= 3000L).isTrue();
 
         // should have been called 4 times: initial call + 3 retries
         verify(mockRequestor, times(4)).startPost(anyString(), anyHeaders());
 
-        assertEquals(actual.reset, true);
-        assertEquals(actual.cursor, "fakeCursor");
+        assertThat(actual.reset).isTrue();
+        assertThat(actual.cursor).isEqualTo("fakeCursor");
     }
 
     @Test(expectedExceptions = RetryException.class)
@@ -150,7 +151,7 @@ public class DbxClientV1Test {
 
         // load File metadata json
         InputStream in = getClass().getResourceAsStream("/file-with-photo-info.json");
-        assertNotNull(in);
+        assertThat(in).isNotNull();
         String metadataJson = IOUtil.toUtf8String(in);
 
         byte [] expected = new byte [] { 1, 2, 3, 4 };
@@ -174,8 +175,8 @@ public class DbxClientV1Test {
         IOUtil.copyStreamToStream(downloader.body, bout);
         byte [] actual = bout.toByteArray();
 
-        assertEquals(actual, expected);
-        assertEquals(downloader.metadata.path, "/Photos/Sample Album/Boston City Flow.jpg");
+        assertThat(actual).isEqualTo(expected);
+        assertThat(downloader.metadata.path).isEqualTo("/Photos/Sample Album/Boston City Flow.jpg");
     }
 
     private static HttpRequestor.Response createEmptyResponse(int statusCode) {
@@ -226,7 +227,7 @@ public class DbxClientV1Test {
     }
 
     private static Map<String, List<String>> headers(String name, String value, String ... rest) {
-        assertTrue(rest.length % 2 == 0);
+        assertThat(rest.length % 2 == 0).isTrue();
 
         Map<String, List<String>> headers = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
         List<String> values = new ArrayList<String>();

--- a/src/test/java/com/dropbox/core/v2/DbxClientV2IT.java
+++ b/src/test/java/com/dropbox/core/v2/DbxClientV2IT.java
@@ -224,7 +224,7 @@ public class DbxClientV2IT {
             assertThat(err.isPath()).isTrue();
 
             LookupError lookup = err.getPathValue();
-            assertThat(lookup).isNotNull;
+            assertThat(lookup).isNotNull();
             assertThat(lookup.tag()).isEqualTo(LookupError.Tag.NOT_FOUND);
             assertThat(lookup.isNotFound()).isTrue();
             assertThat(lookup.isNotFile()).isFalse();

--- a/src/test/java/com/dropbox/core/v2/DbxClientV2IT.java
+++ b/src/test/java/com/dropbox/core/v2/DbxClientV2IT.java
@@ -1,6 +1,7 @@
 package com.dropbox.core.v2;
 
-import static org.testng.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -29,14 +30,14 @@ public class DbxClientV2IT {
         DbxClientV2 client = ITUtil.newClientV2();
 
         FullAccount full = client.users().getCurrentAccount();
-        assertNotNull(full);
-        assertNotNull(full.getName());
-        assertNotNull(full.getAccountId());
+        assertThat(full).isNotNull();
+        assertThat(full.getName()).isNotNull();
+        assertThat(full.getAccountId()).isNotNull();
 
         BasicAccount basic = client.users().getAccount(full.getAccountId());
-        assertNotNull(basic);
-        assertNotNull(basic.getName());
-        assertEquals(basic.getAccountId(), full.getAccountId());
+        assertThat(basic).isNotNull();
+        assertThat(basic.getName()).isNotNull();
+        assertThat(basic.getAccountId()).isEqualTo(full.getAccountId());
     }
 
     @Test
@@ -93,13 +94,13 @@ public class DbxClientV2IT {
                 .withMute(true)
                 .uploadAndFinish(new ByteArrayInputStream(contents), progressListener);
 
-        assertEquals(metadata.getName(), filename);
-        assertEquals(metadata.getPathLower(), path.toLowerCase());
-        assertEquals(metadata.getSize(), contents.length);
+        assertThat(metadata.getName()).isEqualTo(filename);
+        assertThat(metadata.getPathLower()).isEqualTo(path.toLowerCase());
+        assertThat(metadata.getSize()).isEqualTo(contents.length);
 
         Metadata actual = client.files().getMetadata(path);
-        assertTrue(actual instanceof FileMetadata, actual.getClass().getCanonicalName());
-        assertEquals(actual, metadata);
+        assertWithMessage(actual.getClass().getCanonicalName()).that(actual instanceof FileMetadata).isTrue();
+        assertThat(actual).isEqualTo(metadata);
 
         if (trackProgress) {
             progressListener = createTestListener(contents.length);
@@ -112,12 +113,12 @@ public class DbxClientV2IT {
         byte [] actualContents = out.toByteArray();
         FileMetadata actualResult = downloader.getResult();
 
-        assertEquals(actualResult, metadata);
-        assertEquals(actualContents, contents);
-        assertEquals(downloader.getContentType(), "application/octet-stream");
+        assertThat(actualResult).isEqualTo(metadata);
+        assertThat(actualContents).isEqualTo(contents);
+        assertThat(downloader.getContentType()).isEqualTo("application/octet-stream");
 
         Metadata deleted = client.files().delete(path);
-        assertEquals(deleted, metadata);
+        assertThat(deleted).isEqualTo(metadata);
     }
 
     @Test
@@ -133,7 +134,7 @@ public class DbxClientV2IT {
             .withMute(true)
             .uploadAndFinish(new ByteArrayInputStream(contents));
 
-        assertEquals(metadata.getSize(), contents.length);
+        assertThat(metadata.getSize()).isEqualTo(contents.length);
 
         assertRangeDownload(client, path, contents, 0, contents.length);
         assertRangeDownload(client, path, contents, 0, 200);
@@ -159,7 +160,7 @@ public class DbxClientV2IT {
             .withMute(true)
             .uploadAndFinish(new ByteArrayInputStream(rtfV1));
 
-        assertEquals(metadataV1.getPathLower(), path.toLowerCase());
+        assertThat(metadataV1.getPathLower()).isEqualTo(path.toLowerCase());
 
         FileMetadata metadataV2 = client.files().uploadBuilder(path)
             .withAutorename(false)
@@ -167,38 +168,38 @@ public class DbxClientV2IT {
             .withMute(true)
             .uploadAndFinish(new ByteArrayInputStream(rtfV2));
 
-        assertEquals(metadataV2.getPathLower(), path.toLowerCase());
+        assertThat(metadataV2.getPathLower()).isEqualTo(path.toLowerCase());
 
         // ensure we have separate revisions
-        assertNotEquals(metadataV1.getRev(), metadataV2.getRev());
+        assertThat(metadataV1.getRev()).isNotEqualTo(metadataV2.getRev());
 
         // now use download builder to set revision and make sure it works properly
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         client.files().downloadBuilder(path)
             .withRev(metadataV1.getRev())
             .download(out);
-        assertEquals(out.toByteArray(), rtfV1);
+        assertThat(out.toByteArray()).isEqualTo(rtfV1);
 
         out = new ByteArrayOutputStream();
         client.files().downloadBuilder(path)
             .withRev(metadataV2.getRev())
             .download(out);
-        assertEquals(out.toByteArray(), rtfV2);
+        assertThat(out.toByteArray()).isEqualTo(rtfV2);
 
         // ensure we still keep the non-builder optional route in our generator (for
         // backwards-compatibility)
         out = new ByteArrayOutputStream();
         client.files().download(path, metadataV1.getRev()).download(out);
-        assertEquals(out.toByteArray(), rtfV1);
+        assertThat(out.toByteArray()).isEqualTo(rtfV1);
 
         out = new ByteArrayOutputStream();
         client.files().download(path, metadataV2.getRev()).download(out);
-        assertEquals(out.toByteArray(), rtfV2);
+        assertThat(out.toByteArray()).isEqualTo(rtfV2);
 
         // and ensure we keep the required-only route
         out = new ByteArrayOutputStream();
         client.files().download(path).download(out);
-        assertEquals(out.toByteArray(), rtfV2);
+        assertThat(out.toByteArray()).isEqualTo(rtfV2);
     }
 
     @Test(expectedExceptions={GetMetadataErrorException.class})
@@ -210,25 +211,25 @@ public class DbxClientV2IT {
         try {
             client.files().getMetadata(path);
         } catch (GetMetadataErrorException ex) {
-            assertNotNull(ex.getRequestId());
+            assertThat(ex.getRequestId()).isNotNull();
             if (ex.getUserMessage() != null) {
-                assertNotNull(ex.getUserMessage().getLocale());
-                assertNotNull(ex.getUserMessage().getText());
-                assertNotNull(ex.getUserMessage().toString());
+                assertThat(ex.getUserMessage().getLocale()).isNotNull();
+                assertThat(ex.getUserMessage().getText()).isNotNull();
+                assertThat(ex.getUserMessage().toString()).isNotNull();
             }
 
             GetMetadataError err = ex.errorValue;
-            assertNotNull(err);
-            assertEquals(err.tag(), GetMetadataError.Tag.PATH);
-            assertTrue(err.isPath());
+            assertThat(err).isNotNull();
+            assertThat(err.tag()).isEqualTo(GetMetadataError.Tag.PATH);
+            assertThat(err.isPath()).isTrue();
 
             LookupError lookup = err.getPathValue();
-            assertNotNull(lookup);
-            assertEquals(lookup.tag(), LookupError.Tag.NOT_FOUND);
-            assertTrue(lookup.isNotFound());
-            assertFalse(lookup.isNotFile());
-            assertFalse(lookup.isOther());
-            assertFalse(lookup.isMalformedPath());
+            assertThat(lookup).isNotNull;
+            assertThat(lookup.tag()).isEqualTo(LookupError.Tag.NOT_FOUND);
+            assertThat(lookup.isNotFound()).isTrue();
+            assertThat(lookup.isNotFile()).isFalse();
+            assertThat(lookup.isOther()).isFalse();
+            assertThat(lookup.isMalformedPath()).isFalse();
 
             // raise so test can confirm an exception was thrown
             throw ex;
@@ -245,7 +246,7 @@ public class DbxClientV2IT {
         try {
             client.files().listFolderContinue(badCursor);
         } catch (BadRequestException ex) {
-            assertNotNull(ex.getRequestId());
+            assertThat(ex.getRequestId()).isNotNull();
             throw ex;
         }
     }
@@ -262,9 +263,9 @@ public class DbxClientV2IT {
         try {
             client.sharing().getFolderMetadata("-1");
         } catch (DbxApiException ex) {
-            assertNotNull(ex.getUserMessage());
-            assertNotNull(ex.getUserMessage().getLocale());
-            assertNotEquals(ex.getUserMessage().getLocale(), ""); // make sure something is specified
+            assertThat(ex.getUserMessage()).isNotNull();
+            assertThat(ex.getUserMessage().getLocale()).isNotNull();
+            assertThat(ex.getUserMessage().getLocale()).isNotEqualTo(""); // make sure something is specified
         }
     }
 
@@ -286,7 +287,7 @@ public class DbxClientV2IT {
         System.arraycopy(contents, start, expected, 0, expected.length);
         byte [] actual = out.toByteArray();
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     private static void assertUserMessageLocale(Locale locale) throws Exception {
@@ -294,15 +295,15 @@ public class DbxClientV2IT {
         try {
             client.sharing().getFolderMetadata("-1");
         } catch (DbxApiException ex) {
-            assertNotNull(ex.getUserMessage());
-            assertNotNull(ex.getUserMessage().getLocale());
+            assertThat(ex.getUserMessage()).isNotNull();
+            assertThat(ex.getUserMessage().getLocale()).isNotNull();
             if (ex.getUserMessage().getLocale().contains("-")) {
                 // TODO: update this test to properly support language tags when we upgrade away
                 // from Java 6
-                assertEquals(ex.getUserMessage().getLocale(), toLanguageTag(locale));
+                assertThat(ex.getUserMessage().getLocale()).isEqualTo(toLanguageTag(locale));
             } else {
                 // omit the country code
-                assertEquals(ex.getUserMessage().getLocale(), locale.getLanguage());
+                assertThat(ex.getUserMessage().getLocale()).isEqualTo(locale.getLanguage());
             }
         }
     }
@@ -325,8 +326,8 @@ public class DbxClientV2IT {
             private long lastBytesWritten = 0;
             @Override
             public void onProgress(long bytesWritten) {
-                assertTrue(bytesWritten > lastBytesWritten);
-                assertTrue(bytesWritten <= totalLength);
+                assertThat(bytesWritten > lastBytesWritten).isTrue();
+                assertThat(bytesWritten <= totalLength).isTrue();
                 lastBytesWritten = bytesWritten;
             }
         };

--- a/src/test/java/com/dropbox/core/v2/DbxClientV2Test.java
+++ b/src/test/java/com/dropbox/core/v2/DbxClientV2Test.java
@@ -1,8 +1,10 @@
 package com.dropbox.core.v2;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
 import static com.dropbox.core.v2.files.FilesSerializers.serializer;
+import static org.testng.Assert.fail;
 
 import com.dropbox.core.DbxRequestUtil;
 import com.dropbox.core.InvalidAccessTokenException;
@@ -120,9 +122,9 @@ public class DbxClientV2Test {
         // should have only been called 3 times: initial call + 2 retries
         verify(mockRequestor, times(3)).startPost(anyString(), anyHeaders());
 
-        assertEquals(actual.getName(), expected.getName());
-        assertTrue(actual instanceof FileMetadata, actual.getClass().toString());
-        assertEquals(((FileMetadata) actual).getId(), expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
+        assertThat(((FileMetadata) actual).getId()).isEqualTo(expected.getId());
     }
 
     @Test(expectedExceptions = RetryException.class)
@@ -205,8 +207,8 @@ public class DbxClientV2Test {
         FileMetadata actualMetadata = downloader.download(bout);
         byte [] actualBytes = bout.toByteArray();
 
-        assertEquals(actualBytes, expectedBytes);
-        assertEquals(actualMetadata, expectedMetadata);
+        assertThat(actualBytes).isEqualTo(expectedBytes);
+        assertThat(actualMetadata).isEqualTo(expectedMetadata);
     }
 
     @Test
@@ -237,13 +239,13 @@ public class DbxClientV2Test {
 
         // no way easy way to properly test this, but request should
         // have taken AT LEAST 3 seconds due to backoff.
-        assertTrue((end - start) >= 3000L, "duration: " + (end - start) + " millis");
+        assertWithMessage("duration: " + (end - start) + " millis").that(end - start >= 3000L).isTrue();
 
         // should have been called 4 times: initial call + 3 retries
         verify(mockRequestor, times(4)).startPost(anyString(), anyHeaders());
 
-        assertEquals(actual.getName(), expected.getName());
-        assertTrue(actual instanceof FileMetadata, actual.getClass().toString());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
     }
 
     @Test
@@ -273,12 +275,12 @@ public class DbxClientV2Test {
 
         verify(mockRequestor, times(2)).startPost(anyString(), anyHeaders());
 
-        assertEquals(credential.getAccessToken(), "newToken");
-        assertTrue(credential.getExpiresAt() > now);
+        assertThat(credential.getAccessToken()).isEqualTo("newToken");
+        assertThat(credential.getExpiresAt() > now).isTrue();
 
-        assertEquals(actual.getName(), expected.getName());
-        assertTrue(actual instanceof FileMetadata, actual.getClass().toString());
-        assertEquals(((FileMetadata) actual).getId(), expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
+        assertThat(((FileMetadata) actual).getId()).isEqualTo(expected.getId());
     }
 
     @Test
@@ -307,11 +309,11 @@ public class DbxClientV2Test {
         Metadata actual = client.files().getMetadata(expected.getId());
 
         verify(mockRequestor, times(1)).startPost(anyString(), anyHeaders());
-        assertEquals(credential.getAccessToken(), "accesstoken");
+        assertThat(credential.getAccessToken()).isEqualTo("accesstoken");
 
-        assertEquals(actual.getName(), expected.getName());
-        assertTrue(actual instanceof FileMetadata, actual.getClass().toString());
-        assertEquals(((FileMetadata) actual).getId(), expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
+        assertThat(((FileMetadata) actual).getId()).isEqualTo( expected.getId());
     }
 
     @Test
@@ -350,12 +352,12 @@ public class DbxClientV2Test {
 
         verify(mockRequestor, times(2)).startPost(anyString(), anyHeaders());
 
-        assertEquals(credential.getAccessToken(), "accesstoken");
-        assertEquals(credential.getExpiresAt(), new Long(10));
+        assertThat(credential.getAccessToken()).isEqualTo("accesstoken");
+        assertThat(credential.getExpiresAt()).isEqualTo(new Long(10));
 
-        assertEquals(actual.getName(), expected.getName());
-        assertTrue(actual instanceof FileMetadata, actual.getClass().toString());
-        assertEquals(((FileMetadata) actual).getId(), expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
+        assertThat(((FileMetadata) actual).getId()).isEqualTo(expected.getId());
     }
 
     @Test
@@ -387,11 +389,11 @@ public class DbxClientV2Test {
         Metadata actual = client.files().getMetadata(expected.getId());
 
         verify(mockRequestor, times(3)).startPost(anyString(), anyHeaders());
-        assertEquals(credential.getAccessToken(), "new_token");
+        assertThat(credential.getAccessToken()).isEqualTo("new_token");
 
-        assertEquals(actual.getName(), expected.getName());
-        assertTrue(actual instanceof FileMetadata, actual.getClass().toString());
-        assertEquals(((FileMetadata) actual).getId(), expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
+        assertThat(((FileMetadata) actual).getId()).isEqualTo(expected.getId());
     }
 
     @Test
@@ -430,15 +432,15 @@ public class DbxClientV2Test {
             downloader.close();
         }
 
-        assertEquals(out.toString(), "data");
+        assertThat(out.toString()).isEqualTo("data");
 
         Metadata actual = downloader.getResult();
 
         verify(mockRequestor, times(3)).startPost(anyString(), anyHeaders());
-        assertEquals(credential.getAccessToken(), "new_token");
+        assertThat(credential.getAccessToken()).isEqualTo("new_token");
 
-        assertEquals(actual.getName(), expected.getName());
-        assertEquals(((FileMetadata) actual).getId(), expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertThat(((FileMetadata) actual).getId()).isEqualTo(expected.getId());
     }
 
     @Test
@@ -472,11 +474,11 @@ public class DbxClientV2Test {
         Metadata actual = client.files().getMetadata(expected.getId());
 
         verify(mockRequestor, times(4)).startPost(anyString(), anyHeaders());
-        assertEquals(credential.getAccessToken(), "new_token");
+        assertThat(credential.getAccessToken()).isEqualTo("new_token");
 
-        assertEquals(actual.getName(), expected.getName());
-        assertTrue(actual instanceof FileMetadata, actual.getClass().toString());
-        assertEquals(((FileMetadata) actual).getId(), expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
+        assertThat(((FileMetadata) actual).getId()).isEqualTo(expected.getId());
     }
 
     @Test
@@ -501,11 +503,11 @@ public class DbxClientV2Test {
             client.files().getMetadata(expected.getId());
         } catch (InvalidAccessTokenException ex) {
             verify(mockRequestor, times(1)).startPost(anyString(), anyHeaders());
-            assertEquals(credential.getAccessToken(), "accesstoken");
+            assertThat(credential.getAccessToken()).isEqualTo("accesstoken");
 
             AuthError authError = DbxRequestUtil.readJsonFromErrorMessage(AuthError.Serializer
                 .INSTANCE, ex.getMessage(), ex.getRequestId());
-            assertEquals(authError, AuthError.EXPIRED_ACCESS_TOKEN);
+            assertThat(authError).isEqualTo(AuthError.EXPIRED_ACCESS_TOKEN);
             return;
         }
 
@@ -602,7 +604,7 @@ public class DbxClientV2Test {
     }
 
     private static Map<String, List<String>> headers(String name, String value, String ... rest) {
-        assertTrue(rest.length % 2 == 0);
+        assertThat(rest.length % 2 == 0).isTrue();
 
         Map<String, List<String>> headers = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
         List<String> values = new ArrayList<String>();
@@ -627,7 +629,7 @@ public class DbxClientV2Test {
     }
 
     private static byte [] serialize(Metadata metadata) {
-        assertNotNull(metadata);
+        assertThat(metadata).isNotNull();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {


### PR DESCRIPTION
Follow our current coding guidelines to use truth assertThat in tests. Update all tests to do so.