### PR TITLE
Changes method in StandardHttpRequestor from private -> protected

### DIFF
--- a/dropbox-sdk-java/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
+++ b/dropbox-sdk-java/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
@@ -195,7 +195,7 @@ public class StandardHttpRequestor extends HttpRequestor {
     }
 
 
-    private HttpURLConnection prepRequest(String url, Iterable<Header> headers, boolean streaming) throws IOException {
+    protected HttpURLConnection prepRequest(String url, Iterable<Header> headers, boolean streaming) throws IOException {
         URL urlObject = new URL(url);
         HttpURLConnection conn = (HttpURLConnection) urlObject.openConnection(config.getProxy());
 


### PR DESCRIPTION
Addresses #118

It seems reasonable to address this request in the 5.x version of the Dropbox SDK in case additional configuration is needed.  This can be supported through version 5.x of the SDK.