### PR TITLE
Fix for DbxRefreshResult Expires In

### DIFF
--- a/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
+++ b/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
@@ -19,8 +19,8 @@ import java.io.IOException;
  */
 public class DbxRefreshResult {
     private final String accessToken;
-    private final long expiresIn;
-    private long issueTime;
+    private final long expiresIn; /* in seconds */
+    private long issueTime; /* in milliseconds */
     private String scope;
 
     /**

--- a/src/main/java/com/dropbox/core/v2/DbxClientV2.java
+++ b/src/main/java/com/dropbox/core/v2/DbxClientV2.java
@@ -171,7 +171,7 @@ public class DbxClientV2 extends DbxClientV2Base {
         @Override
         public DbxRefreshResult refreshAccessToken() throws DbxException {
             credential.refresh(this.getRequestConfig());
-            return new DbxRefreshResult(credential.getAccessToken(), credential.getExpiresAt());
+            return new DbxRefreshResult(credential.getAccessToken(), (credential.getExpiresAt() - System.currentTimeMillis())/1000);
         }
 
         @Override

--- a/src/main/java/com/dropbox/core/v2/DbxTeamClientV2.java
+++ b/src/main/java/com/dropbox/core/v2/DbxTeamClientV2.java
@@ -214,7 +214,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
         @Override
         public DbxRefreshResult refreshAccessToken() throws DbxException {
             credential.refresh(this.getRequestConfig());
-            return new DbxRefreshResult(credential.getAccessToken(), credential.getExpiresAt());
+            return new DbxRefreshResult(credential.getAccessToken(), (credential.getExpiresAt() - System.currentTimeMillis())/1000);
         }
 
         @Override


### PR DESCRIPTION
This change resolves #304 #294 
This change replaces in all the DbxClient implementors the `refreshAccessToken` function to make sure it is created with the proper Expires In param.
DbxRefreshResult expects Expires In Seconds, which is the time remaining for the token until expired.
However, we were passing in Expires At, which is the point in time where the token will be expired, in Millis.

The main idea is ExpiresIn seconds = (ExpiresAt millis - current time millis) / 1000

Modified the test cases to validate this logic and added an Offset because there is no way to inject the issued time.