### PR TITLE
Fix StoneTask cache misses

### DIFF
--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StonePlugin.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StonePlugin.kt
@@ -3,7 +3,6 @@ package com.dropbox.stone.java
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.withType
@@ -58,7 +57,7 @@ class StonePlugin : Plugin<Project> {
             val mySpecDir: String = specDirPropNameValue ?: "src/${sourceSet.name}/stone"
             specDir.set(File(mySpecDir))
 
-            generatorDir.set(File("${project.projectDir.absoluteFile}/generator/java"))
+            generatorFile.set(File("${project.projectDir}/generator/java/java.stoneg.py"))
             stoneDir.set(File("stone"))
             pythonCommand.set("python")
             outputDir.set(File("${project.buildDir}/generated/source/stone/${sourceSet.name}"))

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
@@ -23,6 +23,7 @@ abstract class StoneTask : DefaultTask() {
     abstract val stoneConfigs: ListProperty<StoneConfig>
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val generatorFile: RegularFileProperty
 
     @get:Internal

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
@@ -22,7 +22,7 @@ abstract class StoneTask : DefaultTask() {
     @get:Input
     abstract val stoneConfigs: ListProperty<StoneConfig>
 
-    @get:Internal
+    @get:InputFile
     abstract val generatorFile: RegularFileProperty
 
     @get:Internal


### PR DESCRIPTION
Pycache files were being included as the cache key for the stone task, frequently invalidating the cache for StoneTask. This PR filters the task inputs to only the file types we care about.