### PR TITLE
Update ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -184,7 +184,7 @@ App key and secret can be found in you app page in [App Console](https://www.dro
 git clone https://github.com/dropbox/dropbox-sdk-java.git
 cd dropbox-sdk-java
 ./update-submodules    # also do this after every "git checkout"
-./gradlew build # requires `python` command to use Python 3
+./gradlew build # requires `python` command to use Python 3.9, pip dropbox
 ```
 
 The output will be in "build/".


### PR DESCRIPTION
Gradlew command needs python 3.9.
it's not compatible with python 3.10.
if you use python 3.10 you will get this error,
ImportError: cannot import name 'Sequence' from 'collections'.
And python should be has installed the module dropbox or stone.
