### PR TITLE
Fix issue with default string values being `"\"\""`

### DIFF
--- a/generated_stone_source/main/src/com/dropbox/core/v2/check/DbxAppCheckRequests.java
+++ b/generated_stone_source/main/src/com/dropbox/core/v2/check/DbxAppCheckRequests.java
@@ -64,8 +64,8 @@ public class DbxAppCheckRequests {
      * least part of the Dropbox API infrastructure is working and that the app
      * key and secret valid.
      *
-     * <p> The {@code query} request parameter will default to {@code "\"\""}
-     * (see {@link #app(String)}). </p>
+     * <p> The {@code query} request parameter will default to {@code ""} (see
+     * {@link #app(String)}). </p>
      *
      * @return EchoResult contains the result returned from the Dropbox servers.
      */

--- a/generated_stone_source/main/src/com/dropbox/core/v2/check/DbxUserCheckRequests.java
+++ b/generated_stone_source/main/src/com/dropbox/core/v2/check/DbxUserCheckRequests.java
@@ -64,8 +64,8 @@ public class DbxUserCheckRequests {
      * least part of the Dropbox API infrastructure is working and that the
      * access token is valid.
      *
-     * <p> The {@code query} request parameter will default to {@code "\"\""}
-     * (see {@link #user(String)}). </p>
+     * <p> The {@code query} request parameter will default to {@code ""} (see
+     * {@link #user(String)}). </p>
      *
      * @return EchoResult contains the result returned from the Dropbox servers.
      */

--- a/generated_stone_source/main/src/com/dropbox/core/v2/check/EchoArg.java
+++ b/generated_stone_source/main/src/com/dropbox/core/v2/check/EchoArg.java
@@ -49,14 +49,14 @@ class EchoArg {
      * <p> The default values for unset fields will be used. </p>
      */
     public EchoArg() {
-        this("\"\"");
+        this("");
     }
 
     /**
      * The string that you'd like to be echoed back to you.
      *
      * @return value for this field, or {@code null} if not present. Defaults to
-     *     "\"\"".
+     *     "".
      */
     public String getQuery() {
         return query;
@@ -132,7 +132,7 @@ class EchoArg {
                 tag = readTag(p);
             }
             if (tag == null) {
-                String f_query = "\"\"";
+                String f_query = "";
                 while (p.getCurrentToken() == JsonToken.FIELD_NAME) {
                     String field = p.getCurrentName();
                     p.nextToken();

--- a/generated_stone_source/main/src/com/dropbox/core/v2/check/EchoResult.java
+++ b/generated_stone_source/main/src/com/dropbox/core/v2/check/EchoResult.java
@@ -46,14 +46,14 @@ public class EchoResult {
      * <p> The default values for unset fields will be used. </p>
      */
     public EchoResult() {
-        this("\"\"");
+        this("");
     }
 
     /**
      * If everything worked correctly, this would be the same as query.
      *
      * @return value for this field, or {@code null} if not present. Defaults to
-     *     "\"\"".
+     *     "".
      */
     public String getResult() {
         return result;
@@ -129,7 +129,7 @@ public class EchoResult {
                 tag = readTag(p);
             }
             if (tag == null) {
-                String f_result = "\"\"";
+                String f_result = "";
                 while (p.getCurrentToken() == JsonToken.FIELD_NAME) {
                     String field = p.getCurrentName();
                     p.nextToken();

--- a/generator/java.stoneg.py
+++ b/generator/java.stoneg.py
@@ -1054,8 +1054,7 @@ class JavaClassWriter(object):
     def java_default_value(self, field):
         assert isinstance(field, Field), repr(field)
         assert field.has_default, repr(field)
-        default_value = '\"\"' if field.default == '' else field.default
-        return self.java_value(field.data_type, default_value)
+        return self.java_value(field.data_type, field.default)
 
     def java_value(self, data_type, stone_value):
         assert isinstance(data_type, DataType), repr(data_type)


### PR DESCRIPTION
Currently, string-optionals will default to quotes wrapped in quotes:

```
public static class Builder {

    protected String linkUrl;
    protected String optionalRlkey;
    protected String optionalPassword;

    protected Builder() {
        this.linkUrl = "\"\"";
        this.optionalRlkey = "\"\"";
        this.optionalPassword = "\"\"";
    }
  
}
```

Line 1053 takes in an empty value and returns `\"\"` to `java_value`, which already contains quotes around the string, causing optional values to pass a value of `\"\"` for optional parameters, potentially causing upstream issues. 

Removing the `default_value` and passing `field.default` through to `java_value` resolves this issue and generates an empty string.

```
public static class Builder {

    protected String linkUrl;
    protected String optionalRlkey;
    protected String optionalPassword;

    protected Builder() {
        this.linkUrl = "";
        this.optionalRlkey = "";
        this.optionalPassword = "";
    }

}
```

https://github.com/dropbox/dropbox-sdk-java/commit/d237d5c8fe9199e68a2f071562dd55a11cb91af6 - This add the problematic line which returns empty quotes if the field default is empty.

#169 - This PR added a String format line which introduced the bug which formats quotes in additional quotes.

With a fix added, we see the generated code now properly generates an emtpy String value in `EchoArg` and `EchoResult`.

![Screen Shot 2022-08-29 at 11 52 54 AM](https://user-images.githubusercontent.com/3921079/187242547-c7181865-044c-4ec2-9d45-da22c6f85d56.png)



