### PR TITLE
Mockito bump from v1 to v4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compileOnly 'com.google.appengine:appengine-api-1.0-sdk:1.9.38'
 
     testImplementation 'org.testng:testng:6.9.10'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
     testImplementation 'org.openjdk.jmh:jmh-core:1.12'
     testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.12'
     testImplementation 'com.google.appengine:appengine-api-1.0-sdk:1.9.38'

--- a/src/main/java/com/dropbox/core/android/FixedSecureRandom.java
+++ b/src/main/java/com/dropbox/core/android/FixedSecureRandom.java
@@ -70,7 +70,7 @@ public final class FixedSecureRandom extends SecureRandom {
         public LinuxPrngSecureRandomProvider()
         {
             super("LinuxPRNG",
-                    1.0,
+                    "1.0",
                     "A Linux-specific random number provider that uses"
                         + " /dev/urandom");
             // Although /dev/urandom is not a SHA-1 PRNG, some apps

--- a/src/test/java/com/dropbox/core/DbxAuthFinishTest.java
+++ b/src/test/java/com/dropbox/core/DbxAuthFinishTest.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -214,7 +214,7 @@ public class DbxAuthFinishTest extends DbxOAuthTestBase {
                 .thenReturn(body);
         when(mockUploader.finish())
                 .thenReturn(finishResponse);
-        when(mockRequestor.startPost(anyString(), anyListOf(HttpRequestor.Header.class)))
+        when(mockRequestor.startPost(anyString(), anyList()))
                 .thenReturn(mockUploader);
 
         DbxRequestConfig mockConfig = CONFIG.copy()

--- a/src/test/java/com/dropbox/core/DbxPKCEWebAuthTest.java
+++ b/src/test/java/com/dropbox/core/DbxPKCEWebAuthTest.java
@@ -17,8 +17,9 @@ import java.util.regex.Pattern;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -89,7 +90,7 @@ public class DbxPKCEWebAuthTest extends DbxOAuthTestBase {
                 .thenReturn(body);
         when(mockUploader.finish())
                 .thenReturn(finishResponse);
-        when(mockRequestor.startPost(anyString(), anyListOf(HttpRequestor.Header.class)))
+        when(mockRequestor.startPost(anyString(), anyList()))
                 .thenReturn(mockUploader);
 
         DbxRequestConfig mockConfig = CONFIG.copy()
@@ -199,7 +200,7 @@ public class DbxPKCEWebAuthTest extends DbxOAuthTestBase {
         HttpRequestor.Uploader mockUploader = mock(HttpRequestor.Uploader.class);
         when(mockUploader.finish())
             .thenReturn(finishResponse);
-        when(mockRequestor.startPost(anyString(), anyListOf(HttpRequestor.Header.class)))
+        when(mockRequestor.startPost(anyString(), anyList()))
             .thenReturn(mockUploader);
 
         DbxRequestConfig mockConfig = CONFIG.copy()

--- a/src/test/java/com/dropbox/core/oauth/DbxCredentialTest.java
+++ b/src/test/java/com/dropbox/core/oauth/DbxCredentialTest.java
@@ -43,7 +43,7 @@ public class DbxCredentialTest {
 
         DbxCredential credential = DbxCredential.Reader.readFully(responseStream);
         assertThat(credential.getAccessToken()).isEqualTo("aaaaa");
-        assertThat(credential.getExpiresAt()).isEqualTo(new Long(10));
+        assertThat(credential.getExpiresAt()).isEqualTo(10L);
         assertThat(credential.getRefreshToken()).isEqualTo("bbbbb");
         assertThat(credential.getAppKey()).isEqualTo("ccccc");
         assertThat(credential.getAppSecret()).isEqualTo("ddddd");

--- a/src/test/java/com/dropbox/core/oauth/DbxRefreshTest.java
+++ b/src/test/java/com/dropbox/core/oauth/DbxRefreshTest.java
@@ -20,8 +20,8 @@ import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,7 +55,7 @@ public class DbxRefreshTest extends DbxOAuthTestBase {
         actual.setIssueTime(0);
 
         assertThat(actual.getAccessToken()).isEqualTo(NEW_TOKEN);
-        assertThat(actual.getExpiresAt()).isEqualTo(new Long(EXPIRES_IN_SECONDS * 1000));
+        assertThat(actual.getExpiresAt()).isEqualTo((EXPIRES_IN_SECONDS * 1000));
     }
 
     @Test
@@ -81,7 +81,7 @@ public class DbxRefreshTest extends DbxOAuthTestBase {
         IOException {
         HttpRequestor mockRequestor = mock(HttpRequestor.class);
         when(mockUploader.finish()).thenReturn(response);
-        when(mockRequestor.startPost(anyString(), anyListOf(HttpRequestor.Header.class)))
+        when(mockRequestor.startPost(anyString(), anyList()))
             .thenReturn(mockUploader);
 
         return CONFIG.copy().withHttpRequestor(mockRequestor).build();

--- a/src/test/java/com/dropbox/core/v1/DbxClientV1Test.java
+++ b/src/test/java/com/dropbox/core/v1/DbxClientV1Test.java
@@ -12,9 +12,9 @@ import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.RetryException;
 import com.dropbox.core.util.IOUtil;
 
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.mockito.Matchers;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -248,6 +248,6 @@ public class DbxClientV1Test {
     }
 
     private static Iterable<HttpRequestor.Header> anyHeaders() {
-        return Matchers.<Iterable<HttpRequestor.Header>>any();
+        return ArgumentMatchers.<Iterable<HttpRequestor.Header>>any();
     }
 }

--- a/src/test/java/com/dropbox/core/v2/DbxClientV2Test.java
+++ b/src/test/java/com/dropbox/core/v2/DbxClientV2Test.java
@@ -13,9 +13,9 @@ import com.dropbox.core.v2.auth.AuthError;
 import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.v2.files.Metadata;
 
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.mockito.Matchers;
 
 import org.testng.annotations.Test;
 
@@ -347,7 +347,7 @@ public class DbxClientV2Test {
         verify(mockRequestor, times(2)).startPost(anyString(), anyHeaders());
 
         assertThat(credential.getAccessToken()).isEqualTo("accesstoken");
-        assertThat(credential.getExpiresAt()).isEqualTo(new Long(10));
+        assertThat(credential.getExpiresAt()).isEqualTo((10L));
 
         assertThat(actual.getName()).isEqualTo(expected.getName());
         assertWithMessage(actual.getClass().toString()).that(actual instanceof FileMetadata).isTrue();
@@ -693,7 +693,7 @@ public class DbxClientV2Test {
     }
 
     private static Iterable<HttpRequestor.Header> anyHeaders() {
-        return Matchers.<Iterable<HttpRequestor.Header>>any();
+        return ArgumentMatchers.<Iterable<HttpRequestor.Header>>any();
     }
 
     private static byte [] serialize(Metadata metadata) {


### PR DESCRIPTION
This diff moves the SDK to Mockito 4 and fixes compiler warnings while running tests.