### PR TITLE
Fix: When doing to app2app auth from example app, Dropbox app would crash.

### DIFF
--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
@@ -95,6 +95,7 @@ public class AuthActivity : Activity() {
     private var mAuthStateNonce: String? = null
     private var mActivityDispatchHandlerPosted = false
     private lateinit var mPKCEManager: DbxPKCEManager
+
     override fun onCreate(savedInstanceState: Bundle?) {
         mState = AuthActivityState.fromAuthParams(sAuthParams)
         if (savedInstanceState == null) {
@@ -181,6 +182,7 @@ public class AuthActivity : Activity() {
 
         // Create intent to auth with official app.
         val officialAuthIntent = DropboxAuthIntent.buildOfficialAuthIntent(
+            callingActivityFullyQualifiedClassName = this@AuthActivity::class.java.name,
             mState = mState,
             stateNonce = stateNonce,
             packageName = this@AuthActivity.packageName,

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -20,12 +20,13 @@ internal object DropboxAuthIntent {
         mState: AuthActivity.AuthActivityState,
         stateNonce: String,
         packageName: String,
-        queryParams: String
+        queryParams: String,
+        callingActivityFullyQualifiedClassName: String
     ): Intent {
         return buildActionAuthenticateIntent().apply {
             putExtra(EXTRA_CONSUMER_KEY, mState.mAppKey)
             putExtra(EXTRA_CONSUMER_SIG, "")
-            putExtra(EXTRA_CALLING_CLASS, javaClass.name)
+            putExtra(EXTRA_CALLING_CLASS, callingActivityFullyQualifiedClassName)
             putExtra(EXTRA_DESIRED_UID, mState.mDesiredUid)
             putExtra(EXTRA_ALREADY_AUTHED_UIDS, mState.mAlreadyAuthedUids.toTypedArray())
             putExtra(EXTRA_SESSION_ID, mState.mSessionId)


### PR DESCRIPTION
Dropbox app would crash when performing a login with the sample app. This was due to the sample app incorrectly declaring its class as `Android.content.intent`.

This PR ensures that the intent we send to the Dropbox app has the correct fully qualified class name.