### PR TITLE
Make Kotlin optional in OSGI Import-Package statement

### DIFF
--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -203,6 +203,7 @@ jar {
                 'com.squareup.okhttp;resolution:=optional',
                 'okhttp3;resolution:=optional',
                 'okio;resolution:=optional',
+                'kotlin.*;resolution:=optional',
                 '*'
 
         def noeeProp = 'osgi.bnd.noee'


### PR DESCRIPTION
## Motivation

For now, even if we don't need Kotlin, we have to add it as dependency when using dropbox-sdk-java in an OSGI bundle.

## Modifications:

* Define all kotlin packages as optional