### PR TITLE
Updates ITUtil.java to use `deleteV2` instead of deprecated `delete`.

### DIFF
--- a/src/test/java/com/dropbox/core/ITUtil.java
+++ b/src/test/java/com/dropbox/core/ITUtil.java
@@ -234,7 +234,7 @@ public final class ITUtil {
                 .withHttpRequestor(newStandardHttpRequestor())
         );
         try {
-            client.files().delete(RootContainer.ROOT);
+            client.files().deleteV2(RootContainer.ROOT);
         } catch (DeleteErrorException ex) {
             if (ex.errorValue.isPathLookup() &&
                 ex.errorValue.getPathLookupValue().isNotFound()) {


### PR DESCRIPTION
The Files route `delete` is marked as deprecated, replaced with `deleteV2`, so this simply updates this test to use the replacement version.