### PR TITLE
Mention android:taskAffinity activity property in Android example

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ Use your Dropbox APP Key in place of `dropboxKey` below.  You need to add the `A
 </manifest>
 ```
 
+Your activity starting the authorization flow should also configured with `android:launchMode="singleTask"`. Also, if that activity is configured with `android:taskAffinity`, then the `AuthActivity` should also configured with the same task affinity, such that authorization result can be passed back to your activity.
+
 🚨[There is a known issue regarding apps with `targetSdk=33` regarding app-to-app authentication when the Dropbox App is installed](https://github.com/dropbox/dropbox-sdk-java/pull/471) 🚨
 A fix is being worked on and will be released in an upcoming version of the Dropbox Mobile App.
 

--- a/examples/android/src/main/AndroidManifest.xml
+++ b/examples/android/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@
             android:exported="true"
             android:configChanges="orientation|keyboard"
             android:launchMode="singleTask">
+            <!-- Your activity starting authorization flow should also configured with android:launchMode="singleTask".
+                 If that activity is configured with android:taskAffinity, this AuthActivity should also configured
+                 with the same android:taskAffinity so the auth result can be correctly passed back. -->
             <intent-filter>
                 <data android:scheme="db-${dropboxKey}" />
 


### PR DESCRIPTION
I've encountered this issue in my app, and the solution is found at https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/Authorization-web-page-not-redirecting-back-to-my-app-in-Android/td-p/246442 thread.

Since this example code is what I found at first (along with official documentations), I think it would be helpful to future developers to leave explanation here.