### PR TITLE
Makes Kotlin compileOnly

### DIFF
--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compileOnly(dropboxJavaSdkLibs.okhttp2)  // support both v2 and v3 to avoid
     compileOnly(dropboxJavaSdkLibs.okhttp3) // method count bloat
     compileOnly(dropboxJavaSdkLibs.appengine.api)
+    compileOnly(dropboxJavaSdkLibs.kotlin.stdlib)
 
     testImplementation 'org.testng:testng:6.9.10'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/dropbox-sdk-java/dependencies/runtimeClasspath.txt
+++ b/dropbox-sdk-java/dependencies/runtimeClasspath.txt
@@ -1,6 +1,1 @@
 com.fasterxml.jackson.core:jackson-core:2.7.9
-org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21
-org.jetbrains.kotlin:kotlin-stdlib:1.6.21
-org.jetbrains:annotations:13.0


### PR DESCRIPTION
Kotlin is ONLY used in the Android code, so the kotlin dependency doesn't need to be included in non-android projects.

This makes Kotlin a compile only dependency for the primary artifact.  Will update instructions to show how the stdlib is needed when using Android.