### PR TITLE
Dont hardcode `src` in StoneTask outputDir

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -313,8 +313,8 @@ tasks.named("generateStone", StoneTask) {
             ),
 
     ])
-    outputDir.set(project.layout.buildDirectory.dir("generated_stone_source/main"))
-    sourceSets { main { java.srcDir(outputDir.file("src")) } }
+    outputDir.set(project.layout.buildDirectory.dir("generated_stone_source/main/src"))
+    sourceSets { main { java.srcDir(outputDir) } }
 }
 
 tasks.named("generateTestStone", StoneTask) {
@@ -333,8 +333,8 @@ tasks.named("generateTestStone", StoneTask) {
                     )
             ),
     ])
-    outputDir.set(project.layout.buildDirectory.dir("generated_stone_source/test"))
-    sourceSets { test { java.srcDir(outputDir.file("src")) } }
+    outputDir.set(project.layout.buildDirectory.dir("generated_stone_source/test/src"))
+    sourceSets { test { java.srcDir(outputDir) } }
 }
 
 mavenPublishing {

--- a/core/build/generated_stone_source/main/src/com/dropbox/core/v2/fileproperties/DbxUserFilePropertiesRequests.java
+++ b/core/build/generated_stone_source/main/src/com/dropbox/core/v2/fileproperties/DbxUserFilePropertiesRequests.java
@@ -31,7 +31,9 @@ public class DbxUserFilePropertiesRequests {
     /**
      * Add property groups to a Dropbox file. See {@link
      * DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)} or
-     * {@code templatesAddForTeam} to create new templates.
+     * {@link
+     * DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)} to
+     * create new templates.
      *
      */
     void propertiesAdd(AddPropertiesArg arg) throws AddPropertiesErrorException, DbxException {
@@ -52,7 +54,9 @@ public class DbxUserFilePropertiesRequests {
     /**
      * Add property groups to a Dropbox file. See {@link
      * DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)} or
-     * {@code templatesAddForTeam} to create new templates.
+     * {@link
+     * DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)} to
+     * create new templates.
      *
      * @param path  A unique identifier for the file or folder. Must match
      *     pattern "{@code /(.|[\\r\\n])*|id:.*|(ns:[0-9]+(/.*)?)}" and not be
@@ -135,10 +139,11 @@ public class DbxUserFilePropertiesRequests {
      * specific property field key value pairs, see {@link
      * DbxUserFilePropertiesRequests#propertiesUpdate(String,List)}. To update a
      * template, see {@link
-     * DbxUserFilePropertiesRequests#templatesUpdateForUser(String)} or {@code
-     * templatesUpdateForTeam}. To remove a template, see {@link
-     * DbxUserFilePropertiesRequests#templatesRemoveForUser(String)} or {@code
-     * templatesRemoveForTeam}.
+     * DbxUserFilePropertiesRequests#templatesUpdateForUser(String)} or {@link
+     * DbxTeamFilePropertiesRequests#templatesUpdateForTeam(String)}. To remove
+     * a template, see {@link
+     * DbxUserFilePropertiesRequests#templatesRemoveForUser(String)} or {@link
+     * DbxTeamFilePropertiesRequests#templatesRemoveForTeam(String)}.
      *
      */
     void propertiesRemove(RemovePropertiesArg arg) throws RemovePropertiesErrorException, DbxException {
@@ -161,10 +166,11 @@ public class DbxUserFilePropertiesRequests {
      * specific property field key value pairs, see {@link
      * DbxUserFilePropertiesRequests#propertiesUpdate(String,List)}. To update a
      * template, see {@link
-     * DbxUserFilePropertiesRequests#templatesUpdateForUser(String)} or {@code
-     * templatesUpdateForTeam}. To remove a template, see {@link
-     * DbxUserFilePropertiesRequests#templatesRemoveForUser(String)} or {@code
-     * templatesRemoveForTeam}.
+     * DbxUserFilePropertiesRequests#templatesUpdateForUser(String)} or {@link
+     * DbxTeamFilePropertiesRequests#templatesUpdateForTeam(String)}. To remove
+     * a template, see {@link
+     * DbxUserFilePropertiesRequests#templatesRemoveForUser(String)} or {@link
+     * DbxTeamFilePropertiesRequests#templatesRemoveForTeam(String)}.
      *
      * @param path  A unique identifier for the file or folder. Must match
      *     pattern "{@code /(.|[\\r\\n])*|id:.*|(ns:[0-9]+(/.*)?)}" and not be
@@ -172,8 +178,9 @@ public class DbxUserFilePropertiesRequests {
      * @param propertyTemplateIds  A list of identifiers for a template created
      *     by {@link
      *     DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must not contain a {@code null} item
-     *     and not be {@code null}.
+     *     or {@link
+     *     DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must not contain a {@code null} item and not be {@code null}.
      *
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
@@ -419,8 +426,10 @@ public class DbxUserFilePropertiesRequests {
      *
      * @param templateId  An identifier for template added by route  See {@link
      *     DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must have length of at least 1, match
-     *     pattern "{@code (/|ptid:).*}", and not be {@code null}.
+     *     or {@link
+     *     DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must have length of at least 1, match pattern "{@code (/|ptid:).*}",
+     *     and not be {@code null}.
      *
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
@@ -489,8 +498,10 @@ public class DbxUserFilePropertiesRequests {
      *
      * @param templateId  An identifier for a template created by {@link
      *     DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must have length of at least 1, match
-     *     pattern "{@code (/|ptid:).*}", and not be {@code null}.
+     *     or {@link
+     *     DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must have length of at least 1, match pattern "{@code (/|ptid:).*}",
+     *     and not be {@code null}.
      *
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
@@ -534,8 +545,10 @@ public class DbxUserFilePropertiesRequests {
      *
      * @param templateId  An identifier for template added by  See {@link
      *     DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must have length of at least 1, match
-     *     pattern "{@code (/|ptid:).*}", and not be {@code null}.
+     *     or {@link
+     *     DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must have length of at least 1, match pattern "{@code (/|ptid:).*}",
+     *     and not be {@code null}.
      *
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
@@ -553,8 +566,10 @@ public class DbxUserFilePropertiesRequests {
      *
      * @param templateId  An identifier for template added by  See {@link
      *     DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must have length of at least 1, match
-     *     pattern "{@code (/|ptid:).*}", and not be {@code null}.
+     *     or {@link
+     *     DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must have length of at least 1, match pattern "{@code (/|ptid:).*}",
+     *     and not be {@code null}.
      *
      * @return Request builder for configuring request parameters and completing
      *     the request.

--- a/core/build/generated_stone_source/main/src/com/dropbox/core/v2/fileproperties/RemovePropertiesArg.java
+++ b/core/build/generated_stone_source/main/src/com/dropbox/core/v2/fileproperties/RemovePropertiesArg.java
@@ -36,8 +36,9 @@ public class RemovePropertiesArg {
      * @param propertyTemplateIds  A list of identifiers for a template created
      *     by {@link
      *     DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must not contain a {@code null} item
-     *     and not be {@code null}.
+     *     or {@link
+     *     DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must not contain a {@code null} item and not be {@code null}.
      *
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
@@ -80,7 +81,8 @@ public class RemovePropertiesArg {
     /**
      * A list of identifiers for a template created by {@link
      * DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)} or
-     * {@code templatesAddForTeam}.
+     * {@link
+     * DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
      *
      * @return value for this field, never {@code null}.
      */

--- a/core/build/generated_stone_source/main/src/com/dropbox/core/v2/files/DbxUserFilesRequests.java
+++ b/core/build/generated_stone_source/main/src/com/dropbox/core/v2/files/DbxUserFilesRequests.java
@@ -3416,8 +3416,9 @@ public class DbxUserFilesRequests {
      * @param propertyTemplateIds  A list of identifiers for a template created
      *     by {@link
      *     com.dropbox.core.v2.fileproperties.DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must not contain a {@code null} item
-     *     and not be {@code null}.
+     *     or {@link
+     *     com.dropbox.core.v2.fileproperties.DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must not contain a {@code null} item and not be {@code null}.
      *
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
@@ -3456,8 +3457,10 @@ public class DbxUserFilesRequests {
      *
      * @param templateId  An identifier for template added by route  See {@link
      *     com.dropbox.core.v2.fileproperties.DbxUserFilePropertiesRequests#templatesAddForUser(String,String,List)}
-     *     or {@code templatesAddForTeam}. Must have length of at least 1, match
-     *     pattern "{@code (/|ptid:).*}", and not be {@code null}.
+     *     or {@link
+     *     com.dropbox.core.v2.fileproperties.DbxTeamFilePropertiesRequests#templatesAddForTeam(String,String,List)}.
+     *     Must have length of at least 1, match pattern "{@code (/|ptid:).*}",
+     *     and not be {@code null}.
      *
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Cat.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Cat.java
@@ -18,10 +18,15 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class Cat extends Pet {
     // struct test.Cat (test.stone)
 
+    @Nullable
     protected final String breed;
+    @Nullable
     protected final Boolean indoor;
 
     /**
@@ -35,7 +40,7 @@ public class Cat extends Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Cat(String name, Date born, String breed, Boolean indoor) {
+    public Cat(@Nonnull String name, @Nullable Date born, @Nullable String breed, @Nullable Boolean indoor) {
         super(name, born);
         this.breed = breed;
         this.indoor = indoor;
@@ -53,7 +58,7 @@ public class Cat extends Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Cat(String name) {
+    public Cat(@Nonnull String name) {
         this(name, null, null, null);
     }
 
@@ -62,7 +67,7 @@ public class Cat extends Pet {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public String getName() {
         return name;
     }
@@ -71,7 +76,7 @@ public class Cat extends Pet {
      *
      * @return value for this field, or {@code null} if not present.
      */
-    @javax.annotation.Nullable
+    @Nullable
     public Date getBorn() {
         return born;
     }
@@ -80,7 +85,7 @@ public class Cat extends Pet {
      *
      * @return value for this field, or {@code null} if not present.
      */
-    @javax.annotation.Nullable
+    @Nullable
     public String getBreed() {
         return breed;
     }
@@ -89,7 +94,7 @@ public class Cat extends Pet {
      *
      * @return value for this field, or {@code null} if not present.
      */
-    @javax.annotation.Nullable
+    @Nullable
     public Boolean getIndoor() {
         return indoor;
     }

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Dog.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Dog.java
@@ -18,10 +18,15 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class Dog extends Pet {
     // struct test.Dog (test.stone)
 
+    @Nonnull
     protected final String breed;
+    @Nullable
     protected final DogSize size;
 
     /**
@@ -36,7 +41,7 @@ public class Dog extends Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Dog(String name, String breed, Date born, DogSize size) {
+    public Dog(@Nonnull String name, @Nonnull String breed, @Nullable Date born, @Nullable DogSize size) {
         super(name, born);
         if (breed == null) {
             throw new IllegalArgumentException("Required value for 'breed' is null");
@@ -58,7 +63,7 @@ public class Dog extends Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Dog(String name, String breed) {
+    public Dog(@Nonnull String name, @Nonnull String breed) {
         this(name, breed, null, null);
     }
 
@@ -67,7 +72,7 @@ public class Dog extends Pet {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public String getName() {
         return name;
     }
@@ -76,7 +81,7 @@ public class Dog extends Pet {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public String getBreed() {
         return breed;
     }
@@ -85,7 +90,7 @@ public class Dog extends Pet {
      *
      * @return value for this field, or {@code null} if not present.
      */
-    @javax.annotation.Nullable
+    @Nullable
     public Date getBorn() {
         return born;
     }
@@ -94,7 +99,7 @@ public class Dog extends Pet {
      *
      * @return value for this field, or {@code null} if not present.
      */
-    @javax.annotation.Nullable
+    @Nullable
     public DogSize getSize() {
         return size;
     }

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Fish.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Fish.java
@@ -18,10 +18,15 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class Fish extends Pet {
     // struct test.Fish (test.stone)
 
+    @Nonnull
     protected final String species;
+    @Nonnull
     protected final TankSize tankSize;
 
     /**
@@ -35,7 +40,7 @@ public class Fish extends Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Fish(String name, String species, TankSize tankSize, Date born) {
+    public Fish(@Nonnull String name, @Nonnull String species, @Nonnull TankSize tankSize, @Nullable Date born) {
         super(name, born);
         if (species == null) {
             throw new IllegalArgumentException("Required value for 'species' is null");
@@ -61,7 +66,7 @@ public class Fish extends Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Fish(String name, String species, TankSize tankSize) {
+    public Fish(@Nonnull String name, @Nonnull String species, @Nonnull TankSize tankSize) {
         this(name, species, tankSize, null);
     }
 
@@ -70,7 +75,7 @@ public class Fish extends Pet {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public String getName() {
         return name;
     }
@@ -79,7 +84,7 @@ public class Fish extends Pet {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public String getSpecies() {
         return species;
     }
@@ -88,7 +93,7 @@ public class Fish extends Pet {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public TankSize getTankSize() {
         return tankSize;
     }
@@ -97,7 +102,7 @@ public class Fish extends Pet {
      *
      * @return value for this field, or {@code null} if not present.
      */
-    @javax.annotation.Nullable
+    @Nullable
     public Date getBorn() {
         return born;
     }

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Pet.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Pet.java
@@ -18,10 +18,15 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class Pet {
     // struct test.Pet (test.stone)
 
+    @Nonnull
     protected final String name;
+    @Nullable
     protected final Date born;
 
     /**
@@ -33,7 +38,7 @@ public class Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Pet(String name, Date born) {
+    public Pet(@Nonnull String name, @Nullable Date born) {
         if (name == null) {
             throw new IllegalArgumentException("Required value for 'name' is null");
         }
@@ -53,7 +58,7 @@ public class Pet {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Pet(String name) {
+    public Pet(@Nonnull String name) {
         this(name, null);
     }
 
@@ -62,7 +67,7 @@ public class Pet {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public String getName() {
         return name;
     }
@@ -71,7 +76,7 @@ public class Pet {
      *
      * @return value for this field, or {@code null} if not present.
      */
-    @javax.annotation.Nullable
+    @Nullable
     public Date getBorn() {
         return born;
     }

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Uninitialized.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/Uninitialized.java
@@ -16,10 +16,14 @@ import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
 import java.util.Arrays;
 
+import javax.annotation.Nonnull;
+
 class Uninitialized {
     // struct test.Uninitialized (test.stone)
 
+    @Nonnull
     protected final UninitializedReason reason;
+    @Nonnull
     protected final String sessionId;
 
     /**
@@ -30,7 +34,7 @@ class Uninitialized {
      * @throws IllegalArgumentException  If any argument does not meet its
      *     preconditions.
      */
-    public Uninitialized(UninitializedReason reason, String sessionId) {
+    public Uninitialized(@Nonnull UninitializedReason reason, @Nonnull String sessionId) {
         if (reason == null) {
             throw new IllegalArgumentException("Required value for 'reason' is null");
         }
@@ -45,7 +49,7 @@ class Uninitialized {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public UninitializedReason getReason() {
         return reason;
     }
@@ -54,7 +58,7 @@ class Uninitialized {
      *
      * @return value for this field, never {@code null}.
      */
-    @javax.annotation.Nonnull
+    @Nonnull
     public String getSessionId() {
         return sessionId;
     }

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StonePlugin.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StonePlugin.kt
@@ -57,10 +57,10 @@ class StonePlugin : Plugin<Project> {
             val mySpecDir: String = specDirPropNameValue ?: "src/${sourceSet.name}/stone"
             specDir.set(File(mySpecDir))
 
-            generatorFile.set(File("${project.projectDir}/generator/java/java.stoneg.py"))
+            generatorFile.set(File("${project.layout.projectDirectory}/generator/java/java.stoneg.py"))
             stoneDir.set(File("stone"))
             pythonCommand.set("python")
-            outputDir.set(File("${project.buildDir}/generated/source/stone/${sourceSet.name}"))
+            outputDir.set(File("${project.layout.buildDirectory}/generated/source/stone/${sourceSet.name}/src"))
 
             sourceSet.java.srcDir("${outputDir}/src")
         }

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
@@ -76,10 +76,10 @@ abstract class StoneTask : DefaultTask() {
             include("**/*.stone")
         }.files
 
-        val refsFile = File(outputDirectory, "refs/javadoc-refs.json")
+        val refsFile = File(outputDirectory.parentFile, "refs/javadoc-refs.json")
         refsFile.parentFile.mkdirs()
 
-        val logFile = File(outputDir.asFile.get(), "log/stone.log")
+        val logFile = File(outputDirectory.parentFile, "log/stone.log")
         logFile.parentFile.mkdirs()
 
         if (routeWhitelistFilter.isPresent) {
@@ -97,7 +97,7 @@ abstract class StoneTask : DefaultTask() {
                     "--attribute", ":all",
 
                     generatorFile.get().asFile,
-                    outputDirectory.resolve("src").absolutePath,
+                    outputDirectory.absolutePath,
                     *specFiles.map { it.absolutePath }.toTypedArray(),
                     "--", "--package", stoneConfig.packageName,
             )


### PR DESCRIPTION
This change allows consumers of StoneTask to define their output directory without the task prepending `src` to the path.