### PR TITLE
Adding in cleanup API calls to Integration Tests

### DIFF
--- a/examples/upload-file/src/main/java/com/dropbox/core/examples/upload_file/Main.java
+++ b/examples/upload-file/src/main/java/com/dropbox/core/examples/upload_file/Main.java
@@ -286,6 +286,13 @@ public class Main {
         } else {
             chunkedUploadFile(dbxClient, localFile, dropboxPath);
         }
+        
+        try {
+            // Delete the file we uploaded so we don't run out of space on the integration test account
+            dbxClient.files().deleteV2(dropboxPath);
+        } catch (DbxException e) {
+            throw new RuntimeException("Could not cleanup the test file we just uploaded at " + dropboxPath, e);
+        }
 
         System.exit(0);
     }


### PR DESCRIPTION
The test account hit an out of space exception.  If we delete the files after uploading in the tests, we can avoid hitting that error in the future.