### PR TITLE
Ensure Integration Tests are Run Correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,10 +104,7 @@ test {
     exclude '**/*IT$*.class'
 
     testLogging {
-        events "skipped", "failed"
-        info {
-            events "passed", "skipped", "failed"
-        }
+        showStandardStreams = true // System.out.println
     }
 }
 
@@ -131,16 +128,10 @@ def getAuthInfoFile() {
     return authInfoFile
 }
 
-
 task integrationTest(type: Test) {
     description 'Runs integration tests against Production or Dev servers.'
 
     useTestNG()
-
-    // TestNG specific options
-    options.parallel 'classes'
-    options.threadCount 4
-    options.preserveOrder true
 
     // only select integration tests (similar to maven-failsafe-plugin rules)
     include '**/IT*.class'
@@ -151,10 +142,7 @@ task integrationTest(type: Test) {
     exclude '**/*V1IT$*.class'
 
     testLogging {
-        events "skipped", "failed"
-        info {
-            events "passed", "skipped", "failed"
-        }
+        showStandardStreams = true // System.out.println
     }
 
     reports {
@@ -174,6 +162,9 @@ task integrationTest(type: Test) {
             systemProperty httpRequestorPropertyName, project.property(httpRequestorPropertyName)
         }
     }
+
+    // Will ensure that integration tests are re-run every time because they are not hermetic
+    outputs.upToDateWhen { false }
 }
 
 javadoc {

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -48,15 +48,13 @@ trap cleanup EXIT
 
 echo "Running integration tests..."
 
-gradle clean
 gradle check
 
 # Run integration tests against major HTTP requestor implementations
 for requestor in "OkHttpRequestor" "OkHttp3Requestor" "StandardHttpRequestor" ; do
-    gradle -Pcom.dropbox.test.httpRequestor="${requestor}" -Pcom.dropbox.test.authInfoFile="${AUTH_FILE}" integrationTest --info
+    gradle -Pcom.dropbox.test.httpRequestor="${requestor}" -Pcom.dropbox.test.authInfoFile="${AUTH_FILE}" integrationTest
     gradle -Pcom.dropbox.test.httpRequestor="${requestor}" -Pcom.dropbox.test.authInfoFile="${AUTH_FILE}" proguardTest
 done
 
 # prepare examples to be run
-android_gradle clean
 android_gradle assemble

--- a/src/test/java/com/dropbox/core/v2/files/TagObjectIT.java
+++ b/src/test/java/com/dropbox/core/v2/files/TagObjectIT.java
@@ -45,10 +45,11 @@ public class TagObjectIT {
         List<TagObject> tagsWithA = getTagsForPath(client, dropboxPath);
         assertEquals("a", tagsWithA.get(0).getUserGeneratedTagValue().getTagText());
         Thread.sleep(1000);
-
-
+        
         // Remove Tag "a" from file
         client.files().tagsRemove(dropboxPath, "a");
+        Thread.sleep(1000);
+
         List<TagObject> tagsNone = getTagsForPath(client, dropboxPath);
         assertEquals(0, tagsNone.size());
         Thread.sleep(1000);


### PR DESCRIPTION
Issues related to Integration Tests that were addressed:
* Parallel execution of our integration tests made logging harder to read, and potentially could cause race conditions. 
 I have now made them run sequentially.
* I have marked the `integrationTest` gradle task as NEVER up to date, meaning it will always re-run.  Our code intended to run the integration tests for each type of Networking Requestor, but was only doing so for the first one.  This has been updated so that we test all 3.
* I've updated our logging to allow `System.out.println` messages from our Integration Tests to print the API Response codes, urls and Dropbox Request IDs that can be used for debugging.  Previous to this it was incredibly hard to debug any integration test failures on Github Actions.  Example Output for OkHttp requestors:
```
    200 | POST | https://content.dropboxapi.com/2/files/upload | X-Dropbox-Request-Id: f973db79afb049ea97ca1ddef1381dbe
    200 | POST | https://api.dropboxapi.com/2/files/get_metadata | X-Dropbox-Request-Id: 028a8e325a364b60b5cdc040b84c03d8
    200 | POST | https://content.dropboxapi.com/2/files/download | X-Dropbox-Request-Id: 924af63e0853480ab67dd53b83f0f6aa
    200 | POST | https://api.dropboxapi.com/2/files/delete_v2 | X-Dropbox-Request-Id: f20fe63fe63b4ea08624858911297057
```