### PR TITLE
Adds queries to SDK manifest

### DIFF
--- a/dropbox-android/src/main/AndroidManifest.xml
+++ b/dropbox-android/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.dropbox.core.sdk.android">
-
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <queries>
+        <package android:name="com.dropbox.android" />
+    </queries>
 </manifest>


### PR DESCRIPTION
Adding the queries element to the SDK's manifest means that consumers don't need to.