### PR TITLE
Support Target SDK 33 in Sample App

### DIFF
--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId "com.dropbox.core.examples.android"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 

--- a/examples/android/src/main/AndroidManifest.xml
+++ b/examples/android/src/main/AndroidManifest.xml
@@ -39,6 +39,11 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <!-- Additional intent-filter required as a workaround for Apps using targetSdk=33 until the fix in the Dropbox app is available to all users. https://github.com/dropbox/dropbox-sdk-java/issues/406 -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".OpenWithActivity"


### PR DESCRIPTION
Updated sample app to include the workaround recommended for the issue https://github.com/dropbox/dropbox-sdk-java/issues/406