### PR TITLE
Fixes "Bad JSON: expected object value"

### DIFF
--- a/src/main/java/com/dropbox/core/stone/StoneSerializer.java
+++ b/src/main/java/com/dropbox/core/stone/StoneSerializer.java
@@ -129,6 +129,7 @@ public abstract class StoneSerializer<T> {
         while (p.getCurrentToken() != null && !p.getCurrentToken().isStructEnd()) {
             if (p.getCurrentToken().isStructStart()) {
                 p.skipChildren();
+                p.nextToken();
             } else if (p.getCurrentToken() == JsonToken.FIELD_NAME) {
                 p.nextToken();
             } else if (p.getCurrentToken().isScalarValue()) {

--- a/src/test/java/com/dropbox/core/v2/teamlog/GetTeamEventsResultTest.java
+++ b/src/test/java/com/dropbox/core/v2/teamlog/GetTeamEventsResultTest.java
@@ -1,0 +1,74 @@
+package com.dropbox.core.v2.teamlog;
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class GetTeamEventsResultTest {
+
+
+    /**
+     * Tests a known type that has extra fields
+     *
+     * Happy path for known objects
+     */
+    @Test
+    public void known_with_body() throws IOException {
+        GetTeamEventsResult result = readGetTeamEventsResultFromFile("known_with_body.json");
+        TeamEvent event = result.events.get(0);
+        assertEquals(EventDetails.Tag.FILE_LOCKING_LOCK_STATUS_CHANGED_DETAILS, event.details.tag());
+    }
+
+    /**
+     * Tests a known type that should have extra fields, but does not, so should throw exception
+     *
+     * Sad path for known objects without required fields
+     */
+    @Test
+    public void known_without_body() {
+        try {
+            GetTeamEventsResult result = readGetTeamEventsResultFromFile("known_without_body.json");
+            assertEquals(EventDetails.Tag.OTHER, result.events.get(0).details.tag());
+        } catch (Exception e) {
+            assertTrue(e.getMessage().startsWith("Required field \"previous_value\" missing."));
+        }
+    }
+
+    /**
+     * Tests backwards compatibility when receiving unknown types that do have extra fields
+     *
+     * Basic test for a new tag with no fields.
+     */
+    @Test
+    public void unknown_with_body() throws IOException {
+        GetTeamEventsResult result = readGetTeamEventsResultFromFile("unknown_with_body.json");
+        assertEquals(EventDetails.Tag.OTHER, result.events.get(0).details.tag());
+    }
+
+    /**
+     * Tests backwards compatibility when receiving unknown types that don't have extra fields
+     */
+    @Test
+    public void unknown_without_body() throws IOException {
+        GetTeamEventsResult result = readGetTeamEventsResultFromFile("unknown_without_body.json");
+        assertEquals(EventDetails.Tag.OTHER, result.events.get(0).details.tag());
+    }
+
+    private GetTeamEventsResult readGetTeamEventsResultFromFile(String filename) throws IOException {
+        String json = readJsonFromFile(filename);
+        return GetTeamEventsResult.Serializer.INSTANCE.deserialize(json);
+    }
+
+    private String readJsonFromFile(String filename) throws IOException {
+        File file = new File("src/test/java/com/dropbox/core/v2/teamlog/" + filename);
+        System.out.println(file.getCanonicalPath());
+        return Files.readString(Path.of(file.toURI()), StandardCharsets.US_ASCII);
+    }
+}

--- a/src/test/java/com/dropbox/core/v2/teamlog/GetTeamEventsResultTest.java
+++ b/src/test/java/com/dropbox/core/v2/teamlog/GetTeamEventsResultTest.java
@@ -35,7 +35,6 @@ public class GetTeamEventsResultTest {
     public void known_without_body() {
         try {
             GetTeamEventsResult result = readGetTeamEventsResultFromFile("known_without_body.json");
-            assertEquals(EventDetails.Tag.OTHER, result.events.get(0).details.tag());
         } catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Required field \"previous_value\" missing."));
         }

--- a/src/test/java/com/dropbox/core/v2/teamlog/known_with_body.json
+++ b/src/test/java/com/dropbox/core/v2/teamlog/known_with_body.json
@@ -1,0 +1,68 @@
+{
+  "events": [
+    {
+      "timestamp": "2020-05-14T15:58:15Z",
+      "event_category": {
+        ".tag": "file_operations"
+      },
+      "actor": {
+        ".tag": "admin",
+        "admin": {
+          ".tag": "team_member",
+          "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+          "display_name": "db test",
+          "email": "testing@example.com",
+          "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+        }
+      },
+      "origin": {
+        "access_method": {
+          ".tag": "end_user",
+          "end_user": {
+            ".tag": "web",
+            "session_id": ""
+          }
+        }
+      },
+      "involve_non_team_member": false,
+      "context": {
+        ".tag": "team_member",
+        "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+        "display_name": "db test",
+        "email": "testing@example.com",
+        "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+      },
+      "participants": [],
+      "assets": [
+        {
+          ".tag": "file",
+          "path": {
+            "contextual": "/some shared folder/test.txt",
+            "namespace_relative": {
+              "ns_id": "7662767952",
+              "relative_path": "/test.txt",
+              "is_shared_namespace": true
+            }
+          },
+          "display_name": "test.txt",
+          "file_id": "id:l1eKEQ3VrqAAAAAAAAAAHw"
+        }
+      ],
+      "event_type": {
+        ".tag": "file_locking_lock_status_changed",
+        "description": "Locked/unlocked editing for a file"
+      },
+      "details": {
+        ".tag": "file_locking_lock_status_changed_details",
+        "previous_value": {
+          ".tag": "locked"
+        },
+        "new_value": {
+          ".tag": "unlocked"
+        }
+      }
+    }
+  ],
+  "cursor": "AABnfF2cvbaP2c1zmbwY8KITrkCjf7V94-BrRsRk3cg3wU6zJP-h0Sh7T8ORvxupn6uvS7Rl_B9uJJ3tp0DbTPCi2aBTw_-z9OnGkGLoEvuMhO1mdRGXGOayxbOEaKM2_m9N4M4lSGZMawU1jJA9z6e7kQ60tHHz8wZoz_Nhu7Wk339vZSIUEIvIeeTch3lEfkODfUs4fWZzPELX9n-qc4qnL14fl59_sVS9_jCceufRl3ichwLnEPOiIT6HHZ3EirPQrg4J7FybSluiHZR7o01BkB3ENK-zlXu7R8ObPLSrYLcGi5tkBa2XVGp4lDXM4rt7CTNDQqZG9Hb36SH0QkJQ7KCZ1zV0_9r5BtpCBHiETw",
+  "has_more": false
+}

--- a/src/test/java/com/dropbox/core/v2/teamlog/known_without_body.json
+++ b/src/test/java/com/dropbox/core/v2/teamlog/known_without_body.json
@@ -1,0 +1,62 @@
+{
+  "events": [
+    {
+      "timestamp": "2020-05-14T15:58:15Z",
+      "event_category": {
+        ".tag": "file_operations"
+      },
+      "actor": {
+        ".tag": "admin",
+        "admin": {
+          ".tag": "team_member",
+          "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+          "display_name": "db test",
+          "email": "testing@example.com",
+          "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+        }
+      },
+      "origin": {
+        "access_method": {
+          ".tag": "end_user",
+          "end_user": {
+            ".tag": "web",
+            "session_id": ""
+          }
+        }
+      },
+      "involve_non_team_member": false,
+      "context": {
+        ".tag": "team_member",
+        "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+        "display_name": "db test",
+        "email": "testing@example.com",
+        "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+      },
+      "participants": [],
+      "assets": [
+        {
+          ".tag": "file",
+          "path": {
+            "contextual": "/some shared folder/test.txt",
+            "namespace_relative": {
+              "ns_id": "7662767952",
+              "relative_path": "/test.txt",
+              "is_shared_namespace": true
+            }
+          },
+          "display_name": "test.txt",
+          "file_id": "id:l1eKEQ3VrqAAAAAAAAAAHw"
+        }
+      ],
+      "event_type": {
+        ".tag": "file_locking_lock_status_changed",
+        "description": "Locked/unlocked editing for a file"
+      },
+      "details": {
+        ".tag": "file_locking_lock_status_changed_details"
+      }
+    }
+  ],
+  "cursor": "AABnfF2cvbaP2c1zmbwY8KITrkCjf7V94-BrRsRk3cg3wU6zJP-h0Sh7T8ORvxupn6uvS7Rl_B9uJJ3tp0DbTPCi2aBTw_-z9OnGkGLoEvuMhO1mdRGXGOayxbOEaKM2_m9N4M4lSGZMawU1jJA9z6e7kQ60tHHz8wZoz_Nhu7Wk339vZSIUEIvIeeTch3lEfkODfUs4fWZzPELX9n-qc4qnL14fl59_sVS9_jCceufRl3ichwLnEPOiIT6HHZ3EirPQrg4J7FybSluiHZR7o01BkB3ENK-zlXu7R8ObPLSrYLcGi5tkBa2XVGp4lDXM4rt7CTNDQqZG9Hb36SH0QkJQ7KCZ1zV0_9r5BtpCBHiETw",
+  "has_more": false
+}

--- a/src/test/java/com/dropbox/core/v2/teamlog/unknown_with_body.json
+++ b/src/test/java/com/dropbox/core/v2/teamlog/unknown_with_body.json
@@ -1,0 +1,68 @@
+{
+  "events": [
+    {
+      "timestamp": "2020-05-14T15:58:15Z",
+      "event_category": {
+        ".tag": "file_operations"
+      },
+      "actor": {
+        ".tag": "admin",
+        "admin": {
+          ".tag": "team_member",
+          "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+          "display_name": "db test",
+          "email": "testing@example.com",
+          "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+        }
+      },
+      "origin": {
+        "access_method": {
+          ".tag": "end_user",
+          "end_user": {
+            ".tag": "web",
+            "session_id": ""
+          }
+        }
+      },
+      "involve_non_team_member": false,
+      "context": {
+        ".tag": "team_member",
+        "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+        "display_name": "db test",
+        "email": "testing@example.com",
+        "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+      },
+      "participants": [],
+      "assets": [
+        {
+          ".tag": "file",
+          "path": {
+            "contextual": "/some shared folder/test.txt",
+            "namespace_relative": {
+              "ns_id": "7662767952",
+              "relative_path": "/test.txt",
+              "is_shared_namespace": true
+            }
+          },
+          "display_name": "test.txt",
+          "file_id": "id:l1eKEQ3VrqAAAAAAAAAAHw"
+        }
+      ],
+      "event_type": {
+        ".tag": "file_locking_lock_status_changed",
+        "description": "Locked/unlocked editing for a file"
+      },
+      "details": {
+        ".tag": "abcdefg",
+        "previous_value": {
+          ".tag": "locked"
+        },
+        "new_value": {
+          ".tag": "unlocked"
+        }
+      }
+    }
+  ],
+  "cursor": "AABnfF2cvbaP2c1zmbwY8KITrkCjf7V94-BrRsRk3cg3wU6zJP-h0Sh7T8ORvxupn6uvS7Rl_B9uJJ3tp0DbTPCi2aBTw_-z9OnGkGLoEvuMhO1mdRGXGOayxbOEaKM2_m9N4M4lSGZMawU1jJA9z6e7kQ60tHHz8wZoz_Nhu7Wk339vZSIUEIvIeeTch3lEfkODfUs4fWZzPELX9n-qc4qnL14fl59_sVS9_jCceufRl3ichwLnEPOiIT6HHZ3EirPQrg4J7FybSluiHZR7o01BkB3ENK-zlXu7R8ObPLSrYLcGi5tkBa2XVGp4lDXM4rt7CTNDQqZG9Hb36SH0QkJQ7KCZ1zV0_9r5BtpCBHiETw",
+  "has_more": false
+}

--- a/src/test/java/com/dropbox/core/v2/teamlog/unknown_without_body.json
+++ b/src/test/java/com/dropbox/core/v2/teamlog/unknown_without_body.json
@@ -1,0 +1,62 @@
+{
+  "events": [
+    {
+      "timestamp": "2020-05-14T15:58:15Z",
+      "event_category": {
+        ".tag": "file_operations"
+      },
+      "actor": {
+        ".tag": "admin",
+        "admin": {
+          ".tag": "team_member",
+          "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+          "display_name": "db test",
+          "email": "testing@example.com",
+          "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+        }
+      },
+      "origin": {
+        "access_method": {
+          ".tag": "end_user",
+          "end_user": {
+            ".tag": "web",
+            "session_id": ""
+          }
+        }
+      },
+      "involve_non_team_member": false,
+      "context": {
+        ".tag": "team_member",
+        "account_id": "dbid:AAAZ86YODCBh5Jen6VnAdG85KJrv1KNkkFQ",
+        "display_name": "db test",
+        "email": "testing@example.com",
+        "team_member_id": "dbmid:AADKrgMss5NUAOy0dFNSF3TZjxjn_rGACdM"
+      },
+      "participants": [],
+      "assets": [
+        {
+          ".tag": "file",
+          "path": {
+            "contextual": "/some shared folder/test.txt",
+            "namespace_relative": {
+              "ns_id": "7662767952",
+              "relative_path": "/test.txt",
+              "is_shared_namespace": true
+            }
+          },
+          "display_name": "test.txt",
+          "file_id": "id:l1eKEQ3VrqAAAAAAAAAAHw"
+        }
+      ],
+      "event_type": {
+        ".tag": "file_locking_lock_status_changed",
+        "description": "Locked/unlocked editing for a file"
+      },
+      "details": {
+        ".tag": "abcdefg"
+      }
+    }
+  ],
+  "cursor": "AABnfF2cvbaP2c1zmbwY8KITrkCjf7V94-BrRsRk3cg3wU6zJP-h0Sh7T8ORvxupn6uvS7Rl_B9uJJ3tp0DbTPCi2aBTw_-z9OnGkGLoEvuMhO1mdRGXGOayxbOEaKM2_m9N4M4lSGZMawU1jJA9z6e7kQ60tHHz8wZoz_Nhu7Wk339vZSIUEIvIeeTch3lEfkODfUs4fWZzPELX9n-qc4qnL14fl59_sVS9_jCceufRl3ichwLnEPOiIT6HHZ3EirPQrg4J7FybSluiHZR7o01BkB3ENK-zlXu7R8ObPLSrYLcGi5tkBa2XVGp4lDXM4rt7CTNDQqZG9Hb36SH0QkJQ7KCZ1zV0_9r5BtpCBHiETw",
+  "has_more": false
+}


### PR DESCRIPTION
Fixes the following issue:
```The Dropbox API v2 Java SDK can crash with "com.dropbox.core.BadResponseException: Bad JSON: expected object value." when deserializing a 'file_locking_lock_status_changed' event```

If a new tag & type is added, it should default to "OTHER".  

This had worked for new tag cases that have no fields, however, if a JSON response had additional fields, it messed up the parser state and would throw an exception.

Fix: In the scenario where we have fields returned for an unknown tag, we have to skip to the next token in this case to continue on.  I have added 4 permutations of test cases along a matrix of (known/unknown) & (fields/no fields).  This should cover these scenarios.