### PR TITLE
Release v5.4.1

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ 5.3.0 ]
 
 jobs:
   build:
@@ -17,27 +17,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
         java-version: '11'
         distribution: 'zulu'
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
         python-version: '3.9.10'
     - run: python -m pip install ply && pip install six
+
     - name: Grant execute permissions
       run: chmod +x gradlew && chmod +x update-submodules
             && chmod +x generate-ci-auth-file && chmod +x scripts/run-examples
+
     - name: Set up submodules
       run: ./update-submodules
+
     - name: Obtain access token
       env:
         APP_KEY: ${{ secrets.APP_KEY }}
         APP_SECRET: ${{ secrets.APP_SECRET }}
         REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
       run: ./generate-ci-auth-file
+
     - name: Run Examples
       run: ./scripts/run-examples $(find `pwd` -name auth_output)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ 5.3.0 ]
 
 jobs:
   build:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,12 @@
+## 5.4.1 (2022-09-27)
+---------------------------------------------
+- Republished `5.3.0` as `5.4.1` due to the premature publishing of `5.4.0`.
+- No other changes.
+
+## 5.4.0 (2022-09-26)
+---------------------------------------------
+- ⚠️ Published prematurely. Please stay on `5.3.0` or update to `5.4.1` (which is just a republished version of `5.3.0`)
+
 ## 5.3.0 (2022-07-20) [Milestone](https://github.com/dropbox/dropbox-sdk-java/milestone/1?closed=1)
 ---------------------------------------------
 - Update dropbox-api-spec to point to more recent version (July 13, 2022) [#400](https://github.com/dropbox/dropbox-sdk-java/pull/400)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -24,7 +24,7 @@ If you're using Maven, then edit your project's "pom.xml" and add this to the `<
 <dependency>
     <groupId>com.dropbox.core</groupId>
     <artifactId>dropbox-core-sdk</artifactId>
-    <version>5.2.0</version>
+    <version>5.4.1</version>
 </dependency>
 ```
 
@@ -33,7 +33,7 @@ If you are using Gradle, then edit your project's "build.gradle" and add this to
 ```groovy
 dependencies {
     // ...
-    implementation 'com.dropbox.core:dropbox-core-sdk:5.2.0'
+    implementation 'com.dropbox.core:dropbox-core-sdk:5.4.1'
 }
 ```
 

--- a/examples/DropboxAndroid/app/build.gradle
+++ b/examples/DropboxAndroid/app/build.gradle
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-    implementation group: 'com.dropbox.core', name: 'dropbox-core-sdk', version: '+', changing: true
+    implementation group: 'com.dropbox.core', name: 'dropbox-core-sdk', version: '5.3.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.7.0'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -14,7 +14,7 @@ subprojects {
     }
 
     dependencies {
-        implementation group: 'com.dropbox.core', name: 'dropbox-core-sdk', version: '+', changing: true
+        implementation group: 'com.dropbox.core', name: 'dropbox-core-sdk', version: '5.3.0'
     }
 
     compileJava {

--- a/examples/upload-file/src/main/java/com/dropbox/core/examples/upload_file/Main.java
+++ b/examples/upload-file/src/main/java/com/dropbox/core/examples/upload_file/Main.java
@@ -15,7 +15,6 @@ import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.v2.files.UploadErrorException;
 import com.dropbox.core.v2.files.UploadSessionCursor;
 import com.dropbox.core.v2.files.UploadSessionFinishErrorException;
-import com.dropbox.core.v2.files.UploadSessionLookupErrorException;
 import com.dropbox.core.v2.files.WriteMode;
 
 import java.io.File;
@@ -42,7 +41,7 @@ public class Main {
      * eliminates unnecessary round-trips to the servers.
      *
      * @param dbxClient Dropbox user authenticated client
-     * @param localFIle local file to upload
+     * @param localFile local file to upload
      * @param dropboxPath Where to upload the file to within Dropbox
      */
     private static void uploadFile(DbxClientV2 dbxClient, File localFile, String dropboxPath) {
@@ -74,7 +73,7 @@ public class Main {
      * to re-upload all the bytes).
      *
      * @param dbxClient Dropbox user authenticated client
-     * @param localFIle local file to upload
+     * @param localFile local file to upload
      * @param dropboxPath Where to upload the file to within Dropbox
      */
     private static void chunkedUploadFile(DbxClientV2 dbxClient, File localFile, String dropboxPath) {
@@ -158,21 +157,6 @@ public class Main {
                 thrown = ex;
                 // network issue with Dropbox (maybe a timeout?) try again
                 continue;
-            } catch (UploadSessionLookupErrorException ex) {
-                if (ex.errorValue.isIncorrectOffset()) {
-                    thrown = ex;
-                    // server offset into the stream doesn't match our offset (uploaded). Seek to
-                    // the expected offset according to the server and try again.
-                    uploaded = ex.errorValue
-                        .getIncorrectOffsetValue()
-                        .getCorrectOffset();
-                    continue;
-                } else {
-                    // Some other error occurred, give up.
-                    System.err.println("Error uploading to Dropbox: " + ex.getMessage());
-                    System.exit(1);
-                    return;
-                }
             } catch (UploadSessionFinishErrorException ex) {
                 if (ex.errorValue.isLookupFailed() && ex.errorValue.getLookupFailedValue().isIncorrectOffset()) {
                     thrown = ex;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # POM
 GROUP = com.dropbox.core
-VERSION_NAME=5.3.0
+VERSION_NAME=5.4.1
 
 POM_ARTIFACT_ID = dropbox-core-sdk
 POM_NAME = Dropbox SDK Java

--- a/src/main/java/com/dropbox/core/DbxSdkVersion.java
+++ b/src/main/java/com/dropbox/core/DbxSdkVersion.java
@@ -12,6 +12,6 @@ public class DbxSdkVersion
     // https://github.com/dropbox/dropbox-sdk-java/issues/357
     private static String loadVersion()
     {
-        return "5.3.0";
+        return "5.4.1";
     }
 }


### PR DESCRIPTION
# Contents of this `5.4.1` release are identical to `v5.3.0` except for version number.

**Why?** `5.4.0` was released prematurely published due to misconfiguration in a GitHub action.

