### PR TITLE
Prepare for 5.3.0-SNAPSHOT

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
-5.2.0 (2022-4-04)
+## 5.3.0-SNAPSHOT (2022-07-20) [Milestone](https://github.com/dropbox/dropbox-sdk-java/milestone/1?closed=1)
 ---------------------------------------------
-- Update dropbox-api-spec to point to more recent version (Feb 2022)
+- Update dropbox-api-spec to point to more recent version (July 13, 2022) [#400](https://github.com/dropbox/dropbox-sdk-java/pull/400)
+- The generateStone Gradle Task now supports Gradle Configuration Caching [#390](https://github.com/dropbox/dropbox-sdk-java/pull/390)
+- API Backwards Compatibility Fix - Won't crash when new types are returned from API [#395](https://github.com/dropbox/dropbox-sdk-java/pull/395)
+- Version Bumps in the Dropbox Android Sample Apps [#391](https://github.com/dropbox/dropbox-sdk-java/pull/391)
+
+5.2.0 (2022-04-04)
+---------------------------------------------
 - Update jackson-core to 2.7.9
 
 5.1.1 (2021-12-17)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@ Releasing
 
  1. Update the top level [gradle.properties](gradle.properties) to a non-SNAPSHOT version.
  2. Update [DbxSdkVersion.java](DbxSdkVersion.java) to a non-SNAPSHOT version.
- 3. Update the [ChangeLog.txt](ChangeLog.txt) for the impending release.
+ 3. Update the [ChangeLog.md](ChangeLog.md) for the impending release.
  4. Update the [ReadMe.md](ReadMe.md) with the new version.
  5. `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
  6. `git tag -a vX.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # POM
 GROUP = com.dropbox.core
-VERSION_NAME=5.2.1-SNAPSHOT
+VERSION_NAME=5.3.0-SNAPSHOT
 
 POM_ARTIFACT_ID = dropbox-core-sdk
 POM_NAME = Dropbox SDK Java

--- a/src/main/java/com/dropbox/core/DbxSdkVersion.java
+++ b/src/main/java/com/dropbox/core/DbxSdkVersion.java
@@ -12,6 +12,6 @@ public class DbxSdkVersion
     // https://github.com/dropbox/dropbox-sdk-java/issues/357
     private static String loadVersion()
     {
-        return "5.2.1-SNAPSHOT";
+        return "5.3.0-SNAPSHOT";
     }
 }


### PR DESCRIPTION
This updates the changelog in preparation for a 5.3.0 release afterwards.