### PR TITLE
5.4.2 Release & README Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ intellij/
 *.iml
 local.properties
 
-# Output file when rendering ReadMe.md locally.
+# Output file when rendering README.md locally.
 /ReadMe.html
 
 # editor temp files

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-## 5.4.0 (2022-09-26)
+## 5.4.2 (2022-10-03)
 ---------------------------------------------
 - Update dropbox-api-spec to point to more recent version (Sept 01, 2022) [#431](https://github.com/dropbox/dropbox-sdk-java/pull/431)
 - Generated stone api code is now checked into repository for greater visibility of spec changes [#418](https://github.com/dropbox/dropbox-sdk-java/pull/418)
@@ -7,13 +7,21 @@
 - Refactored codebase to have multiple modules (sdk-android, sdk-java, examples) [#425](https://github.com/dropbox/dropbox-sdk-java/pull/425)
 - Examples module now uses `/dropbox-sdk-java` instead of published maven artifact, enabling an easier development loop [#426](https://github.com/dropbox/dropbox-sdk-java/pull/426)
 - Moved android code from `dropbox-sdk-java` into `dropbox-sdk-android` [#429](https://github.com/dropbox/dropbox-sdk-java/pull/429)
-- Converted Java code to Kotlin in `dropbox-sdk-android` while maintaining binary compatibility. [#430](https://github.com/dropbox/dropbox-sdk-java/pull/430) 
+- Converted Java code to Kotlin in `dropbox-sdk-android` while mostly maintaining binary compatibility. [#430](https://github.com/dropbox/dropbox-sdk-java/pull/430) 
 - Binary Compatibility Changes since `v5.3.0`[#449](https://github.com/dropbox/dropbox-sdk-java/pull/449) ([see changes](https://github.com/dropbox/dropbox-sdk-java/pull/441/commits/fd9b0a56152d72cd8310c849dbbe42ee239ff371?diff=unified&w=0)):
   - The following classes are now `final` and cannot be extended. 
     - `com.dropbox.core.android.Auth`
     - `com.dropbox.core.android.DbxOfficialAppConnector`
   - In `com.dropbox.core.android.AuthActivity`, constants for the Intent Extra Keys were moved to `com.dropbox.core.android.internal.DropboxAuthIntent`
 - Fixed NPE bug in login flow [#347](https://github.com/dropbox/dropbox-sdk-java/issues/347)
+
+5.4.1 (2022-09-27)
+---------------------------------------------
+- Republished 5.3.0 due to premature release of 5.4.0
+
+5.4.0 (2022-09-26)
+---------------------------------------------
+- Published prematurely due to misconfiguration of GH Action, do not use.
 
 5.3.0 (2022-07-20) [Milestone](https://github.com/dropbox/dropbox-sdk-java/milestone/1?closed=1)
 ---------------------------------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,15 @@
+## 5.4.0 (2022-09-20)
+---------------------------------------------
+- Update dropbox-api-spec to point to more recent version (Sept 01, 2022) [#431](https://github.com/dropbox/dropbox-sdk-java/pull/431)
+- Generated stone api code is now checked into repository for greater visibility of spec changes [#418](https://github.com/dropbox/dropbox-sdk-java/pull/418)
+- Changed from `master` -> `main` [#424](https://github.com/dropbox/dropbox-sdk-java/pull/424)
+- Created android artifact and added gradle version catalog [#414](https://github.com/dropbox/dropbox-sdk-java/pull/414)
+- Refactored codebase to have multiple modules (sdk-android, sdk-java, examples) [#425](https://github.com/dropbox/dropbox-sdk-java/pull/425)
+- Examples module now uses `/dropbox-sdk-java` instead of published maven artifact, enabling an easier development loop [#426](https://github.com/dropbox/dropbox-sdk-java/pull/426)
+- Moved android code from `dropbox-sdk-java` into `dropbox-sdk-android` [#429](https://github.com/dropbox/dropbox-sdk-java/pull/429)
+- Converted Java code to Kotlin in `dropbox-sdk-android` while maintaining binary compatibility. [#430](https://github.com/dropbox/dropbox-sdk-java/pull/430) 
+
+
 ## 5.3.0 (2022-07-20) [Milestone](https://github.com/dropbox/dropbox-sdk-java/milestone/1?closed=1)
 ---------------------------------------------
 - Update dropbox-api-spec to point to more recent version (July 13, 2022) [#400](https://github.com/dropbox/dropbox-sdk-java/pull/400)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,8 @@
 ---------------------------------------------
 - Update dropbox-api-spec to point to more recent version (Sept 01, 2022) [#431](https://github.com/dropbox/dropbox-sdk-java/pull/431)
 - Generated stone api code is now checked into repository for greater visibility of spec changes [#418](https://github.com/dropbox/dropbox-sdk-java/pull/418)
-- Changed from `master` -> `main` [#424](https://github.com/dropbox/dropbox-sdk-java/pull/424)
-- Created android artifact and added gradle version catalog [#414](https://github.com/dropbox/dropbox-sdk-java/pull/414)[#436](https://github.com/dropbox/dropbox-sdk-java/pull/436)
-- Refactored codebase to have multiple modules (sdk-android, sdk-java, examples) [#425](https://github.com/dropbox/dropbox-sdk-java/pull/425)
-- Examples module now uses `/dropbox-sdk-java` instead of published maven artifact, enabling an easier development loop [#426](https://github.com/dropbox/dropbox-sdk-java/pull/426)
+- Renamed `master` -> `main` [#424](https://github.com/dropbox/dropbox-sdk-java/pull/424)
+- Added gradle version catalog [#414](https://github.com/dropbox/dropbox-sdk-java/pull/414)[#436](https://github.com/dropbox/dropbox-sdk-java/pull/436)
 - Moved android code from `dropbox-sdk-java` into `dropbox-sdk-android` [#429](https://github.com/dropbox/dropbox-sdk-java/pull/429)
 - Converted Java code to Kotlin in `dropbox-sdk-android` while mostly maintaining binary compatibility. [#430](https://github.com/dropbox/dropbox-sdk-java/pull/430) 
 - Binary Compatibility Changes since `v5.3.0`[#449](https://github.com/dropbox/dropbox-sdk-java/pull/449) ([see changes](https://github.com/dropbox/dropbox-sdk-java/pull/441/commits/fd9b0a56152d72cd8310c849dbbe42ee239ff371?diff=unified&w=0)):

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,16 +1,21 @@
-## 5.4.0 (2022-09-20)
+## 5.4.0 (2022-09-26)
 ---------------------------------------------
 - Update dropbox-api-spec to point to more recent version (Sept 01, 2022) [#431](https://github.com/dropbox/dropbox-sdk-java/pull/431)
 - Generated stone api code is now checked into repository for greater visibility of spec changes [#418](https://github.com/dropbox/dropbox-sdk-java/pull/418)
 - Changed from `master` -> `main` [#424](https://github.com/dropbox/dropbox-sdk-java/pull/424)
-- Created android artifact and added gradle version catalog [#414](https://github.com/dropbox/dropbox-sdk-java/pull/414)
+- Created android artifact and added gradle version catalog [#414](https://github.com/dropbox/dropbox-sdk-java/pull/414)[#436](https://github.com/dropbox/dropbox-sdk-java/pull/436)
 - Refactored codebase to have multiple modules (sdk-android, sdk-java, examples) [#425](https://github.com/dropbox/dropbox-sdk-java/pull/425)
 - Examples module now uses `/dropbox-sdk-java` instead of published maven artifact, enabling an easier development loop [#426](https://github.com/dropbox/dropbox-sdk-java/pull/426)
 - Moved android code from `dropbox-sdk-java` into `dropbox-sdk-android` [#429](https://github.com/dropbox/dropbox-sdk-java/pull/429)
 - Converted Java code to Kotlin in `dropbox-sdk-android` while maintaining binary compatibility. [#430](https://github.com/dropbox/dropbox-sdk-java/pull/430) 
+- Binary Compatibility Changes since `v5.3.0`[#449](https://github.com/dropbox/dropbox-sdk-java/pull/449) ([see changes](https://github.com/dropbox/dropbox-sdk-java/pull/441/commits/fd9b0a56152d72cd8310c849dbbe42ee239ff371?diff=unified&w=0)):
+  - The following classes are now `final` and cannot be extended. 
+    - `com.dropbox.core.android.Auth`
+    - `com.dropbox.core.android.DbxOfficialAppConnector`
+  - In `com.dropbox.core.android.AuthActivity`, constants for the Intent Extra Keys were moved to `com.dropbox.core.android.internal.DropboxAuthIntent`
+- Fixed NPE bug in login flow [#347](https://github.com/dropbox/dropbox-sdk-java/issues/347)
 
-
-## 5.3.0 (2022-07-20) [Milestone](https://github.com/dropbox/dropbox-sdk-java/milestone/1?closed=1)
+5.3.0 (2022-07-20) [Milestone](https://github.com/dropbox/dropbox-sdk-java/milestone/1?closed=1)
 ---------------------------------------------
 - Update dropbox-api-spec to point to more recent version (July 13, 2022) [#400](https://github.com/dropbox/dropbox-sdk-java/pull/400)
 - The generateStone Gradle Task now supports Gradle Configuration Caching [#390](https://github.com/dropbox/dropbox-sdk-java/pull/390)

--- a/README.md
+++ b/README.md
@@ -262,18 +262,34 @@ To run individual tests, use the `--tests` gradle test filter:
 ./gradlew -Pcom.dropbox.test.authInfoFile=<path-to-test.auth> integrationTest --tests '*.DbxClientV1IT.testAccountInfo'
 ```
 
-## Android 11 Updates
+## Usage on Android
 
-In the event you are using the Android-specific code in this library (i.e. the code in `com.dropbox.core.android` package), you will need to add some code to your `AndroidManifest.xml` when you bump your target SDK version to 30. If your app does not use this code, you can ignore this section.
+Android support *** CALL OUT METHODS USED TO AUTHENTICATE ***
 
-When targeting/running on Android 11 (targetSdk 30 in your app's `build.gradle`), the Android OS will restrict what installed apps your app can query for through the `PackageManager`. Since the android code in this library queries for the official Dropbox app, those restrictions will affect your app when you target SDK 30. In particular, if you don't declare that your app queries for the official Dropbox app, then you will see crashes when you hit the code that talks to the official Dropbox app.
+### Required Dependencies For Android
+The Android code in this SDK is written in Kotlin and is now a runtime dependency. If you do not already have Kotlin in your project, you will need to add `implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.21")` to your dependencies block.
 
-To resolve the issue, add the following to your `AndroidManifest.xml`
+The last published version without Kotlin is `5.3.0`. All future Android code will be written in Kotlin.
 
+### `AndroidManifest.xml`
+
+The following two entries may need to be added to your `AndroidManifest.xml` depending on your target SDK level.
+
+For SDK levels >= `30`
 ```xml
 <queries>
     <package android:name="com.dropbox.android" />
 </queries>
+```
+
+For SDK levels >= `33`
+
+See [#406](https://github.com/dropbox/dropbox-sdk-java/issues/406) for context
+```xml
+<intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+</intent-filter>
 ```
 
 We are working on pulling out this Android-specific code into its own android library with an `AndroidManifest.xml` that can be merged with your existing manifest, but in the meantime, this will work.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# ⚠️ Please use version `5.3.0` or `5.4.1` (These versions are identical).   Version `5.4.0` was published prematurely due to a scripting misconfiguration. A follow up release is actively being worked on and will be released during this week (September 27th-30th).  Thank you! ⚠️
-
 # Dropbox Core SDK for Java
 
 ![GitHub](https://img.shields.io/github/license/dropbox/dropbox-sdk-java)
@@ -10,7 +8,7 @@ A Java library to access [Dropbox's HTTP-based Core API v2](https://www.dropbox.
 
 License: [MIT](License.txt)
 
-Documentation: [Javadocs](https://dropbox.github.io/dropbox-sdk-java/api-docs/v5.4.0/)
+Documentation: [Javadocs](https://dropbox.github.io/dropbox-sdk-java/api-docs/v5.4.2/)
 
 ## Setup
 
@@ -26,7 +24,7 @@ If you're using Maven, then edit your project's "pom.xml" and add this to the `<
 <dependency>
     <groupId>com.dropbox.core</groupId>
     <artifactId>dropbox-core-sdk</artifactId>
-    <version>5.4.0</version>
+    <version>5.4.2</version>
 </dependency>
 ```
 
@@ -35,7 +33,7 @@ If you are using Gradle, then edit your project's "build.gradle" and add this to
 ```groovy
 dependencies {
     // ...
-    implementation 'com.dropbox.core:dropbox-core-sdk:5.4.0'
+    implementation 'com.dropbox.core:dropbox-core-sdk:5.4.2'
 }
 ```
 
@@ -161,9 +159,8 @@ public class Main {
 
 Some more complete examples can be found here:
 
-* Example for a simple web app: [Web File Browser example](examples/web-file-browser/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxAuth.java)
+* Example for a simple web app: [Web File Browser example](examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxAuth.java)
 * Example for an Android app written in Kotlin: [Android Kotlin Example](examples/android)
-* Example for a command-line tool: [Command-Line Authorization example](examples/authorize/src/main/java/com/dropbox/core/examples/authorize/Main.java)
 
 To try out running these examples, please follow the instructions below.
 
@@ -292,7 +289,7 @@ Example in Gradle:
 ```gradle
 dependencies {
     // ...
-    api 'com.squareup.okhttp3:okhttp:3.11.0'
+    api 'com.squareup.okhttp3:okhttp:4.0.0'
 }
 ```
 
@@ -301,16 +298,16 @@ dependencies {
 The JAR's manifest has the following line:
 
 ```
-Require-Capability: osgi.ee;filter="(&(osgi.ee=JavaSE)(version=1.6))"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
 ```
 
-OSGi containers running on Java 1.6 or above should provide this capability.  Unfortunately, some OSGi containers don't do this correctly and will reject the bundle JAR in the OSGi subsystem context.
+Most OSGi containers should provide this capability.  Unfortunately, some OSGi containers don't do this correctly and will reject the bundle JAR in the OSGi subsystem context.
 
 As a workaround, you can build your own version of the JAR that omits the "osgi.ee" capability by running:
 
 ```shell
 ./gradlew clean
-./gradlew -Posgi.bnd.noee=true jar
+./gradlew -Posgi.bnd.noee=true :dropbox-sdk-java:jar
 ```
 
 (This is equivalent to passing the "-noee" option to the OSGi "bnd" tool.)
@@ -334,5 +331,3 @@ Versions 2.0.0-2.0.3 of this SDK require SDK-specific ProGuard rules when shrink
 -dontwarn javax.servlet.**
 -dontwarn org.apache.**
 ```
-
-**IMPORTANT: If you are running version 2.0.x before 2.0.3, you should update to the latest Dropbox SDK version to avoid a deserialization bug that can cause Android apps that use ProGuard to crash.**

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Releasing
  1. Update the top level [gradle.properties](gradle.properties) to a non-SNAPSHOT version.
  2. Update [DbxSdkVersion.java](DbxSdkVersion.java) to a non-SNAPSHOT version.
  3. Update the [ChangeLog.md](ChangeLog.md) for the impending release.
- 4. Update the [ReadMe.md](ReadMe.md) with the new version.
+ 4. Update the [README.md](README.md) with the new version.
  5. `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
  6. `git tag -a vX.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
     * Run `git tag` to verify it

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,7 +10,7 @@ A Java library to access [Dropbox's HTTP-based Core API v2](https://www.dropbox.
 
 License: [MIT](License.txt)
 
-Documentation: [Javadocs](https://dropbox.github.io/dropbox-sdk-java/api-docs/v5.3.0/)
+Documentation: [Javadocs](https://dropbox.github.io/dropbox-sdk-java/api-docs/v5.4.0/)
 
 ## Setup
 
@@ -26,7 +26,7 @@ If you're using Maven, then edit your project's "pom.xml" and add this to the `<
 <dependency>
     <groupId>com.dropbox.core</groupId>
     <artifactId>dropbox-core-sdk</artifactId>
-    <version>5.3.0</version>
+    <version>5.4.0</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@ If you are using Gradle, then edit your project's "build.gradle" and add this to
 ```groovy
 dependencies {
     // ...
-    implementation 'com.dropbox.core:dropbox-core-sdk:5.3.0'
+    implementation 'com.dropbox.core:dropbox-core-sdk:5.4.0'
 }
 ```
 

--- a/dropbox-sdk-java/src/main/java/com/dropbox/core/DbxSdkVersion.java
+++ b/dropbox-sdk-java/src/main/java/com/dropbox/core/DbxSdkVersion.java
@@ -12,6 +12,6 @@ public class DbxSdkVersion
     // https://github.com/dropbox/dropbox-sdk-java/issues/357
     private static String loadVersion()
     {
-        return "5.4.2-SNAPSHOT";
+        return "5.4.2";
     }
 }

--- a/examples/android/ReadMe.md
+++ b/examples/android/ReadMe.md
@@ -13,7 +13,7 @@ Prerequisites: Apache Maven (to build the SDK), [Android Studio](http://develope
 1. Download this repository.
 2. Build the SDK: run `./gradlew build` in the SDK root directory (two levels up from this folder).
 3. In Android Studio, choose "Import Project" and select this folder.
-4. Edit local.properties and add `DROPBOX_APP_KEY=YOUR_KEY_HERE` with your Dropbox API key ([how to get a Dropbox API key](../../ReadMe.md#get-a-dropbox-api-key)).
+4. Edit local.properties and add `DROPBOX_APP_KEY=YOUR_KEY_HERE` with your Dropbox API key ([how to get a Dropbox API key](../../README.md#get-a-dropbox-api-key)).
 5. Build and run.
 
 If you don't have Android Studio, you can use the command-line:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # POM
 GROUP = com.dropbox.core
-VERSION_NAME=5.4.2-SNAPSHOT
+VERSION_NAME=5.4.2
 
 POM_NAME = Dropbox SDK Java
 POM_DESCRIPTION = A Java library to access Dropbox's HTTP-based Core API v2.


### PR DESCRIPTION
To Add:
* Android is in Kotlin and Requires Kotlin 1.6.21+ (that's what it was compiled against)
* How to avoid the bug that has been reported regarding intent filters.