### PR TITLE
Prepare next development version 5.3.1-SNAPSHOT

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,5 +22,5 @@ Releasing
            * Click on Close and refresh until the Release button is active
            * Click Release and submit
  14. Create a GitHub release with the title and tag vX.Y.Z. Attach the sdk, -javadoc, and -sources .jar files from your `build/libs` directory.
- 15. Update gh-pages. Add or replace the files within `https://github.com/dropbox/dropbox-sdk-java/tree/gh-pages` with the files inside `dropbox-sdk-java/build/docs/javadoc`
+ 15. Update gh-pages. Add or replace the files within `https://github.com/dropbox/dropbox-sdk-java/tree/gh-pages` with the files inside `dropbox-sdk-java/build/docs/javadoc`.  Also update the root `index.html` to link to the new version documentation.  This page will be shown here: https://dropbox.github.io/dropbox-sdk-java/
  16. Push these changes to GitHub.

--- a/examples/upload-file/src/main/java/com/dropbox/core/examples/upload_file/Main.java
+++ b/examples/upload-file/src/main/java/com/dropbox/core/examples/upload_file/Main.java
@@ -15,7 +15,6 @@ import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.v2.files.UploadErrorException;
 import com.dropbox.core.v2.files.UploadSessionCursor;
 import com.dropbox.core.v2.files.UploadSessionFinishErrorException;
-import com.dropbox.core.v2.files.UploadSessionLookupErrorException;
 import com.dropbox.core.v2.files.WriteMode;
 
 import java.io.File;
@@ -158,21 +157,6 @@ public class Main {
                 thrown = ex;
                 // network issue with Dropbox (maybe a timeout?) try again
                 continue;
-            } catch (UploadSessionLookupErrorException ex) {
-                if (ex.errorValue.isIncorrectOffset()) {
-                    thrown = ex;
-                    // server offset into the stream doesn't match our offset (uploaded). Seek to
-                    // the expected offset according to the server and try again.
-                    uploaded = ex.errorValue
-                        .getIncorrectOffsetValue()
-                        .getCorrectOffset();
-                    continue;
-                } else {
-                    // Some other error occurred, give up.
-                    System.err.println("Error uploading to Dropbox: " + ex.getMessage());
-                    System.exit(1);
-                    return;
-                }
             } catch (UploadSessionFinishErrorException ex) {
                 if (ex.errorValue.isLookupFailed() && ex.errorValue.getLookupFailedValue().isIncorrectOffset()) {
                     thrown = ex;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # POM
 GROUP = com.dropbox.core
-VERSION_NAME=5.3.0
+VERSION_NAME=5.3.1-SNAPSHOT
 
 POM_ARTIFACT_ID = dropbox-core-sdk
 POM_NAME = Dropbox SDK Java

--- a/src/main/java/com/dropbox/core/DbxSdkVersion.java
+++ b/src/main/java/com/dropbox/core/DbxSdkVersion.java
@@ -12,6 +12,6 @@ public class DbxSdkVersion
     // https://github.com/dropbox/dropbox-sdk-java/issues/357
     private static String loadVersion()
     {
-        return "5.3.0";
+        return "5.3.1-SNAPSHOT";
     }
 }


### PR DESCRIPTION
Bumped to v5.3.1-SNAPSHOT for next development version.

Additionally there was a build error in one of the examples that was not caught during Github Action checks previously.  It looks like an exception type is no longer returned from an API after a stone spec update.  It's curious that it did pass during the release of 5.3.0, but it has no impact on the SDK functionality.  It has been updated so that the test passes as expected.