### PR TITLE
Send Java SDK & Target SDK Versions In App2App Auth

### DIFF
--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/AuthActivity.kt
@@ -119,10 +119,9 @@ public open class AuthActivity : Activity() {
 
         // Create intent to auth with official app.
         val officialAuthIntent = DropboxAuthIntent.buildOfficialAuthIntent(
-            callingActivityFullyQualifiedClassName = this@AuthActivity::class.java.name,
+            authActivity = this@AuthActivity,
             mState = mState,
             stateNonce = stateNonce,
-            packageName = this@AuthActivity.packageName
         )
 
         /*

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -48,7 +48,7 @@ internal object DropboxAuthIntent {
             putExtra(EXTRA_SESSION_ID, mState.mSessionId)
             putExtra(EXTRA_CALLING_PACKAGE, packageName)
             putExtra(EXTRA_AUTH_STATE, stateNonce)
-            putExtra(EXTRA_JAVA_SDK_VERSION, DbxSdkVersion.Version)
+            putExtra(EXTRA_DROPBOX_SDK_JAVA_VERSION, DbxSdkVersion.Version)
             authActivity.getTargetSdkVersion()?.let { targetSdkVersion ->
                 putExtra(EXTRA_TARGET_SDK_VERSION, targetSdkVersion)
             }
@@ -117,14 +117,14 @@ internal object DropboxAuthIntent {
     const val EXTRA_AUTH_STATE: String = "AUTH_STATE"
 
     /**
-     * Used for internal authentication logic. You won't ever have to use this.
+     * Used for internal authentication logic. The targetSdk version of the application using the Dropbox SDK Java.
      */
     const val EXTRA_TARGET_SDK_VERSION: String = "TARGET_SDK_VERSION"
 
     /**
-     * Used for internal authentication logic. You won't ever have to use this.
+     * Used for internal authentication logic. The version of this Dropbox SDK Java.
      */
-    const val EXTRA_JAVA_SDK_VERSION: String = "JAVA_SDK_VERSION"
+    const val EXTRA_DROPBOX_SDK_JAVA_VERSION: String = "DROPBOX_SDK_JAVA_VERSION"
 
     /**
      * Used for internal authentication. Allows app to request a specific UID to auth against

--- a/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/dropbox-sdk-android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -1,6 +1,10 @@
 package com.dropbox.core.android.internal
 
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.dropbox.core.DbxSdkVersion
 import com.dropbox.core.android.AuthActivity
 
 internal object DropboxAuthIntent {
@@ -12,6 +16,16 @@ internal object DropboxAuthIntent {
             }
     }
 
+    fun Context.getTargetSdkVersion(): Int? {
+        return try {
+            val packageInfo: PackageInfo = packageManager.getPackageInfo(packageName, 0)
+            val targetSdkVersion: Int = packageInfo.applicationInfo.targetSdkVersion
+            targetSdkVersion
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     /**
      * @return Intent to auth with official app
      * Extras should be filled in by callee
@@ -19,9 +33,12 @@ internal object DropboxAuthIntent {
     fun buildOfficialAuthIntent(
         mState: AuthSessionViewModel.State,
         stateNonce: String,
-        packageName: String,
-        callingActivityFullyQualifiedClassName: String
+        authActivity: AuthActivity,
     ): Intent {
+
+        val callingActivityFullyQualifiedClassName = authActivity::class.java.name
+        val packageName = authActivity.packageName
+
         return buildActionAuthenticateIntent().apply {
             putExtra(EXTRA_CONSUMER_KEY, mState.mAppKey)
             putExtra(EXTRA_CONSUMER_SIG, "")
@@ -31,6 +48,10 @@ internal object DropboxAuthIntent {
             putExtra(EXTRA_SESSION_ID, mState.mSessionId)
             putExtra(EXTRA_CALLING_PACKAGE, packageName)
             putExtra(EXTRA_AUTH_STATE, stateNonce)
+            putExtra(EXTRA_JAVA_SDK_VERSION, DbxSdkVersion.Version)
+            authActivity.getTargetSdkVersion()?.let { targetSdkVersion ->
+                putExtra(EXTRA_TARGET_SDK_VERSION, targetSdkVersion)
+            }
 
             mState.mTokenAccessType?.apply {
                 val queryParams = QueryParamsUtil.createExtraQueryParams(
@@ -94,6 +115,16 @@ internal object DropboxAuthIntent {
      * Used for internal authentication. You won't ever have to use this.
      */
     const val EXTRA_AUTH_STATE: String = "AUTH_STATE"
+
+    /**
+     * Used for internal authentication logic. You won't ever have to use this.
+     */
+    const val EXTRA_TARGET_SDK_VERSION: String = "TARGET_SDK_VERSION"
+
+    /**
+     * Used for internal authentication logic. You won't ever have to use this.
+     */
+    const val EXTRA_JAVA_SDK_VERSION: String = "JAVA_SDK_VERSION"
 
     /**
      * Used for internal authentication. Allows app to request a specific UID to auth against


### PR DESCRIPTION
Sending additional information (targetSdk and Java Sdk Versions) to the Dropbox App during authentication.

Here is a debug printout of one of these intents now:
```
15:19:10.442  I  --- Intent ---
15:19:10.442  I  type: null
15:19:10.442  I  package: com.dropbox.android
15:19:10.442  I  scheme: null
15:19:10.442  I  component: ComponentInfo{com.dropbox.android/com.dropbox.android.activity.auth.DropboxAuth}
15:19:10.442  I  flags: 0
15:19:10.442  I  categories: null
15:19:10.442  I  selector: null
15:19:10.442  I  action: com.dropbox.android.AUTHENTICATE_V2
15:19:10.442  I  dataString: null
15:19:10.442  I  * extra: DESIRED_UID=null
15:19:10.442  I  * extra: TARGET_SDK_VERSION=33
15:19:10.442  I  * extra: AUTH_STATE=oauth2code:vmiHjrnoF62FMETwoyHHlOJ-DLPldBOq5BHfRWCKHCA:S256:offline:account_info.read files.content.write files.content.read sharing.read
15:19:10.442  I  * extra: DROPBOX_SDK_JAVA_VERSION=5.4.3-SNAPSHOT
15:19:10.442  I  * extra: ALREADY_AUTHED_UIDS=[Ljava.lang.String;@e6ab6d7
15:19:10.442  I  * extra: CONSUMER_KEY=...
15:19:10.442  I  * extra: CONSUMER_SIG=
15:19:10.442  I  * extra: CALLING_CLASS=com.dropbox.core.android.AuthActivity
15:19:10.442  I  * extra: AUTH_QUERY_PARAMS=code_challenge=...&code_challenge_method=S256&token_access_type=offline&response_type=code&scope=account_info.read files.content.write files.content.read sharing.read
15:19:10.442  I  * extra: CALLING_PACKAGE=com.dropbox.core.examples.android
15:19:10.442  I  * extra: SESSION_ID=null
```