### PR TITLE
add import for @Inject annotation to stone.gradle

### DIFF
--- a/dropbox-sdk-java/stone.gradle
+++ b/dropbox-sdk-java/stone.gradle
@@ -1,3 +1,5 @@
+import javax.inject.Inject
+
 apply plugin: 'java'
 
 class StoneConfig implements Serializable {


### PR DESCRIPTION
Without this import, we were getting the following warning in CI

```
> Task :dropbox-sdk-java:generateStone
Execution optimizations have been disabled for task ':dropbox-sdk-java:generateStone' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/runner/work/dropbox-sdk-java/dropbox-sdk-java/dropbox-sdk-java/generated_stone_source/main'. Reason: Task ':dropbox-sdk-java:compileKotlin' uses this output of task ':dropbox-sdk-java:generateStone' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```