### PR TITLE
Overriding output directory for Generating Code from Stone API Spec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     repositories {
         google()
@@ -38,4 +37,17 @@ apply plugin: "com.dropbox.dependency-guard"
 
 dependencyGuard {
     configuration("classpath")
+}
+
+// configure SDK to use the generated_stone_source output directory so we can track changes in Git
+def sdkProject = findProject(':dropbox-sdk-java')
+sdkProject.configure(sdkProject) {
+    afterEvaluate {
+        generateStone {
+            outputDir "${project.projectDir}/generated_stone_source/main"
+        }
+        generateTestStone {
+            outputDir "${project.projectDir}/generated_stone_source/test"
+        }
+    }
 }

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id "com.vanniktech.maven.publish"
     id "com.github.ben-manes.versions"
     id "com.dropbox.dependency-guard"
+    id "com.dropbox.stone.java"
 }
 
 dependencyGuard {

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -28,6 +28,7 @@ ext {
 sourceSets {
     main {
         java {
+            // Including the Android Code this way until it is later released as a separate artifact
             srcDir '../dropbox-sdk-android/src/main/java'
         }
     }

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -246,8 +246,6 @@ dependencyUpdates.resolutionStrategy = {
     }
 }
 
-apply plugin: "com.dropbox.stone.java"
-
 generateStone {
     String unusedClassesToGenerate = 'AuthError, PathRoot, PathRootError, AccessError, RateLimitError'
     String packageName = 'com.dropbox.core.v2'


### PR DESCRIPTION
This overrides the generated source directory ONLY in this project's configuration.  This keeps the default value of the `outputDir` to be in `"${project.buildDir}/generated/source/stone/${sourceSet.name}"`