### PR TITLE
move to jakarta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 5.4.6-SNAPSHOT
+## 6.0.0-SNAPSHOT
+- Updated to `jakarta.servlet` to unblock adoption of Spring Boot v3, **this is a breaking change if you use `DbxSessionStore`.**
 - Added better error messaging when trying to build the project without submodules initialized.
+- Improved generateStone task to properly declare inputs and outputs
 - Removed obsolete javadoc flag
 - Updated test dependencies
+- Updated to Gradle 7.6.2
 - Removed redundant gradle wrappers
 
 ## 5.4.5 (2023-05-16)

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Another workaround is to tell your OSGi container to provide that requirement: [
 
 ### Does this SDK require any special ProGuard rules for shrink optimizations?
 
-Versions 2.0.0-2.0.3 of this SDK require SDK-specific ProGuard rules when shrinking is enabled. However, since version **2.0.4**, the only ProGuard rules necessary are for the SDK's required and optional dependencies. If you encounter ProGuard warnings, consider adding the following "-dontwarn" directives to your ProGuard configuration file:
+The only ProGuard rules necessary are for the SDK's required and optional dependencies. If you encounter ProGuard warnings, consider adding the following "-dontwarn" directives to your ProGuard configuration file:
 
 ```
 -dontwarn okio.**

--- a/dropbox-sdk-java/api/dropbox-sdk-java.api
+++ b/dropbox-sdk-java/api/dropbox-sdk-java.api
@@ -218,11 +218,11 @@ public abstract interface class com/dropbox/core/DbxSessionStore {
 }
 
 public final class com/dropbox/core/DbxStandardSessionStore : com/dropbox/core/DbxSessionStore {
-	public fun <init> (Ljavax/servlet/http/HttpSession;Ljava/lang/String;)V
+	public fun <init> (Ljakarta/servlet/http/HttpSession;Ljava/lang/String;)V
 	public fun clear ()V
 	public fun get ()Ljava/lang/String;
 	public fun getKey ()Ljava/lang/String;
-	public fun getSession ()Ljavax/servlet/http/HttpSession;
+	public fun getSession ()Ljakarta/servlet/http/HttpSession;
 	public fun set (Ljava/lang/String;)V
 }
 

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -1,7 +1,6 @@
 import com.dropbox.stone.java.StoneTask
 import com.dropbox.stone.java.model.ClientSpec
 import com.dropbox.stone.java.model.StoneConfig
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id 'java-library'
@@ -18,16 +17,8 @@ dependencyGuard {
     configuration("runtimeClasspath")
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-tasks.withType(KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 ext {
     mavenName = 'Official Dropbox Java SDK'

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -1,6 +1,7 @@
 import com.dropbox.stone.java.StoneTask
 import com.dropbox.stone.java.model.ClientSpec
 import com.dropbox.stone.java.model.StoneConfig
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id 'java-library'
@@ -17,8 +18,16 @@ dependencyGuard {
     configuration("runtimeClasspath")
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
 
 ext {
     mavenName = 'Official Dropbox Java SDK'

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     // Android
     compileOnly 'com.google.android:android:4.1.1.4' // Until 6.x when we have an Android Artifact
     compileOnly(dropboxJavaSdkLibs.kotlin.stdlib) // Only used in Android Code
-    compileOnly("jakarta.servlet:jakarta.servlet-api:6.0.0")
+    compileOnly(dropboxJavaSdkLibs.jakarta.servlet.api)
     compileOnly(dropboxJavaSdkLibs.okhttp2)  // support both v2 and v3 to avoid
     compileOnly(dropboxJavaSdkLibs.okhttp3) // method count bloat
     compileOnly(dropboxJavaSdkLibs.appengine.api)

--- a/dropbox-sdk-java/build.gradle
+++ b/dropbox-sdk-java/build.gradle
@@ -42,8 +42,7 @@ dependencies {
     // Android
     compileOnly 'com.google.android:android:4.1.1.4' // Until 6.x when we have an Android Artifact
     compileOnly(dropboxJavaSdkLibs.kotlin.stdlib) // Only used in Android Code
-
-    compileOnly(dropboxJavaSdkLibs.servlet.api)
+    compileOnly("jakarta.servlet:jakarta.servlet-api:6.0.0")
     compileOnly(dropboxJavaSdkLibs.okhttp2)  // support both v2 and v3 to avoid
     compileOnly(dropboxJavaSdkLibs.okhttp3) // method count bloat
     compileOnly(dropboxJavaSdkLibs.appengine.api)

--- a/dropbox-sdk-java/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
+++ b/dropbox-sdk-java/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 
 /*>>> import checkers.nullness.quals.Nullable; */
 

--- a/dropbox-sdk-java/src/main/java/com/dropbox/core/DbxWebAuth.java
+++ b/dropbox-sdk-java/src/main/java/com/dropbox/core/DbxWebAuth.java
@@ -37,11 +37,11 @@ import com.dropbox.core.v2.DbxRawClientV2;
  * <h2> Part 1 </h2>
  * <p> Handler for "http://my-server.com/dropbox-auth-start": </p>
  * <pre>
- *     {@link javax.servlet.http.HttpServletRequest} request = ...
- *     {@link javax.servlet.http.HttpServletResponse} response = ...
+ *     {@link jakarta.servlet.http.HttpServletRequest} request = ...
+ *     {@link jakarta.servlet.http.HttpServletResponse} response = ...
  *
  *     <b>// Select a spot in the session for DbxWebAuth to store the CSRF token.</b>
- *     {@link javax.servlet.http.HttpSession} session = request.getSession(true);
+ *     {@link jakarta.servlet.http.HttpSession} session = request.getSession(true);
  *     String sessionKey = "dropbox-auth-csrf-token";
  *     {@link DbxSessionStore} csrfTokenStore = new DbxStandardSessionStore(session, sessionKey);
  *
@@ -62,11 +62,11 @@ import com.dropbox.core.v2.DbxRawClientV2;
  * <h2> Part 2 </h2>
  * <p> Handler for "http://my-server.com/dropbox-auth-finish": </p>
  * <pre>
- *     {@link javax.servlet.http.HttpServletRequest} request = ...
- *     {@link javax.servlet.http.HttpServletResponse} response = ...
+ *     {@link jakarta.servlet.http.HttpServletRequest} request = ...
+ *     {@link jakarta.servlet.http.HttpServletResponse} response = ...
  *
  *     <b>// Fetch the session to verify our CSRF token</b>
- *     {@link javax.servlet.http.HttpSession} session = request.getSession(true);
+ *     {@link jakarta.servlet.http.HttpSession} session = request.getSession(true);
  *     String sessionKey = "dropbox-auth-csrf-token";
  *     {@link DbxSessionStore} csrfTokenStore = new DbxStandardSessionStore(session, sessionKey);
  *     String redirectUri = "http://my-server.com/dropbox-auth-finish";

--- a/examples/android/proguard-rules.pro
+++ b/examples/android/proguard-rules.pro
@@ -26,8 +26,8 @@
 -dontwarn com.google.protos.cloud.sql.**
 -dontwarn com.google.cloud.sql.**
 -dontwarn javax.activation.**
--dontwarn javax.mail.**
--dontwarn javax.servlet.**
+-dontwarn jakarta.mail.**
+-dontwarn jakarta.servlet.**
 -dontwarn org.apache.**
 
 # Support classes for compatibility with older API versions

--- a/examples/examples/build.gradle
+++ b/examples/examples/build.gradle
@@ -12,13 +12,13 @@ java {
 
 dependencies {
     implementation(project(":dropbox-sdk-java"))
-    implementation("org.eclipse.jetty.aggregate:jetty-server:8.1.18.v20150929")
-    implementation("javax.servlet:javax.servlet-api:3.1.0")
+    implementation("org.eclipse.jetty:jetty-server:11.0.15")
+    implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
     implementation("org.apache.commons:commons-lang3:3.4")
     implementation(dropboxJavaSdkLibs.jackson.core)
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.0")
     implementation(dropboxJavaSdkLibs.okhttp3)
-    implementation("org.json:json:20220320")
+    implementation("org.json:json:20230618")
 
     testImplementation(dropboxJavaSdkLibs.test.junit)
 }

--- a/examples/examples/build.gradle
+++ b/examples/examples/build.gradle
@@ -13,7 +13,7 @@ java {
 dependencies {
     implementation(project(":dropbox-sdk-java"))
     implementation("org.eclipse.jetty:jetty-server:11.0.15")
-    implementation("jakarta.servlet:jakarta.servlet-api:6.0.0")
+    implementation(dropboxJavaSdkLibs.jakarta.servlet.api)
     implementation("org.apache.commons:commons-lang3:3.4")
     implementation(dropboxJavaSdkLibs.jackson.core)
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.0")

--- a/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/Common.java
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/Common.java
@@ -11,10 +11,10 @@ import com.dropbox.core.util.LangUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;

--- a/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxAuth.java
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxAuth.java
@@ -6,10 +6,10 @@ import com.dropbox.core.DbxSessionStore;
 import com.dropbox.core.DbxStandardSessionStore;
 import com.dropbox.core.DbxWebAuth;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 
 /**

--- a/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxBrowse.java
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/DropboxBrowse.java
@@ -18,11 +18,11 @@ import com.dropbox.core.v2.files.ListFolderResult;
 import com.dropbox.core.v2.files.LookupError;
 import com.dropbox.core.v2.files.Metadata;
 
-import javax.servlet.MultipartConfigElement;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.Part;
+import jakarta.servlet.MultipartConfigElement;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Part;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;

--- a/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/FormProtection.java
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/FormProtection.java
@@ -1,9 +1,8 @@
 package com.dropbox.core.examples.web_file_browser;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.Part;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/WebFileBrowserExample.java
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/web_file_browser/WebFileBrowserExample.java
@@ -4,6 +4,9 @@ import com.dropbox.core.DbxAppInfo;
 import com.dropbox.core.json.JsonReader;
 import static com.dropbox.core.util.StringUtil.jq;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -13,10 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 
@@ -38,9 +37,9 @@ public class WebFileBrowserExample extends AbstractHandler {
     // -------------------------------------------------------------------------------------------
     // URI Routing
     // -------------------------------------------------------------------------------------------
-
+    @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-        throws IOException, ServletException {
+            throws IOException, ServletException {
         // Don't pollute the logging with the favicon.ico requests that browsers issue.
         if (target.equals("/favicon.ico")) {
             response.sendError(404);

--- a/gradle/dropboxJavaSdkLibs.versions.toml
+++ b/gradle/dropboxJavaSdkLibs.versions.toml
@@ -32,7 +32,6 @@ kotlin-test-jvm = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 okhttp2 = 'com.squareup.okhttp:okhttp:2.7.5'
 okhttp3 = 'com.squareup.okhttp3:okhttp:4.0.0'
-servlet-api = 'javax.servlet:servlet-api:2.5'
 
 androidx-test-junit = 'androidx.test.ext:junit:1.1.3'
 androidx-test-espresso-core = 'androidx.test.espresso:espresso-core:3.4.0'

--- a/gradle/dropboxJavaSdkLibs.versions.toml
+++ b/gradle/dropboxJavaSdkLibs.versions.toml
@@ -22,6 +22,7 @@ androidx-recyclerview = 'androidx.recyclerview:recyclerview:1.2.1'
 appengine-api = 'com.google.appengine:appengine-api-1.0-sdk:1.9.38'
 glide = 'com.github.bumptech.glide:glide:4.12.0'
 jackson-core = 'com.fasterxml.jackson.core:jackson-core:2.15.0'
+jakarta-servlet-api = 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
This PR moves us to the Jakarta Servlet namespace to allow users of Spring boot V3 to consume our SDK. 
I used the built in migration tool in IntelliJ to do the bulk of the work.
I also had to bump the jetty servlet version for compatibility in our examples and tests.

Fixes #495