### PR TITLE
Handle rotation change by storing in a "view model"

### DIFF
--- a/dropbox-sdk-android/api/dropbox-sdk-android.api
+++ b/dropbox-sdk-android/api/dropbox-sdk-android.api
@@ -43,7 +43,6 @@ public class com/dropbox/core/android/AuthActivity : android/app/Activity {
 	protected fun onCreate (Landroid/os/Bundle;)V
 	protected fun onNewIntent (Landroid/content/Intent;)V
 	protected fun onResume ()V
-	protected fun onSaveInstanceState (Landroid/os/Bundle;)V
 	public fun onTopResumedActivityChanged (Z)V
 	public static final fun setSecurityProvider (Lcom/dropbox/core/android/AuthActivity$SecurityProvider;)V
 }

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
@@ -54,8 +54,8 @@ public open class AuthActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (!AuthSessionViewModel.isAuthInProgress()) {
-            val newState = AuthSessionViewModel.State.fromAuthParams(sAuthParams)
-            AuthSessionViewModel.startAuthSession(newState)
+            val newStateFromAuthParams = AuthSessionViewModel.State.fromAuthParams(sAuthParams)
+            AuthSessionViewModel.startAuthSession(newStateFromAuthParams)
         }
         setTheme(R.style.Theme_Translucent_NoTitleBar)
         super.onCreate(savedInstanceState)
@@ -163,7 +163,6 @@ public open class AuthActivity : Activity() {
             // Save state that indicates we started a request, only after
             // we started one successfully.
             mState.mAuthStateNonce = stateNonce
-            setAuthParams(null, null, null)
         })
         mActivityDispatchHandlerPosted = true
     }
