### PR TITLE
Create a Java Only Example

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,7 +63,7 @@ jobs:
       run: ./gradlew check
 
     - name: Run Integration Tests for Examples
-      run: ./gradlew :examples:examples:test -Pci=true --info
+      run: ./gradlew :examples:examples:test :examples:java:test -Pci=true --info
 
     - name: Run Integration Tests - OkHttpRequestor
       run: ./gradlew -Pcom.dropbox.test.httpRequestor=OkHttpRequestor -Pcom.dropbox.test.authInfoFile=../auth_output integrationTest &&

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -36,16 +36,16 @@ sourceSets {
 }
 
 dependencies {
-    // Important: Jackson 2.8+ will be free to use JDK7 features and no longer guarantees JDK6
-    //            compatibility
     api(dropboxJavaSdkLibs.jackson.core)
 
+    // Android
     compileOnly 'com.google.android:android:4.1.1.4' // Until 6.x when we have an Android Artifact
+    compileOnly(dropboxJavaSdkLibs.kotlin.stdlib) // Only used in Android Code
+
     compileOnly(dropboxJavaSdkLibs.servlet.api)
     compileOnly(dropboxJavaSdkLibs.okhttp2)  // support both v2 and v3 to avoid
     compileOnly(dropboxJavaSdkLibs.okhttp3) // method count bloat
     compileOnly(dropboxJavaSdkLibs.appengine.api)
-    compileOnly(dropboxJavaSdkLibs.kotlin.stdlib)
 
     testImplementation 'org.testng:testng:6.9.10'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/examples/examples/src/main/java/com/dropbox/core/examples/CredentialsUtil.kt
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/CredentialsUtil.kt
@@ -62,6 +62,10 @@ object CredentialsUtil {
         return DbxCredential(accessToken)
     }
 
+    /**
+     * JSON file that is generated at auth_output when the ./generate-ci-auth-file script is run
+     * with the required parameters.  This is read in CI during integration tests.
+     */
     private val authOutputFile = File("../../auth_output")
 
     fun getDbxCredential(): DbxCredential {

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -1,5 +1,11 @@
 plugins {
     id("java")
+    id("com.dropbox.dependency-guard")
+}
+
+dependencyGuard {
+    configuration("compileClasspath")
+    configuration("runtimeClasspath")
 }
 
 description = 'Java Examples'

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id("java")
+}
+
+description = 'Java Examples'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+dependencies {
+    implementation(project(":dropbox-sdk-java"))
+
+    testImplementation(dropboxJavaSdkLibs.test.junit)
+}
+
+test {
+    // Uses the "ci" gradle property and sets it as an environment variable for the test
+    environment("ci", project.findProperty("ci"))
+
+    // Ensure that tests are always run because integration tests are non-deterministic
+    outputs.upToDateWhen { false }
+}

--- a/examples/java/dependencies/compileClasspath.txt
+++ b/examples/java/dependencies/compileClasspath.txt
@@ -1,0 +1,1 @@
+com.fasterxml.jackson.core:jackson-core:2.7.9

--- a/examples/java/dependencies/runtimeClasspath.txt
+++ b/examples/java/dependencies/runtimeClasspath.txt
@@ -1,0 +1,1 @@
+com.fasterxml.jackson.core:jackson-core:2.7.9

--- a/examples/java/src/main/java/com/dropbox/core/examples/CredentialsUtil.java
+++ b/examples/java/src/main/java/com/dropbox/core/examples/CredentialsUtil.java
@@ -1,0 +1,43 @@
+package com.dropbox.core.examples;
+
+import com.dropbox.core.DbxAuthInfo;
+import com.dropbox.core.json.JsonReader;
+import com.dropbox.core.oauth.DbxCredential;
+
+import java.io.File;
+
+public final class CredentialsUtil {
+    /**
+     * JSON file that is generated at auth_output when the ./generate-ci-auth-file script is run
+     * with the required parameters.  This is read in CI during integration tests.
+     */
+    public static final File authOutputFile = new File("../../auth_output");
+
+    public static DbxCredential getDbxCredential() {
+        try {
+            return DbxCredential.Reader.readFromFile(authOutputFile);
+        } catch (JsonReader.FileLoadException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public final DbxAuthInfo getAuthInfo() {
+        try {
+            return DbxAuthInfo.Reader.readFromFile(authOutputFile);
+        } catch (JsonReader.FileLoadException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static final class OAuth2TokenInputs {
+        public final String appKey;
+        public final String appSecret;
+        public final String refreshToken;
+
+        public OAuth2TokenInputs(String appKey, String appSecret, String refreshToken) {
+            this.appKey = appKey;
+            this.appSecret = appSecret;
+            this.refreshToken = refreshToken;
+        }
+    }
+}

--- a/examples/java/src/main/java/com/dropbox/core/examples/account_info/AccountInfoExample.java
+++ b/examples/java/src/main/java/com/dropbox/core/examples/account_info/AccountInfoExample.java
@@ -1,0 +1,29 @@
+package com.dropbox.core.examples.account_info;
+
+import com.dropbox.core.DbxException;
+import com.dropbox.core.DbxRequestConfig;
+import com.dropbox.core.examples.CredentialsUtil;
+import com.dropbox.core.oauth.DbxCredential;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.users.FullAccount;
+
+
+public final class AccountInfoExample {
+
+    public static void main(String[] args) {
+        DbxCredential credential = CredentialsUtil.getDbxCredential();
+        new AccountInfoExample().runExample(credential);
+    }
+
+    public void runExample(DbxCredential credential) {
+        DbxRequestConfig requestConfig = new DbxRequestConfig("examples-account-info");
+        DbxClientV2 dbxClient = new DbxClientV2(requestConfig, credential);
+
+        try {
+            FullAccount dbxAccountInfo = dbxClient.users().getCurrentAccount();
+            System.out.println(dbxAccountInfo.toStringMultiline());
+        } catch (DbxException ex) {
+            throw new RuntimeException("Error making API call: " + ex.getMessage());
+        }
+    }
+}

--- a/examples/java/src/test/java/com/dropbox/core/examples/account_info/AccountInfoExampleTest.java
+++ b/examples/java/src/test/java/com/dropbox/core/examples/account_info/AccountInfoExampleTest.java
@@ -1,0 +1,23 @@
+package com.dropbox.core.examples.account_info;
+
+import static org.junit.Assume.assumeTrue;
+
+import com.dropbox.core.examples.CredentialsUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AccountInfoExampleTest {
+
+    @Before
+    public void setup() {
+        // Only run if this is running in CI
+        Boolean isRunningInCI = System.getenv("ci").equals("true");
+        assumeTrue(isRunningInCI);
+    }
+
+    @Test
+    public void accountInfo() {
+        new AccountInfoExample().runExample(CredentialsUtil.getDbxCredential());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ include ':proguard'
 include ':dropbox-sdk-java'
 include ':examples:android'
 include ':examples:examples'
+include ':examples:java'
 
 dependencyResolutionManagement {
     versionCatalogs {


### PR DESCRIPTION
I wanted to ensure everything works when this is just consumed via Java even though we added in Kotlin.  All the Kotlin code is isolated to Android, so it will be an additionally required dependency for Android users.