### PR TITLE
ChangeLog/ReadMe: Update for 3.2.0 release

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,8 @@
+3.2.0 (2021-03-22)
+---------------------------------------------
+- update Java tests to use Google's Truth library
+- bump target Java version from 6 to 8
+
 3.1.5 (2020-08-11)
 ---------------------------------------------
 - Fix bug in authorization flow.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-# Dropbox Core SDK for Java 6+
+# Dropbox Core SDK for Java 8+
 
 ![GitHub](https://img.shields.io/github/license/dropbox/dropbox-sdk-java)
 ![Maven Central](https://img.shields.io/maven-central/v/com.dropbox.core/dropbox-core-sdk)
@@ -8,7 +8,7 @@ A Java library to access [Dropbox's HTTP-based Core API v2](https://www.dropbox.
 
 License: [MIT](License.txt)
 
-Documentation: [Javadocs](https://dropbox.github.io/dropbox-sdk-java/api-docs/v3.1.x/)
+Documentation: [Javadocs](https://dropbox.github.io/dropbox-sdk-java/api-docs/v3.2.x/)
 
 ## Setup
 
@@ -18,7 +18,7 @@ If you're using Maven, then edit your project's "pom.xml" and add this to the `<
 <dependency>
     <groupId>com.dropbox.core</groupId>
     <artifactId>dropbox-core-sdk</artifactId>
-    <version>3.1.5</version>
+    <version>3.2.0</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ If you are using Gradle, then edit your project's "build.gradle" and add this to
 ```groovy
 dependencies {
     // ...
-    implementation 'com.dropbox.core:dropbox-core-sdk:3.1.5'
+    implementation 'com.dropbox.core:dropbox-core-sdk:3.2.0'
 }
 ```
 

--- a/src/main/java/com/dropbox/core/DbxSdkVersion.java
+++ b/src/main/java/com/dropbox/core/DbxSdkVersion.java
@@ -12,6 +12,6 @@ public class DbxSdkVersion
 
     private static String loadVersion()
     {
-        return "3.1.5"; //TODO: figure out a consistent way to generate it.
+        return "3.2.0"; //TODO: figure out a consistent way to generate it.
     }
 }


### PR DESCRIPTION
Bump versions and readme/changelog for 3.2.0

3.2.0 (2021-03-22)
---------------------------------------------
- update Java tests to use Google's Truth library
- bump target Java version from 6 to 8