@@ -268,8 +267,6 @@ public open class AuthActivity : Activity() {
 
     private fun authFinished(authResult: Intent?) {
         result = authResult
-        mState.mAuthStateNonce = null
-        setAuthParams(null, null, null)
         AuthSessionViewModel.endAuthSession()
         finish()
     }

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
@@ -13,7 +13,6 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import com.dropbox.core.DbxHost
-import com.dropbox.core.DbxPKCEManager
 import com.dropbox.core.DbxRequestConfig
 import com.dropbox.core.DbxRequestUtil
 import com.dropbox.core.IncludeGrantedScopes
@@ -21,6 +20,7 @@ import com.dropbox.core.TokenAccessType
 import com.dropbox.core.android.internal.AuthParameters
 import com.dropbox.core.android.internal.AuthUtils.createPKCEStateNonce
 import com.dropbox.core.android.internal.AuthUtils.createStateNonce
+import com.dropbox.core.android.internal.AuthSessionViewModel
 import com.dropbox.core.android.internal.DropboxAuthIntent
 import com.dropbox.core.android.internal.QueryParamsUtil
 import com.dropbox.core.android.internal.TokenRequestAsyncTask
@@ -50,67 +50,15 @@ public open class AuthActivity : Activity() {
         public val secureRandom: SecureRandom
     }
 
-    /**
-     * These instance variables need not be stored in savedInstanceState as onNewIntent()
-     * does not read them.
-     */
-    internal data class AuthActivityState(
-        val mAppKey: String? = null,
-        val mApiType: String? = null,
-        val mDesiredUid: String? = null,
-        val mAlreadyAuthedUids: List<String> = emptyList(),
-        val mSessionId: String? = null,
-        val mTokenAccessType: TokenAccessType? = null,
-        val mRequestConfig: DbxRequestConfig? = null,
-        val mHost: DbxHost? = null,
-        val mScope: String? = null,
-        val mIncludeGrantedScopes: IncludeGrantedScopes? = null,
-    ) {
-        companion object {
-            fun fromAuthParams(sAuthParams: AuthParameters?): AuthActivityState {
-                return AuthActivityState(
-                    mAppKey = sAuthParams?.sAppKey,
-                    mApiType = sAuthParams?.sApiType,
-                    mDesiredUid = sAuthParams?.sDesiredUid,
-                    mAlreadyAuthedUids = sAuthParams?.sAlreadyAuthedUids ?: emptyList(),
-                    mSessionId = sAuthParams?.sSessionId,
-                    mTokenAccessType = sAuthParams?.sTokenAccessType,
-                    mRequestConfig = sAuthParams?.sRequestConfig,
-                    mHost = sAuthParams?.sHost,
-                    mScope = sAuthParams?.sScope,
-                    mIncludeGrantedScopes = sAuthParams?.sIncludeGrantedScopes,
-                )
-            }
-        }
-    }
-
-    private var mState: AuthActivityState = AuthActivityState()
-
-    // Stored in savedInstanceState to track an ongoing auth attempt, which
-    // must include a locally-generated nonce in the response.
-    private var mAuthStateNonce: String? = null
     private var mActivityDispatchHandlerPosted = false
-    private lateinit var mPKCEManager: DbxPKCEManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        mState = AuthActivityState.fromAuthParams(sAuthParams)
-        if (savedInstanceState == null) {
-            result = null
-            mAuthStateNonce = null
-            mPKCEManager = DbxPKCEManager()
-        } else {
-            mAuthStateNonce = savedInstanceState.getString(SIS_KEY_AUTH_STATE_NONCE)
-            mPKCEManager = DbxPKCEManager(savedInstanceState.getString(SIS_KEY_PKCE_CODE_VERIFIER))
+        if (!AuthSessionViewModel.isAuthInProgress()) {
+            val newState = AuthSessionViewModel.State.fromAuthParams(sAuthParams)
+            AuthSessionViewModel.startAuthSession(newState)
         }
-
         setTheme(R.style.Theme_Translucent_NoTitleBar)
         super.onCreate(savedInstanceState)
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putString(SIS_KEY_AUTH_STATE_NONCE, mAuthStateNonce)
-        outState.putString(SIS_KEY_PKCE_CODE_VERIFIER, mPKCEManager.codeVerifier)
     }
 
     override fun onResume() {
@@ -121,6 +69,8 @@ public open class AuthActivity : Activity() {
             onTopResumedActivityChanged(true /* onTop */)
         }
     }
+
+    private val mState : AuthSessionViewModel.State get() = AuthSessionViewModel.state
 
     /**
      * AuthActivity is launched first time, or user didn't finish oauth/dauth flow but
@@ -136,7 +86,7 @@ public open class AuthActivity : Activity() {
         if (isFinishing || !onTop) {
             return
         }
-        val authNotFinish = mAuthStateNonce != null || mState.mAppKey == null
+        val authNotFinish = mState.mAuthStateNonce != null || mState.mAppKey == null
         if (authNotFinish) {
             // We somehow returned to this activity without being forwarded
             // here by the official app.
@@ -159,7 +109,7 @@ public open class AuthActivity : Activity() {
         val stateNonce: String = if (mState.mTokenAccessType != null) {
             // short live token flow
             createPKCEStateNonce(
-                codeChallenge = mPKCEManager.codeChallenge,
+                codeChallenge = mState.mPKCEManager.codeChallenge,
                 tokenAccessType = mState.mTokenAccessType.toString(),
                 scope = mState.mScope,
                 mIncludeGrantedScopes = mState.mIncludeGrantedScopes
@@ -173,7 +123,7 @@ public open class AuthActivity : Activity() {
             tokenAccessType = mState.mTokenAccessType,
             scope = mState.mScope,
             includeGrantedScopes = mState.mIncludeGrantedScopes,
-            pkceManagerCodeChallenge = mPKCEManager.codeChallenge
+            pkceManagerCodeChallenge = mState.mPKCEManager.codeChallenge
         )
 
         // Create intent to auth with official app.
@@ -212,7 +162,7 @@ public open class AuthActivity : Activity() {
             }
             // Save state that indicates we started a request, only after
             // we started one successfully.
-            mAuthStateNonce = stateNonce
+            mState.mAuthStateNonce = stateNonce
             setAuthParams(null, null, null)
         })
         mActivityDispatchHandlerPosted = true
@@ -220,7 +170,7 @@ public open class AuthActivity : Activity() {
 
     override fun onNewIntent(intent: Intent) {
         // Reject attempt to finish authentication if we never started (nonce=null)
-        if (null == mAuthStateNonce) {
+        if (null == mState.mAuthStateNonce) {
             authFinished(null)
             return
         }
@@ -254,7 +204,7 @@ public open class AuthActivity : Activity() {
         if (token != null && token != "" && secret != null && secret != "" && uid != null && uid != "" && state != null && state != "") {
             // Reject attempt to link if the nonce in the auth state doesn't match,
             // or if we never asked for auth at all.
-            if (mAuthStateNonce != state) {
+            if (mState.mAuthStateNonce != state) {
                 authFinished(null)
                 return
             }
@@ -270,7 +220,7 @@ public open class AuthActivity : Activity() {
                 // code flow with PKCE
                 val tokenRequest = TokenRequestAsyncTask(
                     secret,
-                    mPKCEManager,
+                    mState.mPKCEManager,
                     mState.mRequestConfig!!,
                     mState.mAppKey!!,
                     mState.mHost!!
@@ -283,10 +233,22 @@ public open class AuthActivity : Activity() {
                         newResult = Intent()
                         // access_token and access_secret are OAuth1 concept. In OAuth2 we only
                         // have access token. So I put both of them to be the same.
-                        newResult.putExtra(DropboxAuthIntent.EXTRA_ACCESS_TOKEN, dbxAuthFinish.accessToken)
-                        newResult.putExtra(DropboxAuthIntent.EXTRA_ACCESS_SECRET, dbxAuthFinish.accessToken)
-                        newResult.putExtra(DropboxAuthIntent.EXTRA_REFRESH_TOKEN, dbxAuthFinish.refreshToken)
-                        newResult.putExtra(DropboxAuthIntent.EXTRA_EXPIRES_AT, dbxAuthFinish.expiresAt)
+                        newResult.putExtra(
+                            DropboxAuthIntent.EXTRA_ACCESS_TOKEN,
+                            dbxAuthFinish.accessToken
+                        )
+                        newResult.putExtra(
+                            DropboxAuthIntent.EXTRA_ACCESS_SECRET,
+                            dbxAuthFinish.accessToken
+                        )
+                        newResult.putExtra(
+                            DropboxAuthIntent.EXTRA_REFRESH_TOKEN,
+                            dbxAuthFinish.refreshToken
+                        )
+                        newResult.putExtra(
+                            DropboxAuthIntent.EXTRA_EXPIRES_AT,
+                            dbxAuthFinish.expiresAt
+                        )
                         newResult.putExtra(DropboxAuthIntent.EXTRA_UID, dbxAuthFinish.userId)
                         newResult.putExtra(DropboxAuthIntent.EXTRA_CONSUMER_KEY, mState.mAppKey)
                         newResult.putExtra(DropboxAuthIntent.EXTRA_SCOPE, dbxAuthFinish.scope)
@@ -306,8 +268,9 @@ public open class AuthActivity : Activity() {
 
     private fun authFinished(authResult: Intent?) {
         result = authResult
-        mAuthStateNonce = null
+        mState.mAuthStateNonce = null
         setAuthParams(null, null, null)
+        AuthSessionViewModel.endAuthSession()
         finish()
     }
 
@@ -319,7 +282,8 @@ public open class AuthActivity : Activity() {
         // Web Auth currently does not support desiredUid and only one alreadyAuthUid (param n).
         // We use first alreadyAuthUid arbitrarily.
         // Note that the API treats alreadyAuthUid of 0 and not present equivalently.
-        val alreadyAuthedUid = if (mState.mAlreadyAuthedUids.isNotEmpty()) mState.mAlreadyAuthedUids[0] else "0"
+        val alreadyAuthedUid =
+            if (mState.mAlreadyAuthedUids.isNotEmpty()) mState.mAlreadyAuthedUids[0] else "0"
         val params: MutableList<String?> =
             mutableListOf(
                 "k", mState.mAppKey,
@@ -334,7 +298,7 @@ public open class AuthActivity : Activity() {
                     tokenAccessType = mState.mTokenAccessType,
                     scope = mState.mScope,
                     includeGrantedScopes = mState.mIncludeGrantedScopes,
-                    pkceManagerCodeChallenge = mPKCEManager.codeChallenge,
+                    pkceManagerCodeChallenge = mState.mPKCEManager.codeChallenge,
                 )
             )
         }
@@ -370,12 +334,6 @@ public open class AuthActivity : Activity() {
          * The path for a successful callback with token (not the initial auth request).
          */
         const val AUTH_PATH_CONNECT: String = "/connect"
-
-        // saved instance state keys
-        private const val SIS_KEY_AUTH_STATE_NONCE = "SIS_KEY_AUTH_STATE_NONCE"
-
-        // saved instance PKCE manger key
-        private const val SIS_KEY_PKCE_CODE_VERIFIER = "SIS_KEY_PKCE_CODE_VERIFIER"
 
         // Class-level state used to replace the default SecureRandom implementation
         // if desired.
@@ -612,7 +570,11 @@ public open class AuthActivity : Activity() {
          */
         @JvmStatic
         @Deprecated("Use Methods in com.dropbox.core.android.Auth, This will be removed in future versions.")
-        public fun checkAppBeforeAuth(context: Context, appKey: String, alertUser: Boolean): Boolean {
+        public fun checkAppBeforeAuth(
+            context: Context,
+            appKey: String,
+            alertUser: Boolean
+        ): Boolean {
             // Check if the app has set up its manifest properly.
             val testIntent = Intent(Intent.ACTION_VIEW)
             val scheme = "db-$appKey"

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/AuthSessionViewModel.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/AuthSessionViewModel.kt
@@ -43,10 +43,9 @@ internal class AuthSessionViewModel {
     }
 
     companion object {
-
         private var _state: State = State()
 
-        var authInProgress = false
+        private var authInProgress = false
 
         val state: State get() = _state
 
@@ -61,7 +60,7 @@ internal class AuthSessionViewModel {
 
         fun endAuthSession() {
             authInProgress = false
-            _state = State()
+            this._state = State()
         }
     }
 }

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/AuthSessionViewModel.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/AuthSessionViewModel.kt
@@ -1,0 +1,67 @@
+package com.dropbox.core.android.internal
+
+import android.content.Intent
+import com.dropbox.core.DbxHost
+import com.dropbox.core.DbxPKCEManager
+import com.dropbox.core.DbxRequestConfig
+import com.dropbox.core.IncludeGrantedScopes
+import com.dropbox.core.TokenAccessType
+
+internal class AuthSessionViewModel {
+
+    internal data class State(
+        var mHost: DbxHost? = null,
+        var result: Intent? = null,
+        var mPKCEManager: DbxPKCEManager = DbxPKCEManager(),
+        var mAuthStateNonce: String? = null,
+        var mAppKey: String? = null,
+        var mApiType: String? = null,
+        var mDesiredUid: String? = null,
+        var mAlreadyAuthedUids: List<String> = emptyList(),
+        var mSessionId: String? = null,
+        var mTokenAccessType: TokenAccessType? = null,
+        var mRequestConfig: DbxRequestConfig? = null,
+        var mScope: String? = null,
+        var mIncludeGrantedScopes: IncludeGrantedScopes? = null,
+    ) {
+        companion object {
+            fun fromAuthParams(sAuthParams: AuthParameters?): State {
+                return State(
+                    mAppKey = sAuthParams?.sAppKey,
+                    mApiType = sAuthParams?.sApiType,
+                    mDesiredUid = sAuthParams?.sDesiredUid,
+                    mAlreadyAuthedUids = sAuthParams?.sAlreadyAuthedUids ?: emptyList(),
+                    mSessionId = sAuthParams?.sSessionId,
+                    mTokenAccessType = sAuthParams?.sTokenAccessType,
+                    mRequestConfig = sAuthParams?.sRequestConfig,
+                    mHost = sAuthParams?.sHost,
+                    mScope = sAuthParams?.sScope,
+                    mIncludeGrantedScopes = sAuthParams?.sIncludeGrantedScopes,
+                )
+            }
+        }
+    }
+
+    companion object {
+
+        private var _state: State = State()
+
+        var authInProgress = false
+
+        val state: State get() = _state
+
+        fun isAuthInProgress(): Boolean {
+            return authInProgress
+        }
+
+        fun startAuthSession(state: State) {
+            authInProgress = true
+            this._state = state
+        }
+
+        fun endAuthSession() {
+            authInProgress = false
+            _state = State()
+        }
+    }
+}

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -17,7 +17,7 @@ internal object DropboxAuthIntent {
      * Extras should be filled in by callee
      */
     fun buildOfficialAuthIntent(
-        mState: AuthActivity.AuthActivityState,
+        mState: AuthSessionViewModel.State,
         stateNonce: String,
         packageName: String,
         queryParams: String,

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxCredentialUtil.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxCredentialUtil.kt
@@ -13,16 +13,6 @@ class DropboxCredentialUtil(appContext: Context) {
         AppCompatActivity.MODE_PRIVATE
     )
 
-//    //deserialize the credential from SharedPreferences if it exists
-//    fun getDbxCredential(): DbxCredential? {
-//        val credentialFromSharedPref = readCredentialLocally()
-//        if (credentialFromSharedPref != null) {
-//            return credentialFromSharedPref
-//        }
-//
-//        return null
-//    }
-
     fun readCredentialLocally(): DbxCredential? {
         val serializedCredentialJson = sharedPreferences.getString("credential", null)
         Log.d(TAG, "Local Credential Value from Shared Preferences: $serializedCredentialJson")


### PR DESCRIPTION
We currently have a limitation of not using the AndroidX libraries for ViewModel until we use a separate Android Artifact in our 6.x versions.  Therefore, this is a workaround to have a static store for the State of our Auth Session.  There were issues during configuration changes without this work that caused problems with null pointers.