### PR TITLE
Update output artifacts

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -83,4 +83,4 @@ jobs:
       with:
         name: BuildArtifacts
         path: |
-          build/distributions/
+          build/libs/


### PR DESCRIPTION
When migrating from `java` to `java-library` the output location has changed