### PR TITLE
Use dropbox-sdk-java as source from examples Gradle Project

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -60,13 +60,16 @@ jobs:
       run: cd examples && ./gradlew assemble
 
     - name: Run Integration Tests - OkHttpRequestor
-      run: ./gradlew -Pcom.dropbox.test.httpRequestor=OkHttpRequestor -Pcom.dropbox.test.authInfoFile=../auth_output integrationTest proguardTest
+      run: ./gradlew -Pcom.dropbox.test.httpRequestor=OkHttpRequestor -Pcom.dropbox.test.authInfoFile=../auth_output integrationTest &&
+           ./gradlew -Pcom.dropbox.test.httpRequestor=OkHttpRequestor -Pcom.dropbox.test.authInfoFile=../auth_output proguardTest
 
     - name: Run Integration Tests - OkHttp3Requestor
-      run: ./gradlew -Pcom.dropbox.test.httpRequestor=OkHttp3Requestor -Pcom.dropbox.test.authInfoFile=../auth_output integrationTest proguardTest
+      run: ./gradlew -Pcom.dropbox.test.httpRequestor=OkHttp3Requestor -Pcom.dropbox.test.authInfoFile=../auth_output integrationTest &&
+           ./gradlew -Pcom.dropbox.test.httpRequestor=OkHttp3Requestor -Pcom.dropbox.test.authInfoFile=../auth_output proguardTest
 
     - name: Run Integration Tests - StandardHttpRequestor
-      run: ./gradlew -Pcom.dropbox.test.httpRequestor=StandardHttpRequestor -Pcom.dropbox.test.authInfoFile=../auth_output integrationTest proguardTest
+      run: ./gradlew -Pcom.dropbox.test.httpRequestor=StandardHttpRequestor -Pcom.dropbox.test.authInfoFile=../auth_output integrationTest &&
+           ./gradlew -Pcom.dropbox.test.httpRequestor=StandardHttpRequestor -Pcom.dropbox.test.authInfoFile=../auth_output proguardTest
 
     - name: Upload Artifacts
       run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-daemon --no-parallel

--- a/examples/account-info-legacy/build.gradle
+++ b/examples/account-info-legacy/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Account Info Example (Dropbox Core API SDK)'

--- a/examples/account-info/build.gradle
+++ b/examples/account-info/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Account Info Example (Dropbox Core API SDK)'

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -56,7 +56,7 @@ android {
 }
 
 dependencies {
-    implementation "com.dropbox.core:dropbox-core-sdk:5.3.0"
+    implementation(project(":dropbox-sdk-java"))
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.7.10"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3'

--- a/examples/authorize-legacy/build.gradle
+++ b/examples/authorize-legacy/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Authorize Example (Dropbox Core API SDK) with legacy OAuth2 flow which use long ' +
         'live token'

--- a/examples/authorize/build.gradle
+++ b/examples/authorize/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Authorize Example (Dropbox Core API SDK) with short lived token and scope'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,9 +2,14 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.2.1"
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
+        classpath files('../gradle/dropbox-pem-converter-plugin')
+        classpath 'gradle.plugin.com.github.blindpirate:gradle-legacy-osgi-plugin:0.0.6'
+        classpath "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10"
     }
 }
@@ -13,47 +18,5 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-    }
-}
-
-subprojects {
-    pluginManager.withPlugin('java') {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-
-        dependencies {
-            implementation "com.dropbox.core:dropbox-core-sdk:5.3.0"
-        }
-
-        // allow subprojects to run with arbitrary number of arguments specified through project properties:
-        //
-        //   -Parg0=... -Parg1=... -Parg2=...
-        //
-        // This is intended to be used by the ./run script and not through gradle directly
-        task run(type: JavaExec) {
-            standardInput = System.in
-            classpath = sourceSets.main.runtimeClasspath
-            main = "com.dropbox.core.examples.${project.name.replace('-', '_')}.Main"
-
-            // convenience for not having to always specify the auth file
-            def useAuthInfoFileProp = project.properties.get('useAuthInfoFileProp', 'false') == 'true'
-            if (useAuthInfoFileProp && project.hasProperty('com.dropbox.test.authInfoFile')) {
-                args project.property('com.dropbox.test.authInfoFile')
-            }
-
-            def failOnError = project.properties.get('failOnError', 'false') == 'true'
-            ignoreExitValue !failOnError
-
-            def argi = 0
-            while (true) {
-                def prop = "arg${argi}"
-                if (project.hasProperty(prop)) {
-                    args project.property(prop)
-                } else {
-                    break
-                }
-                ++argi
-            }
-        }
     }
 }

--- a/examples/global-callbacks/build.gradle
+++ b/examples/global-callbacks/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Global Callbacks Example (Dropbox Core API SDK)'

--- a/examples/gradle/integration-test-config.gradle
+++ b/examples/gradle/integration-test-config.gradle
@@ -1,0 +1,40 @@
+pluginManager.withPlugin('java') {
+
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+
+    dependencies {
+        implementation(project(":dropbox-sdk-java"))
+    }
+
+    // allow subprojects to run with arbitrary number of arguments specified through project properties:
+    //
+    //   -Parg0=... -Parg1=... -Parg2=...
+    //
+    // This is intended to be used by the ./run script and not through gradle directly
+    task run(type: JavaExec) {
+        standardInput = System.in
+        classpath = sourceSets.main.runtimeClasspath
+        main = "com.dropbox.core.examples.${project.name.replace('-', '_')}.Main"
+
+        // convenience for not having to always specify the auth file
+        def useAuthInfoFileProp = project.properties.get('useAuthInfoFileProp', 'false') == 'true'
+        if (useAuthInfoFileProp && project.hasProperty('com.dropbox.test.authInfoFile')) {
+            args project.property('com.dropbox.test.authInfoFile')
+        }
+
+        def failOnError = project.properties.get('failOnError', 'false') == 'true'
+        ignoreExitValue !failOnError
+
+        def argi = 0
+        while (true) {
+            def prop = "arg${argi}"
+            if (project.hasProperty(prop)) {
+                args project.property(prop)
+            } else {
+                break
+            }
+            ++argi
+        }
+    }
+}

--- a/examples/longpoll/build.gradle
+++ b/examples/longpoll/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'List Folder Longpoll Example (Dropbox Core API SDK)'

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -10,3 +10,5 @@ include ':upgrade-oauth1-token'
 include ':upload-file'
 include ':web-file-browser'
 include ':android'
+include ':dropbox-sdk-java'
+project(":dropbox-sdk-java").projectDir = file("../dropbox-sdk-java")

--- a/examples/tutorial/build.gradle
+++ b/examples/tutorial/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Tutorial Example (Dropbox Core API SDK)'

--- a/examples/upgrade-oauth1-token/build.gradle
+++ b/examples/upgrade-oauth1-token/build.gradle
@@ -1,3 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Upgrade OAuth 1 Token Example (Dropbox Core API SDK)'

--- a/examples/upload-file/build.gradle
+++ b/examples/upload-file/build.gradle
@@ -1,2 +1,4 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
+
 description = 'Upload File Example (Dropbox Core API SDK)'

--- a/examples/web-file-browser/build.gradle
+++ b/examples/web-file-browser/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply from: '../gradle/integration-test-config.gradle'
 
 description = 'Web File Browser Example (Dropbox Core API SDK)'
 


### PR DESCRIPTION
Using the source of `dropbox-sdk-java` instead of a published version.  This will aid development and is now possible because of the work done to move it into a module #425 