### PR TITLE
Fix output location to be `dropbox-sdk-java` project and not `root` project

### DIFF
--- a/stone.gradle
+++ b/stone.gradle
@@ -216,7 +216,7 @@ project.sourceSets.all { SourceSet sourceSet ->
         stoneDir 'stone'
         routeWhitelistFilter project.properties.get(routeWhitelistFilterPropName, null)
         pythonCommand 'python'
-        outputDir "${project.rootDir}/generated_stone_source/${sourceSet.name}"
+        outputDir "${project.getProjectDir()}/generated_stone_source/${sourceSet.name}"
 
         inputs.dir { project.fileTree(dir: generatorDir, exclude: '**/*.pyc') }.withPropertyName("stone").withPathSensitivity(PathSensitivity.RELATIVE)
         inputs.dir(getSpecFiles(objects, getSpecDir().get())).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("stoneSpec").skipWhenEmpty(true)


### PR DESCRIPTION
This fixes an issue where the generated source creates a new dir in the root project (via rootDir) even though this repo contains the generated files already committed. 