### PR TITLE
Fix version name in javadocs and issue with search

### DIFF
--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -8,6 +8,7 @@ targetCompatibility = JavaVersion.VERSION_11
 
 ext {
     mavenName = 'Official Dropbox Java SDK'
+    version = VERSION_NAME
     generatedSources = file("$buildDir/generated-sources")
     generatedResources = file("$buildDir/generated-resources")
     authInfoPropertyName = 'com.dropbox.test.authInfoFile'
@@ -156,6 +157,7 @@ javadoc {
     if (JavaVersion.current().isJava8Compatible()) {
         options.addBooleanOption "Xdoclint:all,-missing", true
     }
+    options.addBooleanOption('-no-module-directories', true)
     options.addStringOption "link", "http://docs.oracle.com/javase/6/docs/api/"
 }
 


### PR DESCRIPTION
Ensures that version name looks correct

Old (https://dropbox.github.io/dropbox-sdk-java/api-docs/v5.2.0/):
![image](https://user-images.githubusercontent.com/15068619/191356244-fc4953cb-d914-4ad5-b2e6-50ba1a2ace13.png)


New: 
<img width="507" alt="image" src="https://user-images.githubusercontent.com/15068619/191356163-d0b67fc1-183b-4ed0-82e0-3f19b0cb8b5f.png">

Also fix search by adding new compiler flag