### PR TITLE
Fixed logout issue in Sample App.

### DIFF
--- a/dropbox-sdk-android/README.md
+++ b/dropbox-sdk-android/README.md
@@ -1,0 +1,3 @@
+For 5.x, the source code in this folder is actually used from the `dropbox-sdk-java` module.
+
+In 6.x versions, we will have a standalone Android artifact, and that is why this folder is split apart.

--- a/examples/android/src/main/AndroidManifest.xml
+++ b/examples/android/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <application
         android:allowBackup="false"
         android:icon="@drawable/dropbox_big"
+        android:name=".DropboxAndroidSampleApplication"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         android:supportsRtl="false">

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/BaseSampleActivity.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/BaseSampleActivity.kt
@@ -3,10 +3,7 @@ package com.dropbox.core.examples.android
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import com.dropbox.core.android.Auth
-import com.dropbox.core.examples.android.internal.api.DropboxApiWrapper
-import com.dropbox.core.examples.android.internal.api.DropboxAppConfig
-import com.dropbox.core.examples.android.internal.api.DropboxCredentialUtil
-import com.dropbox.core.examples.android.internal.api.DropboxOAuthUtil
+import com.dropbox.core.examples.android.internal.di.AppGraph
 
 
 /**
@@ -15,26 +12,18 @@ import com.dropbox.core.examples.android.internal.api.DropboxOAuthUtil
  */
 abstract class BaseSampleActivity : AppCompatActivity() {
 
-    protected val dropboxAppConfig = DropboxAppConfig()
+    val appGraph: AppGraph get() = (this.applicationContext as DropboxAndroidSampleApplication).appGraph
 
-    protected val dropboxCredentialUtil by lazy { DropboxCredentialUtil(this.applicationContext) }
+    protected val dropboxOAuthUtil get() = appGraph.dropboxOAuthUtil
 
-    protected val dropboxOAuthUtil by lazy {
-        DropboxOAuthUtil(
-            dropboxAppConfig = dropboxAppConfig,
-            dropboxCredentialUtil = dropboxCredentialUtil
-        )
-    }
+    protected val dropboxCredentialUtil get() = appGraph.dropboxCredentialUtil
 
-    protected val dropboxApiWrapper
-        get() = DropboxApiWrapper(
-            dbxCredential = dropboxCredentialUtil.getLocalCredential()!!,
-            clientIdentifier = dropboxAppConfig.clientIdentifier
-        )
+    protected val dropboxApiWrapper get() = appGraph.dropboxApiWrapper
 
     // will use our Short Lived Token.
     override fun onResume() {
         super.onResume()
+        dropboxOAuthUtil.onResume()
         if (isAuthenticated()) {
             loadData()
         }
@@ -53,7 +42,7 @@ abstract class BaseSampleActivity : AppCompatActivity() {
     protected abstract fun loadData()
 
     protected fun isAuthenticated(): Boolean {
-        return dropboxCredentialUtil.getLocalCredential() != null
+        return dropboxCredentialUtil.isAuthenticated()
     }
 
 }

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/DropboxAndroidSampleApplication.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/DropboxAndroidSampleApplication.kt
@@ -1,0 +1,9 @@
+package com.dropbox.core.examples.android
+
+import android.app.Application
+import com.dropbox.core.examples.android.internal.di.AppGraph
+import com.dropbox.core.examples.android.internal.di.AppGraphImpl
+
+class DropboxAndroidSampleApplication : Application() {
+    val appGraph: AppGraph = AppGraphImpl(this)
+}

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/HomeActivity.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/HomeActivity.kt
@@ -31,10 +31,6 @@ class HomeActivity : BaseSampleActivity() {
 
         val toolbar = findViewById<Toolbar>(R.id.app_bar)
         setSupportActionBar(toolbar)
-        val loginButton = findViewById<Button>(R.id.login_button)
-        loginButton.setOnClickListener {
-            dropboxOAuthUtil.startDropboxAuthorization(this)
-        }
         filesButton.setOnClickListener {
             startActivity(
                 FilesActivity.getIntent(
@@ -111,7 +107,7 @@ class HomeActivity : BaseSampleActivity() {
             dropboxOAuthUtil.startDropboxAuthorization(this)
         }
         logoutButton.setOnClickListener {
-            dropboxOAuthUtil.revokeDropboxAuthorization(lifecycleScope)
+            dropboxOAuthUtil.revokeDropboxAuthorization(dropboxApiWrapper)
             resetUi()
         }
         uploadImageButton.setOnClickListener {

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxCredentialUtil.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxCredentialUtil.kt
@@ -2,6 +2,7 @@ package com.dropbox.core.examples.android.internal.api
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.dropbox.core.android.Auth
 import com.dropbox.core.oauth.DbxCredential
@@ -12,33 +13,48 @@ class DropboxCredentialUtil(appContext: Context) {
         AppCompatActivity.MODE_PRIVATE
     )
 
-    //deserialize the credential from SharedPreferences if it exists
-    fun getLocalCredential(): DbxCredential? {
-        val serializedCredential = sharedPreferences.getString("credential", null)
-        val resultCredential: DbxCredential? = if (serializedCredential != null) {
-            DbxCredential.Reader.readFully(serializedCredential)
-        } else {
-            val authDbxCredential = Auth.dbxCredential //fetch the result from the AuthActivity
-            if (authDbxCredential != null) {
-                storeCredentialLocally(authDbxCredential)
-                authDbxCredential
-            } else {
-                null
-            }
+//    //deserialize the credential from SharedPreferences if it exists
+//    fun getDbxCredential(): DbxCredential? {
+//        val credentialFromSharedPref = readCredentialLocally()
+//        if (credentialFromSharedPref != null) {
+//            return credentialFromSharedPref
+//        }
+//
+//        return null
+//    }
+
+    fun readCredentialLocally(): DbxCredential? {
+        val serializedCredentialJson = sharedPreferences.getString("credential", null)
+        Log.d(TAG, "Local Credential Value from Shared Preferences: $serializedCredentialJson")
+        return try {
+            DbxCredential.Reader.readFully(serializedCredentialJson)
+        } catch (e: Exception) {
+            Log.d(TAG, "Something went wrong parsing the credential, clearing it")
+            removeCredentialLocally()
+            null
         }
-        return resultCredential
     }
 
     //serialize the credential and store in SharedPreferences
     fun storeCredentialLocally(dbxCredential: DbxCredential) {
+        Log.d(TAG, "Storing credential in Shared Preferences")
         sharedPreferences.edit().apply {
             putString("credential", DbxCredential.Writer.writeToString(dbxCredential))
         }.apply()
     }
 
     fun removeCredentialLocally() {
+        Log.d(TAG, "Clearing credential from Shared Preferences")
         sharedPreferences.edit().apply {
             remove("credential")
         }.apply()
+    }
+
+    fun isAuthenticated(): Boolean {
+        return readCredentialLocally() != null
+    }
+
+    private companion object {
+        private val TAG = DropboxCredentialUtil::class.java.simpleName
     }
 }

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/internal/di/AppGraph.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/internal/di/AppGraph.kt
@@ -1,0 +1,11 @@
+package com.dropbox.core.examples.android.internal.di
+
+import com.dropbox.core.examples.android.internal.api.DropboxApiWrapper
+import com.dropbox.core.examples.android.internal.api.DropboxCredentialUtil
+import com.dropbox.core.examples.android.internal.api.DropboxOAuthUtil
+
+interface AppGraph {
+    val dropboxCredentialUtil: DropboxCredentialUtil
+    val dropboxOAuthUtil: DropboxOAuthUtil
+    val dropboxApiWrapper: DropboxApiWrapper
+}

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/internal/di/AppGraphImpl.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/internal/di/AppGraphImpl.kt
@@ -1,0 +1,26 @@
+package com.dropbox.core.examples.android.internal.di;
+
+import android.content.Context
+import com.dropbox.core.examples.android.internal.api.DropboxApiWrapper
+import com.dropbox.core.examples.android.internal.api.DropboxAppConfig
+import com.dropbox.core.examples.android.internal.api.DropboxCredentialUtil
+import com.dropbox.core.examples.android.internal.api.DropboxOAuthUtil
+
+internal class AppGraphImpl(context: Context) : AppGraph {
+    private val dropboxAppConfig = DropboxAppConfig()
+
+    override val dropboxCredentialUtil by lazy { DropboxCredentialUtil(context.applicationContext) }
+
+    override val dropboxOAuthUtil by lazy {
+        DropboxOAuthUtil(
+            dropboxAppConfig = dropboxAppConfig,
+            dropboxCredentialUtil = dropboxCredentialUtil
+        )
+    }
+
+    override val dropboxApiWrapper
+        get() = DropboxApiWrapper(
+            dbxCredential = dropboxCredentialUtil.readCredentialLocally()!!,
+            clientIdentifier = dropboxAppConfig.clientIdentifier
+        )
+}


### PR DESCRIPTION
The sample app wasn't keeping track of when it was waiting for an auth result.  Because of this, we would re-read the credential result from the Dropbox SDK, and that token would already be invalidated.