### PR TITLE
fix: Add queries to manifest of android sample app and misc cleanup

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -159,11 +159,10 @@ public class Main {
 
 Some more complete examples can be found here:
   * Example for a simple web app: [Web File Browser example](examples/web-file-browser/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxAuth.java)
-  * Example for an Android app written in Kotlin: [Android Kotlin Example](examples/DropboxAndroid)
-  * Example for an Android app (deprecated): [Android example](examples/android/src/main/java/com/dropbox/core/examples/android/UserActivity.java)
+  * Example for an Android app written in Kotlin: [Android Kotlin Example](examples/android)
   * Example for a command-line tool: [Command-Line Authorization example](examples/authorize/src/main/java/com/dropbox/core/examples/authorize/Main.java)
 
-To try out running this examples, please follow the instructions below.
+To try out running these examples, please follow the instructions below.
 
 ### Save your Dropbox API key
 
@@ -193,13 +192,13 @@ The output will be in "build/".
 
 1. Follow the instructions in the "Build from source" section above.
 2. Save your Dropbox API key in a file called "test.app".  See: [Save your Dropbox API key](#save-your-dropbox-api-key), above.
-3. Compile and install the SDK into your local maven repo: `./gradlew install`
-4. To compile all the examples: `(cd examples/ && ./gradlew classes`
-5. To compile just one example: `(cd examples/ && ./gradlew :<example-name>:classes`
+3. Compile and install the SDK into your local maven repo: `./gradlew build`
+4. To compile all the examples: `cd examples/ && ./gradlew classes`
+5. To compile just one example: `cd examples/ && ./gradlew :<example-name>:classes`
 
 #### authorize
 
-This examples runs through the OAuth 2 authorization flow.
+This example runs through the OAuth 2 authorization flow.
 
 ```
 cd examples

--- a/examples/android/ReadMe.md
+++ b/examples/android/ReadMe.md
@@ -1,21 +1,19 @@
-### This example is not fully up to date, please see [our latest example](../DropboxAndroid)
-
 # Example Android application (using the Dropbox SDK for Java.)
 
 This shows the Dropbox API authorization flow and some API calls to retrieve files.
 
 ## Requirements
 
-This example is backwards compatible with Android 4.4 (KitKat). Ensure your build environment supports at least Android SDK version 19.
+This example is backwards compatible with Android 5.0 (Lollipop). Ensure your build environment supports at least Android SDK version 21.
 
 ## Running the example
 
 Prerequisites: Apache Maven (to build the SDK), [Android Studio](http://developer.android.com/sdk/installing/) (not strictly necessary)
 
 1. Download this repository.
-2. Build the SDK: run `./gradlew install` in the SDK root directory (two levels up from this folder).
+2. Build the SDK: run `./gradlew build` in the SDK root directory (two levels up from this folder).
 3. In Android Studio, choose "Import Project" and select this folder.
-4. Edit "src/main/AndroidManifest.xml" and "src/main/res/values/strings.xml" and replace `YOUR_APP_KEY_HERE` with your Dropbox API key ([how to get a Dropbox API key](../../ReadMe.md#get-a-dropbox-api-key)).
+4. Edit local.properties and add `DROPBOX_APP_KEY=YOUR_KEY_HERE` with your Dropbox API key ([how to get a Dropbox API key](../../ReadMe.md#get-a-dropbox-api-key)).
 5. Build and run.
 
 If you don't have Android Studio, you can use the command-line:

--- a/examples/android/src/main/AndroidManifest.xml
+++ b/examples/android/src/main/AndroidManifest.xml
@@ -31,7 +31,6 @@
             android:configChanges="orientation|keyboard"
             android:launchMode="singleTask">
             <intent-filter>
-                <!-- Change this to be db- followed by your app key -->
                 <data android:scheme="db-${dropboxKey}" />
 
                 <action android:name="android.intent.action.VIEW" />

--- a/examples/android/src/main/AndroidManifest.xml
+++ b/examples/android/src/main/AndroidManifest.xml
@@ -61,5 +61,7 @@
                 android:resource="@xml/provider_paths" />
         </provider>
     </application>
-
+    <queries>
+        <package android:name="com.dropbox.android" />
+    </queries>
 </manifest>

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/OpenWithActivity.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/OpenWithActivity.kt
@@ -52,17 +52,18 @@ class OpenWithActivity : BaseSampleActivity() {
         val mInstalled = findViewById<View>(R.id.is_installed) as Button
         mInstalled.setOnClickListener {
             val installInfo = DbxOfficialAppConnector.isInstalled(this@OpenWithActivity)
-            showToast(installInfo?.toString() ?: "Not installed!")
+            val toastText = installInfo?.toString() ?: "Not installed!"
+            showToast(toastText)
         }
         val mGenLinked = findViewById<View>(R.id.is_linked_any_button) as Button
         mGenLinked.setOnClickListener {
             val isSigned = DbxOfficialAppConnector.isAnySignedIn(this@OpenWithActivity)
-            showToast("Any Signed in?:$isSigned")
+            showToast("Any Signed in?: $isSigned")
         }
         val mSpecLinked = findViewById<View>(R.id.is_linked_spec_button) as Button
         mSpecLinked.setOnClickListener {
             val isSigned = mDoac!!.isSignedIn(this@OpenWithActivity)
-            showToast("Signed in?:$isSigned")
+            showToast("Signed in?: $isSigned")
         }
         val mPreview = findViewById<View>(R.id.preview_button) as Button
         mPreview.setOnClickListener {

--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -3,8 +3,8 @@
 #
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx1024m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# Default value: -Xmx1024m
+# org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -12,4 +12,4 @@
 org.gradle.parallel=true
 android.useAndroidX=true
 
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
This diff adds the <queries> tag to our manifest, which allows the sample app to return the correct results when using the `Test open with` features.

Tested on Pixel 6 on API 33

Also gave the readmes and other files a quick cleanup.