### PR TITLE
Updating Target SDK in Android Sample App

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -39,5 +39,5 @@ jobs:
         APP_SECRET: ${{ secrets.APP_SECRET }}
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
       run: ./generate-ci-auth-file
-    - name: Run examples
+    - name: Run Examples
       run: ./scripts/run-examples $(find `pwd` -name auth_output)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,7 +43,7 @@ jobs:
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
       run: ./generate-ci-auth-file
 
-    - name: Run examples
+    - name: Run Integration Tests
       run: ./scripts/run-integration-tests $(find `pwd` -name auth_output)
 
     - name: Upload Artifacts

--- a/examples/DropboxAndroid/gradle.properties
+++ b/examples/DropboxAndroid/gradle.properties
@@ -11,4 +11,3 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 android.useAndroidX=true
-org.gradle.unsafe.configuration-cache=false

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -20,13 +20,13 @@ allprojects {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.dropbox.core.examples.android"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }

--- a/examples/android/src/main/AndroidManifest.xml
+++ b/examples/android/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="false">
         <activity
             android:name=".UserActivity"
+            android:exported="true"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -22,9 +23,11 @@
         </activity>
         <activity
             android:name=".FilesActivity"
+            android:exported="false"
             android:label="@string/title_activity_files" />
         <activity
             android:name="com.dropbox.core.android.AuthActivity"
+            android:exported="true"
             android:configChanges="orientation|keyboard"
             android:launchMode="singleTask">
             <intent-filter>
@@ -40,6 +43,7 @@
         </activity>
         <activity
             android:name=".internal.OpenWithActivity"
+            android:exported="true"
             android:label="@string/title_activity_openwith">
             <intent-filter>
                 <action android:name="com.dropbox.android.intent.action.DBXC_EDIT"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ POM_DEVELOPER_ID = dropbox-api-team
 POM_DEVELOPER_NAME = Dropbox API Team
 POM_DEVELOPER_URL = https://github.com/dropbox/
 POM_DEVELOPER_EMAIL = api-support@dropbox.com
+
+# Disable Configuration Cache until we test it in this project
+org.gradle.unsafe.configuration-cache=false


### PR DESCRIPTION
Target Android Versions: 
* We were seeing warnings in the Github Action logs, so did a minor bump to avoid seeing the warning.

Exported Activities:
* In preparation of new Target SDKs, added `android:exported` values.

Configuration Cache:
* In order to avoid issues, I have globally disabled configuration cache until we have fully tested.

Github Action Names:
* Disambiguation of task names.