### PR TITLE
Exclude pycache from task input key on StoneTask

### DIFF
--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
@@ -53,10 +53,12 @@ abstract class StoneTask : DefaultTask() {
 
     init {
         stoneFiles.setFrom(stoneDir.asFileTree.matching {
+            exclude("**/__pycache__/**")
             include("**/*.py")
         })
 
         specFiles.setFrom(specDir.asFileTree.matching {
+            exclude("**/__pycache__/**")
             include("**/*.stone")
         })
     }


### PR DESCRIPTION
These directories invalidate the cache unnecessarily, exclude them from the task inputs.