### PR TITLE
Remove sleeps from Tagging Integration Test

### DIFF
--- a/src/test/java/com/dropbox/core/v2/files/TagObjectIT.java
+++ b/src/test/java/com/dropbox/core/v2/files/TagObjectIT.java
@@ -36,23 +36,18 @@ public class TagObjectIT {
         client.files().uploadBuilder(dropboxPath)
                 .withMode(WriteMode.OVERWRITE)
                 .uploadAndFinish(new ByteArrayInputStream(contents));
-        Thread.sleep(1000);
 
         // Add Tag "a" to file
         client.files().tagsAdd(dropboxPath, "a");
-        Thread.sleep(1000);
 
         List<TagObject> tagsWithA = getTagsForPath(client, dropboxPath);
         assertEquals("a", tagsWithA.get(0).getUserGeneratedTagValue().getTagText());
-        Thread.sleep(1000);
         
         // Remove Tag "a" from file
         client.files().tagsRemove(dropboxPath, "a");
-        Thread.sleep(1000);
 
         List<TagObject> tagsNone = getTagsForPath(client, dropboxPath);
         assertEquals(0, tagsNone.size());
-        Thread.sleep(1000);
 
         // Cleanup, delete our test directory.
         client.files().deleteV2(dropboxPath);


### PR DESCRIPTION
The Tagging test was flaky, so `sleep(1000)` calls were added between API calls.  Because these integration tests are now running sequentially after this change: https://github.com/dropbox/dropbox-sdk-java/pull/401, my hypotheses is that we may no longer need the sleep calls.