### PR TITLE
Fix dependency declaration for the Android Library

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -316,8 +316,14 @@ Versions 2.0.0-2.0.3 of this SDK require SDK-specific ProGuard rules when shrink
 -dontwarn okio.**
 -dontwarn okhttp3.**
 -dontwarn com.squareup.okhttp.**
+-dontwarn com.google.apphosting.**
 -dontwarn com.google.appengine.**
+-dontwarn com.google.protos.cloud.sql.**
+-dontwarn com.google.cloud.sql.**
+-dontwarn javax.activation.**
+-dontwarn javax.mail.**
 -dontwarn javax.servlet.**
+-dontwarn org.apache.**
 ```
 
 **IMPORTANT: If you are running version 2.0.x before 2.0.3, you should update to the latest Dropbox SDK version to avoid a deserialization bug that can cause Android apps that use ProGuard to crash.**

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     // Important: Jackson 2.8+ will be free to use JDK7 features and no longer guarantees JDK6
     //            compatibility
     api 'com.fasterxml.jackson.core:jackson-core:2.7.4'
+
+    // DO NOT flip this back to implementation, we should split the android code to its own module in the future
     compileOnly 'com.google.android:android:4.1.1.4'
 
     implementation 'javax.servlet:servlet-api:2.5'

--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,11 @@ dependencies {
     // Important: Jackson 2.8+ will be free to use JDK7 features and no longer guarantees JDK6
     //            compatibility
     api 'com.fasterxml.jackson.core:jackson-core:2.7.4'
+    compileOnly 'com.google.android:android:4.1.1.4'
 
     implementation 'javax.servlet:servlet-api:2.5'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'  // support both v2 and v3 to avoid
     implementation 'com.squareup.okhttp3:okhttp:4.0.0' // method count bloat
-    implementation 'com.google.android:android:4.1.1.4'
     implementation 'com.google.appengine:appengine-api-1.0-sdk:1.9.38'
 
     testImplementation 'org.testng:testng:6.9.10'

--- a/build.gradle
+++ b/build.gradle
@@ -41,11 +41,10 @@ dependencies {
 
     // DO NOT flip this back to implementation, we should split the android code to its own module in the future
     compileOnly 'com.google.android:android:4.1.1.4'
-
-    implementation 'javax.servlet:servlet-api:2.5'
-    implementation 'com.squareup.okhttp:okhttp:2.7.5'  // support both v2 and v3 to avoid
-    implementation 'com.squareup.okhttp3:okhttp:4.0.0' // method count bloat
-    implementation 'com.google.appengine:appengine-api-1.0-sdk:1.9.38'
+    compileOnly 'javax.servlet:servlet-api:2.5'
+    compileOnly 'com.squareup.okhttp:okhttp:2.7.5'  // support both v2 and v3 to avoid
+    compileOnly 'com.squareup.okhttp3:okhttp:4.0.0' // method count bloat
+    compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.38'
 
     testImplementation 'org.testng:testng:6.9.10'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -58,10 +58,7 @@ android {
 }
 
 dependencies {
-    implementation (project("dropbox-sdk-java"))
-//    {
-//        exclude (group: 'com.google.android')
-//    }
+    implementation project("dropbox-sdk-java")
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -58,7 +58,10 @@ android {
 }
 
 dependencies {
-    implementation group: 'com.dropbox.core', name: 'dropbox-core-sdk', version: '+', changing: true
+    implementation (project("dropbox-sdk-java"))
+//    {
+//        exclude (group: 'com.google.android')
+//    }
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/examples/android/gradle.properties
+++ b/examples/android/gradle.properties
@@ -17,3 +17,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
+
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/examples/android/proguard-rules.pro
+++ b/examples/android/proguard-rules.pro
@@ -21,8 +21,14 @@
 -dontwarn okio.**
 -dontwarn okhttp3.**
 -dontwarn com.squareup.okhttp.**
+-dontwarn com.google.apphosting.**
 -dontwarn com.google.appengine.**
+-dontwarn com.google.protos.cloud.sql.**
+-dontwarn com.google.cloud.sql.**
+-dontwarn javax.activation.**
+-dontwarn javax.mail.**
 -dontwarn javax.servlet.**
+-dontwarn org.apache.**
 
 # Support classes for compatibility with older API versions
 

--- a/examples/android/settings.gradle
+++ b/examples/android/settings.gradle
@@ -1,0 +1,2 @@
+include ':dropbox-sdk-java'
+project(':dropbox-sdk-java').projectDir = new File("../..")

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -56,7 +56,7 @@ android_gradle clean
 android_gradle assemble
 
 # Run integration tests against major HTTP requestor implementations
-for requestor in "StandardHttpRequestor" "OkHttpRequestor" "OkHttp3Requestor" ; do
+for requestor in "StandardHttpRequestor " "OkHttpRequestor" "OkHttp3Requestor" ; do
     gradle -Pcom.dropbox.test.httpRequestor="${requestor}" -Pcom.dropbox.test.authInfoFile="${AUTH_FILE}" integrationTest proguardTest
 done
 

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -56,7 +56,7 @@ android_gradle clean
 android_gradle assemble
 
 # Run integration tests against major HTTP requestor implementations
-for requestor in "StandardHttpRequestor " "OkHttpRequestor" "OkHttp3Requestor" ; do
+for requestor in "StandardHttpRequestor" "OkHttpRequestor" "OkHttp3Requestor" ; do
     gradle -Pcom.dropbox.test.httpRequestor="${requestor}" -Pcom.dropbox.test.authInfoFile="${AUTH_FILE}" integrationTest proguardTest
 done
 


### PR DESCRIPTION
fixes #369 

This also changes our example project to depend on the sdk as a project dependency instead of grabbing whatever is the latest in Maven Central. This will catch breakages in the PR instead of after the fact.