### PR TITLE
Applying Gradle Plugins by ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,8 @@ buildscript {
 plugins {
     alias(dropboxJavaSdkLibs.plugins.maven.publish.plugin) apply false
     alias(dropboxJavaSdkLibs.plugins.gradle.version.plugin) apply false
-    alias(dropboxJavaSdkLibs.plugins.dependency.guard)
+    alias(dropboxJavaSdkLibs.plugins.dependency.guard) apply false
+    alias(dropboxJavaSdkLibs.plugins.blind.pirate.osgi) apply false
 }
 
 allprojects {
@@ -31,6 +32,8 @@ allprojects {
         }
     }
 }
+
+apply plugin: "com.dropbox.dependency-guard"
 
 dependencyGuard {
     configuration("classpath")

--- a/dependencies/classpath.txt
+++ b/dependencies/classpath.txt
@@ -1,5 +1,6 @@
 androidx.databinding:databinding-common:7.2.2
 androidx.databinding:databinding-compiler-common:7.2.2
+biz.aQute.bnd:biz.aQute.bndlib:5.2.0
 com.android.databinding:baseLibrary:7.2.2
 com.android.tools.analytics-library:crash:30.2.2
 com.android.tools.analytics-library:protos:30.2.2
@@ -48,6 +49,7 @@ com.fasterxml.jackson.module:jackson-module-kotlin:2.11.1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.42.0
 com.github.ben-manes:gradle-versions-plugin:0.42.0
+com.github.blindpirate.osgi:com.github.blindpirate.osgi.gradle.plugin:0.0.6
 com.github.gundy:semver4j:0.16.4
 com.google.android:annotations:4.1.1.4
 com.google.api.grpc:proto-google-common-protos:1.12.0
@@ -85,6 +87,7 @@ commons-codec:commons-codec:1.11
 commons-io:commons-io:2.4
 commons-logging:commons-logging:1.2
 de.undercouch:gradle-download-task:4.1.1
+gradle.plugin.com.github.blindpirate:gradle-legacy-osgi-plugin:0.0.6
 io.github.x-stream:mxparser:1.2.1
 io.grpc:grpc-api:1.21.1
 io.grpc:grpc-context:1.21.1

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java-library'
-    id "com.github.blindpirate.osgi" version "0.0.6"
+    id "com.github.blindpirate.osgi"
     id "org.jetbrains.kotlin.jvm"
-    alias(dropboxJavaSdkLibs.plugins.gradle.version.plugin)
-    alias(dropboxJavaSdkLibs.plugins.maven.publish.plugin)
-    alias(dropboxJavaSdkLibs.plugins.dependency.guard)
+    id "com.vanniktech.maven.publish"
+    id "com.github.ben-manes.versions"
+    id "com.dropbox.dependency-guard"
 }
 
 

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java-library'
-    alias(dropboxJavaSdkLibs.plugins.blind.pirate.osgi)
+    id "com.github.blindpirate.osgi"
     id "org.jetbrains.kotlin.jvm"
     id "com.vanniktech.maven.publish"
-    alias(dropboxJavaSdkLibs.plugins.gradle.version.plugin)
-    alias(dropboxJavaSdkLibs.plugins.dependency.guard)
+    id "com.github.ben-manes.versions"
+    id "com.dropbox.dependency-guard"
 }
 
 

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java-library'
-    id "com.github.blindpirate.osgi"
+    alias(dropboxJavaSdkLibs.plugins.blind.pirate.osgi)
     id "org.jetbrains.kotlin.jvm"
     id "com.vanniktech.maven.publish"
-    id "com.github.ben-manes.versions"
-    id "com.dropbox.dependency-guard"
+    alias(dropboxJavaSdkLibs.plugins.gradle.version.plugin)
+    alias(dropboxJavaSdkLibs.plugins.dependency.guard)
 }
 
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -10,9 +10,11 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
     }
 }
-
 plugins {
     alias(dropboxJavaSdkLibs.plugins.maven.publish.plugin) apply false
+    alias(dropboxJavaSdkLibs.plugins.gradle.version.plugin) apply false
+    alias(dropboxJavaSdkLibs.plugins.dependency.guard) apply false
+    alias(dropboxJavaSdkLibs.plugins.blind.pirate.osgi) apply false
 }
 
 allprojects {

--- a/gradle/dropboxJavaSdkLibs.versions.toml
+++ b/gradle/dropboxJavaSdkLibs.versions.toml
@@ -43,3 +43,4 @@ dependency-guard = { id = "com.dropbox.dependency-guard", version.ref = "depende
 gradle-version-plugin = "com.github.ben-manes.versions:0.42.0"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 maven-publish-plugin = "com.vanniktech.maven.publish:0.18.0"
+blind-pirate-osgi = "com.github.blindpirate.osgi:0.0.6"


### PR DESCRIPTION
Applying plugins via id, so when this project is included in a different project config, it could use different versions without collision.

In the Dropbox codebase, this module is included as a source module, and we need this configuration.