### PR TITLE
Update java.stoneg.py for python 3.10 compatability

### DIFF
--- a/dropbox-sdk-java/generator/java/java.stoneg.py
+++ b/dropbox-sdk-java/generator/java/java.stoneg.py
@@ -9,7 +9,13 @@ import six
 import sys
 import types
 
-from collections import defaultdict, OrderedDict, Sequence
+from collections import defaultdict, OrderedDict
+
+if sys.version_info >= (3, 10):
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
+
 from contextlib import contextmanager
 from functools import (
     partial,


### PR DESCRIPTION
Python 3.10 moved the Sequence package. This PR reflects the new location and maintains backwards compatibility.