### PR TITLE
Fixes #456 and adds both login types to the sample app.

### DIFF
--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/Auth.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/Auth.kt
@@ -12,7 +12,7 @@ import com.dropbox.core.android.AuthActivity.Companion.makeIntent
 import com.dropbox.core.android.internal.DropboxAuthIntent
 import com.dropbox.core.oauth.DbxCredential
 import com.dropbox.core.util.StringUtil
-import java.util.*
+import java.util.Arrays
 
 /**
  * Helper class for integrating with [AuthActivity]
@@ -25,11 +25,15 @@ public class Auth {
          */
         @JvmStatic
         public fun startOAuth2Authentication(
-                context: Context,
-                appKey: String?,
-                ) {
+            context: Context,
+            appKey: String?,
+        ) {
             startOAuth2Authentication(
-                    context, appKey, null, null, null
+                context = context,
+                appKey = appKey,
+                desiredUid = null,
+                alreadyAuthedUids = null,
+                sessionId = null
             )
         }
 
@@ -38,16 +42,22 @@ public class Auth {
          */
         @JvmStatic
         public fun startOAuth2Authentication(
-                context: Context,
-                appKey: String?,
-                desiredUid: String?,
-                alreadyAuthedUids: Array<String>?,
-                sessionId: String?,
+            context: Context,
+            appKey: String?,
+            desiredUid: String?,
+            alreadyAuthedUids: Array<String>?,
+            sessionId: String?,
         ) {
             startOAuth2Authentication(
-                    context, appKey, desiredUid, alreadyAuthedUids, sessionId, "www.dropbox.com"
+                context = context,
+                appKey = appKey,
+                desiredUid = desiredUid,
+                alreadyAuthedUids = alreadyAuthedUids,
+                sessionId = sessionId,
+                webHost = "www.dropbox.com"
             )
         }
+
         /**
          *
          *
@@ -64,12 +74,16 @@ public class Auth {
             requestConfig: DbxRequestConfig?,
             scope: Collection<String?>? = null
         ) {
-            startOAuth2PKCE(context, appKey, requestConfig, null, scope)
+            startOAuth2PKCE(
+                context = context,
+                appKey = appKey,
+                requestConfig = requestConfig,
+                host = null,
+                scope = scope
+            )
         }
 
         /**
-         *
-         *
          * Starts the Dropbox OAuth process by launching the Dropbox official app (AKA DAuth) or web
          * browser if dropbox official app is not available. In browser flow, normally user needs to
          * sign in.
@@ -168,19 +182,20 @@ public class Auth {
                         " must ask for specific new scopes"
             }
             startOAuth2Authentication(
-                context,
-                appKey,
-                null,
-                null,
-                null,
-                null,
-                TokenAccessType.OFFLINE,
-                requestConfig,
-                host,
-                scope,
-                includeGrantedScopes
+                context = context,
+                appKey = appKey,
+                desiredUid = null,
+                alreadyAuthedUids = null,
+                sessionId = null,
+                webHost = null,
+                tokenAccessType = TokenAccessType.OFFLINE,
+                requestConfig = requestConfig,
+                host = host,
+                scope = scope,
+                includeGrantedScopes = includeGrantedScopes
             )
         }
+
         /**
          * Starts the Dropbox authentication process by launching an external app
          * (either the Dropbox app if available or a web browser) where the user
@@ -223,8 +238,15 @@ public class Auth {
             webHost: String?
         ) {
             startOAuth2Authentication(
-                context, appKey, desiredUid, alreadyAuthedUids, sessionId,
-                webHost, null, null, null
+                context = context,
+                appKey = appKey,
+                desiredUid = desiredUid,
+                alreadyAuthedUids = alreadyAuthedUids,
+                sessionId = sessionId,
+                webHost = webHost,
+                tokenAccessType = null,
+                requestConfig = null,
+                host = null
             )
         }
 

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -20,7 +20,6 @@ internal object DropboxAuthIntent {
         mState: AuthSessionViewModel.State,
         stateNonce: String,
         packageName: String,
-        queryParams: String,
         callingActivityFullyQualifiedClassName: String
     ): Intent {
         return buildActionAuthenticateIntent().apply {
@@ -32,7 +31,14 @@ internal object DropboxAuthIntent {
             putExtra(EXTRA_SESSION_ID, mState.mSessionId)
             putExtra(EXTRA_CALLING_PACKAGE, packageName)
             putExtra(EXTRA_AUTH_STATE, stateNonce)
+
             mState.mTokenAccessType?.apply {
+                val queryParams = QueryParamsUtil.createExtraQueryParams(
+                    tokenAccessType = mState.mTokenAccessType,
+                    scope = mState.mScope,
+                    includeGrantedScopes = mState.mIncludeGrantedScopes,
+                    pkceManagerCodeChallenge = mState.mPKCEManager.codeChallenge
+                )
                 // to support legacy DBApp with V1 flow with
                 putExtra(EXTRA_AUTH_QUERY_PARAMS, queryParams)
             }

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/BaseSampleActivity.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/BaseSampleActivity.kt
@@ -3,6 +3,9 @@ package com.dropbox.core.examples.android
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import com.dropbox.core.android.Auth
+import com.dropbox.core.examples.android.internal.api.DropboxApiWrapper
+import com.dropbox.core.examples.android.internal.api.DropboxCredentialUtil
+import com.dropbox.core.examples.android.internal.api.DropboxOAuthUtil
 import com.dropbox.core.examples.android.internal.di.AppGraph
 
 
@@ -12,13 +15,13 @@ import com.dropbox.core.examples.android.internal.di.AppGraph
  */
 abstract class BaseSampleActivity : AppCompatActivity() {
 
-    val appGraph: AppGraph get() = (this.applicationContext as DropboxAndroidSampleApplication).appGraph
+    private val appGraph: AppGraph get() = (this.applicationContext as DropboxAndroidSampleApplication).appGraph
 
-    protected val dropboxOAuthUtil get() = appGraph.dropboxOAuthUtil
+    protected val dropboxOAuthUtil: DropboxOAuthUtil get() = appGraph.dropboxOAuthUtil
 
-    protected val dropboxCredentialUtil get() = appGraph.dropboxCredentialUtil
+    private val dropboxCredentialUtil: DropboxCredentialUtil get() = appGraph.dropboxCredentialUtil
 
-    protected val dropboxApiWrapper get() = appGraph.dropboxApiWrapper
+    protected val dropboxApiWrapper: DropboxApiWrapper get() = appGraph.dropboxApiWrapper
 
     // will use our Short Lived Token.
     override fun onResume() {

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/HomeActivity.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/HomeActivity.kt
@@ -88,7 +88,8 @@ class HomeActivity : BaseSampleActivity() {
         fetchAccountInfo()
     }
 
-    private val loginButton get() = findViewById<Button>(R.id.login_button)
+    private val loginWithOAuth2PXCEButton get() = findViewById<Button>(R.id.login_button_pkce)
+    private val loginWithOAuth2Button get() = findViewById<Button>(R.id.login_button_oauth)
     private val logoutButton get() = findViewById<Button>(R.id.logout_button)
     private val uploadImageButton get() = findViewById<Button>(R.id.upload_button)
     private val accountPhoto get() = findViewById<ImageView>(R.id.account_photo)
@@ -103,8 +104,11 @@ class HomeActivity : BaseSampleActivity() {
 
     override fun onStart() {
         super.onStart()
-        loginButton.setOnClickListener {
-            dropboxOAuthUtil.startDropboxAuthorization(this)
+        loginWithOAuth2PXCEButton.setOnClickListener {
+            dropboxOAuthUtil.startDropboxAuthorization2PKCE(this)
+        }
+        loginWithOAuth2Button.setOnClickListener {
+            dropboxOAuthUtil.startDropboxAuthorizationOAuth2(this)
         }
         logoutButton.setOnClickListener {
             dropboxOAuthUtil.revokeDropboxAuthorization(dropboxApiWrapper)
@@ -125,7 +129,8 @@ class HomeActivity : BaseSampleActivity() {
             loggedInContent.visibility = View.VISIBLE
             logoutButton.visibility = View.VISIBLE
 
-            loginButton.visibility = View.GONE
+            loginWithOAuth2Button.visibility = View.GONE
+            loginWithOAuth2PXCEButton.visibility = View.GONE
 
             filesButton.isEnabled = true
             openWithButton.isEnabled = true
@@ -137,7 +142,8 @@ class HomeActivity : BaseSampleActivity() {
             typeText.visibility = View.GONE
             logoutButton.visibility = View.GONE
 
-            loginButton.visibility = View.VISIBLE
+            loginWithOAuth2Button.visibility = View.VISIBLE
+            loginWithOAuth2PXCEButton.visibility = View.VISIBLE
 
             uploadImageButton.isEnabled = false
             filesButton.isEnabled = false

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxOAuthUtil.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxOAuthUtil.kt
@@ -38,7 +38,7 @@ class DropboxOAuthUtil(
      * Because mobile apps need to keep Dropbox secrets in their binaries we need to use PKCE.
      * Read more about this here: https://dropbox.tech/developers/pkce--what-and-why-
      **/
-    fun startDropboxAuthorization(context: Context) {
+    fun startDropboxAuthorization2PKCE(context: Context) {
         val requestConfig = DbxRequestConfig(dropboxAppConfig.clientIdentifier)
 
         // The scope's your app will need from Dropbox
@@ -50,6 +50,19 @@ class DropboxOAuthUtil(
             "sharing.read"
         )
         Auth.startOAuth2PKCE(context, dropboxAppConfig.apiKey, requestConfig, scopes)
+        isAwaitingResult = true
+    }
+
+    /**
+     * Starts the Dropbox OAuth process by launching the Dropbox official app or web
+     * browser if dropbox official app is not available. In browser flow, normally user needs to
+     * sign in.
+     *
+     * Because mobile apps need to keep Dropbox secrets in their binaries we need to use PKCE.
+     * Read more about this here: https://dropbox.tech/developers/pkce--what-and-why-
+     **/
+    fun startDropboxAuthorizationOAuth2(context: Context) {
+        Auth.startOAuth2Authentication(context, dropboxAppConfig.apiKey)
         isAwaitingResult = true
     }
 

--- a/examples/android/src/main/res/layout/activity_home.xml
+++ b/examples/android/src/main/res/layout/activity_home.xml
@@ -20,14 +20,27 @@
             android:paddingRight="@dimen/activity_horizontal_margin"
             android:paddingBottom="@dimen/activity_vertical_margin">
 
-            <Button
-                android:id="@+id/login_button"
-                style="@style/ButtonStyle"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="16dp"
-                android:text="@string/login_with_dropbox"
-                tools:visibility="visible" />
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/login_button_pkce"
+                    style="@style/ButtonStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/login_with_dropbox_pkce"
+                    tools:visibility="visible" />
+
+                <Button
+                    android:id="@+id/login_button_oauth"
+                    style="@style/ButtonStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/login_with_dropbox_oauth"
+                    tools:visibility="visible" />
+            </LinearLayout>
 
             <RelativeLayout
                 android:id="@+id/logged_in_content"

--- a/examples/android/src/main/res/values/strings.xml
+++ b/examples/android/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Dropbox Java SDK Android Example</string>
     <string name="title_activity_files">Files</string>
     <string name="title_activity_openwith">Open With</string>
-    <string name="login_with_dropbox">Login with Dropbox</string>
+    <string name="login_with_dropbox_oauth">Login with Dropbox (OAuth2)</string>
+    <string name="login_with_dropbox_pkce">Login with Dropbox (OAuth2 PKCE)</string>
     <string name="logout_of_dropbox">Logout of Dropbox</string>
 </resources>


### PR DESCRIPTION
This will fix #456 

Also adds an additional button to launch the normal `OAuth2` flow or the `OAuth2 PKCE` flow.
<img width="200" alt="Screen Shot 2022-09-30 at 12 26 23 PM" src="https://user-images.githubusercontent.com/264948/193315181-c81ba8f8-4def-4638-ae1a-d71cc8445c5e.png">