### PR TITLE
ChangeLog/ReadMe: Update for 3.2.1 release

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,7 @@
+3.2.1 (2021-03-29)
+---------------------------------------------
+- revert Java version bump (back to Java 6)
+
 3.2.0 (2021-03-22)
 ---------------------------------------------
 - update Java tests to use Google's Truth library

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-# Dropbox Core SDK for Java 8+
+# Dropbox Core SDK for Java 6+
 
 ![GitHub](https://img.shields.io/github/license/dropbox/dropbox-sdk-java)
 ![Maven Central](https://img.shields.io/maven-central/v/com.dropbox.core/dropbox-core-sdk)
@@ -18,7 +18,7 @@ If you're using Maven, then edit your project's "pom.xml" and add this to the `<
 <dependency>
     <groupId>com.dropbox.core</groupId>
     <artifactId>dropbox-core-sdk</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ If you are using Gradle, then edit your project's "build.gradle" and add this to
 ```groovy
 dependencies {
     // ...
-    implementation 'com.dropbox.core:dropbox-core-sdk:3.2.0'
+    implementation 'com.dropbox.core:dropbox-core-sdk:3.2.1'
 }
 ```
 

--- a/src/main/java/com/dropbox/core/DbxSdkVersion.java
+++ b/src/main/java/com/dropbox/core/DbxSdkVersion.java
@@ -12,6 +12,6 @@ public class DbxSdkVersion
 
     private static String loadVersion()
     {
-        return "3.2.0"; //TODO: figure out a consistent way to generate it.
+        return "3.2.1"; //TODO: figure out a consistent way to generate it.
     }
 }


### PR DESCRIPTION
3.2.1 (2021-03-29)
---------------------------------------------
- revert Java version bump (back to Java 6)
