### PR TITLE
Support Android SDK 35

### DIFF
--- a/android/src/main/java/com/dropbox/core/android/DbxOfficialAppConnector.kt
+++ b/android/src/main/java/com/dropbox/core/android/DbxOfficialAppConnector.kt
@@ -28,14 +28,15 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Parcel
 import android.util.Base64
-import com.dropbox.core.android.DropboxUidNotInitializedException
 import com.dropbox.core.android.internal.DropboxAuthIntent
 
 /**
  * The DbxOfficialAppConnector is used by an app to communicate with the Official Android Dropbox
  * app.
  */
-public class DbxOfficialAppConnector(uid: String?) {
+public class DbxOfficialAppConnector(
+    uid: String?,
+) {
     /**
      * uid associated with this DbxOfficialAppConnector
      */
@@ -51,20 +52,23 @@ public class DbxOfficialAppConnector(uid: String?) {
          * Version of Dropbox installed
          */
         @JvmField
-        public val versionCode: Int
+        public val versionCode: Int,
     ) {
-        override fun toString(): String {
-            return String.format(
+        override fun toString(): String =
+            String.format(
                 "DbxOfficialAppInstallInfo(versionCode=%s, supportsOpenWith=%s)",
-                versionCode, supportsOpenWith
+                versionCode,
+                supportsOpenWith,
             )
-        }
     }
 
     /**
      * Add uid information to an explicit intent directed to DropboxApp
      */
-    protected fun addExtrasToIntent(context: Context, intent: Intent) {
+    protected fun addExtrasToIntent(
+        context: Context,
+        intent: Intent,
+    ) {
         intent.putExtra(EXTRA_DROPBOX_UID, uid)
         intent.putExtra(EXTRA_CALLING_PACKAGE, context.packageName)
     }
@@ -82,7 +86,9 @@ public class DbxOfficialAppConnector(uid: String?) {
         val i = pm.getLaunchIntentForPackage("com.dropbox.android")
         return if (getDropboxAppPackage(context, i) == null) {
             null
-        } else i
+        } else {
+            i
+        }
     }
 
     /**
@@ -112,7 +118,7 @@ public class DbxOfficialAppConnector(uid: String?) {
     init {
         if (uid == null || uid.length == 0) {
             throw DropboxUidNotInitializedException(
-                "Must initialize session's uid before constructing DbxOfficialAppConnector"
+                "Must initialize session's uid before constructing DbxOfficialAppConnector",
             )
         }
         this.uid = uid
@@ -132,7 +138,11 @@ public class DbxOfficialAppConnector(uid: String?) {
      * @return Intent that when passed into startActivity() displays Dropbox preview Returns null if
      * DropboxApp is not installed
      */
-    public fun getPreviewFileIntent(context: Context, path: String?, lastRev: String?): Intent? {
+    public fun getPreviewFileIntent(
+        context: Context,
+        path: String?,
+        lastRev: String?,
+    ): Intent? {
         // TODO(jiuyangzhao): Assert path is valid
         val previewIntent = Intent(ACTION_SHOW_DROPBOX_PREVIEW)
         addExtrasToIntent(context, previewIntent)
@@ -140,7 +150,9 @@ public class DbxOfficialAppConnector(uid: String?) {
         previewIntent.putExtra(EXTRA_DROPBOX_REV, lastRev)
         return if (getDropboxAppPackage(context, previewIntent) == null) {
             null
-        } else previewIntent
+        } else {
+            previewIntent
+        }
     }
 
     public companion object {
@@ -152,7 +164,7 @@ public class DbxOfficialAppConnector(uid: String?) {
         public const val EXTRA_DROPBOX_UID: String = "com.dropbox.android.intent.extra.DROPBOX_UID"
         public const val EXTRA_CALLING_PACKAGE: String = "com.dropbox.android.intent.extra.CALLING_PACKAGE"
 
-        //OpenWith intent definitions. You won't need to use this unless you are our official partner in openwith.
+        // OpenWith intent definitions. You won't need to use this unless you are our official partner in openwith.
         // from Dropbox actions
         public const val ACTION_DBXC_EDIT: String = "com.dropbox.android.intent.action.DBXC_EDIT"
         public const val ACTION_DBXC_VIEW: String = "com.dropbox.android.intent.action.DBXC_VIEW"
@@ -160,7 +172,7 @@ public class DbxOfficialAppConnector(uid: String?) {
         // to Dropbox actions
         public const val ACTION_SHOW_DROPBOX_PREVIEW: String = "com.dropbox.android.intent.action.SHOW_PREVIEW"
 
-        //extras (used either dirction)
+        // extras (used either dirction)
         public const val EXTRA_DROPBOX_PATH: String = "com.dropbox.android.intent.extra.DROPBOX_PATH"
         public const val EXTRA_DROPBOX_READ_ONLY: String = "com.dropbox.android.intent.extra.READ_ONLY"
         public const val EXTRA_DROPBOX_REV: String = "com.dropbox.android.intent.extra.DROPBOX_REV"
@@ -173,7 +185,6 @@ public class DbxOfficialAppConnector(uid: String?) {
          */
         @JvmStatic
         public fun isInstalled(context: Context): DbxOfficialAppInstallInfo? {
-
             // For now, use dAuth intent
             val authIntent = DropboxAuthIntent.buildActionAuthenticateIntent()
             val dropboxPackage = getDropboxAppPackage(context, authIntent) ?: return null
@@ -182,8 +193,9 @@ public class DbxOfficialAppConnector(uid: String?) {
             return DbxOfficialAppInstallInfo(supportsOpenWith, versionCode)
         }
 
-        private val LOGGED_IN_URI = Uri
-            .parse("content://com.dropbox.android.provider.SDK/is_user_logged_in/")
+        private val LOGGED_IN_URI =
+            Uri
+                .parse("content://com.dropbox.android.provider.SDK/is_user_logged_in/")
         private const val CORRECT_USER = 1
         private const val NO_USER = 0
         private const val WRONG_USER = -1
@@ -196,21 +208,28 @@ public class DbxOfficialAppConnector(uid: String?) {
          * @return NO_USER if no users connected CORRECT_USER if uid connected WRONG_USER if uid not
          * connected
          */
-        private fun getLoggedinState(context: Context, uid: String?): Int {
-            val cursor = context.contentResolver.query(
-                LOGGED_IN_URI.buildUpon().appendPath(uid).build(), null,  // projection
-                null,  // selection clause
-                null,  // selection args
-                null
-            )
-                ?: // DropboxApp not installed
-                return NO_USER // sort order
+        private fun getLoggedinState(
+            context: Context,
+            uid: String?,
+        ): Int {
+            val cursor =
+                context.contentResolver.query(
+                    LOGGED_IN_URI.buildUpon().appendPath(uid).build(),
+                    null, // projection
+                    null, // selection clause
+                    null, // selection args
+                    null,
+                )
+                    ?: // DropboxApp not installed
+                    return NO_USER // sort order
             cursor.moveToFirst()
             val columnIndex = cursor.getColumnIndex("logged_in")
             return if (columnIndex < 0) {
                 // Column Doesn't Exist
                 NO_USER
-            } else cursor.getInt(columnIndex)
+            } else {
+                cursor.getInt(columnIndex)
+            }
         }
 
         /**
@@ -228,53 +247,57 @@ public class DbxOfficialAppConnector(uid: String?) {
          */
         @JvmStatic
         public fun getDropboxPlayStoreIntent(): Intent {
-                val intent = Intent(Intent.ACTION_VIEW)
-                intent.data = Uri.parse("market://details?id=com.dropbox.android")
-                return intent
-            }
+            val intent = Intent(Intent.ACTION_VIEW)
+            intent.data = Uri.parse("market://details?id=com.dropbox.android")
+            return intent
+        }
 
-        /* Begin internal functions */
-        private val DROPBOX_APP_SIGNATURES = arrayOf(
-            "308202223082018b02044bd207bd300d06092a864886f70d01010405003058310b3"
-                    + "009060355040613025553310b300906035504081302434131163014060355040713"
-                    + "0d53616e204672616e636973636f3110300e060355040a130744726f70626f78311"
-                    + "2301006035504031309546f6d204d65796572301e170d3130303432333230343930"
-                    + "315a170d3430303431353230343930315a3058310b3009060355040613025553310"
-                    + "b3009060355040813024341311630140603550407130d53616e204672616e636973"
-                    + "636f3110300e060355040a130744726f70626f783112301006035504031309546f6"
-                    + "d204d6579657230819f300d06092a864886f70d010101050003818d003081890281"
-                    + "8100ac1595d0ab278a9577f0ca5a14144f96eccde75f5616f36172c562fab0e98c4"
-                    + "8ad7d64f1091c6cc11ce084a4313d522f899378d312e112a748827545146a779def"
-                    + "a7c31d8c00c2ed73135802f6952f59798579859e0214d4e9c0554b53b26032a4d2d"
-                    + "fc2f62540d776df2ea70e2a6152945fb53fef5bac5344251595b729d48102030100"
-                    + "01300d06092a864886f70d01010405000381810055c425d94d036153203dc0bbeb3"
-                    + "516f94563b102fff39c3d4ed91278db24fc4424a244c2e59f03bbfea59404512b8b"
-                    + "f74662f2a32e37eafa2ac904c31f99cfc21c9ff375c977c432d3b6ec22776f28767"
-                    + "d0f292144884538c3d5669b568e4254e4ed75d9054f75229ac9d4ccd0b7c3c74a34"
-                    + "f07b7657083b2aa76225c0c56ffc",
-            "308201e53082014ea00302010202044e17e115300d06092a864886f70d010105050"
-                    + "03037310b30090603550406130255533110300e060355040a1307416e64726f6964"
-                    + "311630140603550403130d416e64726f6964204465627567301e170d31313037303"
-                    + "93035303331375a170d3431303730313035303331375a3037310b30090603550406"
-                    + "130255533110300e060355040a1307416e64726f6964311630140603550403130d4"
-                    + "16e64726f696420446562756730819f300d06092a864886f70d010101050003818d"
-                    + "003081890281810096759fe5abea6a0757039b92adc68d672efa84732c3f959408e"
-                    + "12efa264545c61f23141026a6d01eceeeaa13ec7087087e5894a3363da8bf5c69ed"
-                    + "93657a6890738a80998e4ca22dc94848f30e2d0e1890000ae2cddf543b20c0c3828"
-                    + "deca6c7944b5ecd21a9d18c988b2b3e54517dafbc34b48e801bb1321e0fa49e4d57"
-                    + "5d7f0203010001300d06092a864886f70d0101050500038181002b6d4b65bcfa6ec"
-                    + "7bac97ae6d878064d47b3f9f8da654995b8ef4c385bc4fbfbb7a987f60783ef0348"
-                    + "760c0708acd4b7e63f0235c35a4fbcd5ec41b3b4cb295feaa7d5c27fa562a02562b"
-                    + "7e1f4776b85147be3e295714986c4a9a07183f48ea09ae4d3ea31b88d0016c65b93"
-                    + "526b9c45f2967c3d28dee1aff5a5b29b9c2c8639"
-        )
+        // Begin internal functions
+        private val DROPBOX_APP_SIGNATURES =
+            arrayOf(
+                "308202223082018b02044bd207bd300d06092a864886f70d01010405003058310b3" +
+                    "009060355040613025553310b300906035504081302434131163014060355040713" +
+                    "0d53616e204672616e636973636f3110300e060355040a130744726f70626f78311" +
+                    "2301006035504031309546f6d204d65796572301e170d3130303432333230343930" +
+                    "315a170d3430303431353230343930315a3058310b3009060355040613025553310" +
+                    "b3009060355040813024341311630140603550407130d53616e204672616e636973" +
+                    "636f3110300e060355040a130744726f70626f783112301006035504031309546f6" +
+                    "d204d6579657230819f300d06092a864886f70d010101050003818d003081890281" +
+                    "8100ac1595d0ab278a9577f0ca5a14144f96eccde75f5616f36172c562fab0e98c4" +
+                    "8ad7d64f1091c6cc11ce084a4313d522f899378d312e112a748827545146a779def" +
+                    "a7c31d8c00c2ed73135802f6952f59798579859e0214d4e9c0554b53b26032a4d2d" +
+                    "fc2f62540d776df2ea70e2a6152945fb53fef5bac5344251595b729d48102030100" +
+                    "01300d06092a864886f70d01010405000381810055c425d94d036153203dc0bbeb3" +
+                    "516f94563b102fff39c3d4ed91278db24fc4424a244c2e59f03bbfea59404512b8b" +
+                    "f74662f2a32e37eafa2ac904c31f99cfc21c9ff375c977c432d3b6ec22776f28767" +
+                    "d0f292144884538c3d5669b568e4254e4ed75d9054f75229ac9d4ccd0b7c3c74a34" +
+                    "f07b7657083b2aa76225c0c56ffc",
+                "308201e53082014ea00302010202044e17e115300d06092a864886f70d010105050" +
+                    "03037310b30090603550406130255533110300e060355040a1307416e64726f6964" +
+                    "311630140603550403130d416e64726f6964204465627567301e170d31313037303" +
+                    "93035303331375a170d3431303730313035303331375a3037310b30090603550406" +
+                    "130255533110300e060355040a1307416e64726f6964311630140603550403130d4" +
+                    "16e64726f696420446562756730819f300d06092a864886f70d010101050003818d" +
+                    "003081890281810096759fe5abea6a0757039b92adc68d672efa84732c3f959408e" +
+                    "12efa264545c61f23141026a6d01eceeeaa13ec7087087e5894a3363da8bf5c69ed" +
+                    "93657a6890738a80998e4ca22dc94848f30e2d0e1890000ae2cddf543b20c0c3828" +
+                    "deca6c7944b5ecd21a9d18c988b2b3e54517dafbc34b48e801bb1321e0fa49e4d57" +
+                    "5d7f0203010001300d06092a864886f70d0101050500038181002b6d4b65bcfa6ec" +
+                    "7bac97ae6d878064d47b3f9f8da654995b8ef4c385bc4fbfbb7a987f60783ef0348" +
+                    "760c0708acd4b7e63f0235c35a4fbcd5ec41b3b4cb295feaa7d5c27fa562a02562b" +
+                    "7e1f4776b85147be3e295714986c4a9a07183f48ea09ae4d3ea31b88d0016c65b93" +
+                    "526b9c45f2967c3d28dee1aff5a5b29b9c2c8639",
+            )
 
         /**
          * Verify that intent will be processed by Dropbox App
          *
          * @return PackageInfo of DropboxApp if Dropbox App can process intent, else null
          */
-        internal fun getDropboxAppPackage(context: Context, intent: Intent?): PackageInfo? {
+        internal fun getDropboxAppPackage(
+            context: Context,
+            intent: Intent?,
+        ): PackageInfo? {
             val manager = context.packageManager
             val infos = manager.queryIntentActivities(intent!!, 0)
             if (1 != infos.size) {
@@ -285,15 +308,17 @@ public class DbxOfficialAppConnector(uid: String?) {
                 // The official app exists. Make sure it's the correct one by
                 // checking signing keys.
                 val resolveInfo = manager.resolveActivity(intent, 0) ?: return null
-                val packageInfo: PackageInfo = try {
-                    manager.getPackageInfo(
-                        resolveInfo.activityInfo.packageName,
-                        PackageManager.GET_SIGNATURES
-                    )
-                } catch (e: PackageManager.NameNotFoundException) {
-                    return null
-                }
-                for (signature in packageInfo.signatures) {
+                val packageInfo: PackageInfo =
+                    try {
+                        manager.getPackageInfo(
+                            resolveInfo.activityInfo.packageName,
+                            PackageManager.GET_SIGNING_CERTIFICATES,
+                        )
+                    } catch (e: PackageManager.NameNotFoundException) {
+                        return null
+                    }
+                val signatures = packageInfo.signingInfo?.signingCertificateHistory ?: return null
+                for (signature in signatures) {
                     for (dbSignature in DROPBOX_APP_SIGNATURES) {
                         if (dbSignature == signature.toCharsString()) {
                             return packageInfo
@@ -326,11 +351,12 @@ public class DbxOfficialAppConnector(uid: String?) {
             // _uri is extracted and becomes intent's data uri
             // All other items in bundle transferred to returned intent's extras
             val b: ByteArray
-            b = try {
-                Base64.decode(UtmContent, 0)
-            } catch (ex: IllegalArgumentException) {
-                throw DropboxParseException("UtmContent was not base64 encoded: " + ex.message)
-            }
+            b =
+                try {
+                    Base64.decode(UtmContent, 0)
+                } catch (ex: IllegalArgumentException) {
+                    throw DropboxParseException("UtmContent was not base64 encoded: " + ex.message)
+                }
             val parcel = Parcel.obtain()
             parcel.unmarshall(b, 0, b.size)
             parcel.setDataPosition(0)
@@ -341,8 +367,9 @@ public class DbxOfficialAppConnector(uid: String?) {
             }
             val action = bundle.getString("_action") ?: throw DropboxParseException("_action was not present in bundle")
             bundle.remove("_action")
-            val uri = bundle.getParcelable<Uri>("_uri")
-                ?: throw DropboxParseException("_uri was not present in bundle")
+            val uri =
+                bundle.getParcelable<Uri>("_uri")
+                    ?: throw DropboxParseException("_uri was not present in bundle")
             bundle.remove("_uri")
             val type = bundle.getString("_type") ?: throw DropboxParseException("_type was not present in bundle")
             bundle.remove("_type")

--- a/android/src/main/java/com/dropbox/core/android/DbxOfficialAppConnector.kt
+++ b/android/src/main/java/com/dropbox/core/android/DbxOfficialAppConnector.kt
@@ -34,9 +34,7 @@ import com.dropbox.core.android.internal.DropboxAuthIntent
  * The DbxOfficialAppConnector is used by an app to communicate with the Official Android Dropbox
  * app.
  */
-public class DbxOfficialAppConnector(
-    uid: String?,
-) {
+public class DbxOfficialAppConnector(uid: String?) {
     /**
      * uid associated with this DbxOfficialAppConnector
      */
@@ -52,23 +50,20 @@ public class DbxOfficialAppConnector(
          * Version of Dropbox installed
          */
         @JvmField
-        public val versionCode: Int,
+        public val versionCode: Int
     ) {
-        override fun toString(): String =
-            String.format(
+        override fun toString(): String {
+            return String.format(
                 "DbxOfficialAppInstallInfo(versionCode=%s, supportsOpenWith=%s)",
-                versionCode,
-                supportsOpenWith,
+                versionCode, supportsOpenWith
             )
+        }
     }
 
     /**
      * Add uid information to an explicit intent directed to DropboxApp
      */
-    protected fun addExtrasToIntent(
-        context: Context,
-        intent: Intent,
-    ) {
+    protected fun addExtrasToIntent(context: Context, intent: Intent) {
         intent.putExtra(EXTRA_DROPBOX_UID, uid)
         intent.putExtra(EXTRA_CALLING_PACKAGE, context.packageName)
     }
@@ -86,9 +81,7 @@ public class DbxOfficialAppConnector(
         val i = pm.getLaunchIntentForPackage("com.dropbox.android")
         return if (getDropboxAppPackage(context, i) == null) {
             null
-        } else {
-            i
-        }
+        } else i
     }
 
     /**
@@ -118,7 +111,7 @@ public class DbxOfficialAppConnector(
     init {
         if (uid == null || uid.length == 0) {
             throw DropboxUidNotInitializedException(
-                "Must initialize session's uid before constructing DbxOfficialAppConnector",
+                "Must initialize session's uid before constructing DbxOfficialAppConnector"
             )
         }
         this.uid = uid
@@ -138,11 +131,7 @@ public class DbxOfficialAppConnector(
      * @return Intent that when passed into startActivity() displays Dropbox preview Returns null if
      * DropboxApp is not installed
      */
-    public fun getPreviewFileIntent(
-        context: Context,
-        path: String?,
-        lastRev: String?,
-    ): Intent? {
+    public fun getPreviewFileIntent(context: Context, path: String?, lastRev: String?): Intent? {
         // TODO(jiuyangzhao): Assert path is valid
         val previewIntent = Intent(ACTION_SHOW_DROPBOX_PREVIEW)
         addExtrasToIntent(context, previewIntent)
@@ -150,9 +139,7 @@ public class DbxOfficialAppConnector(
         previewIntent.putExtra(EXTRA_DROPBOX_REV, lastRev)
         return if (getDropboxAppPackage(context, previewIntent) == null) {
             null
-        } else {
-            previewIntent
-        }
+        } else previewIntent
     }
 
     public companion object {
@@ -193,9 +180,8 @@ public class DbxOfficialAppConnector(
             return DbxOfficialAppInstallInfo(supportsOpenWith, versionCode)
         }
 
-        private val LOGGED_IN_URI =
-            Uri
-                .parse("content://com.dropbox.android.provider.SDK/is_user_logged_in/")
+        private val LOGGED_IN_URI = Uri
+            .parse("content://com.dropbox.android.provider.SDK/is_user_logged_in/")
         private const val CORRECT_USER = 1
         private const val NO_USER = 0
         private const val WRONG_USER = -1
@@ -208,28 +194,21 @@ public class DbxOfficialAppConnector(
          * @return NO_USER if no users connected CORRECT_USER if uid connected WRONG_USER if uid not
          * connected
          */
-        private fun getLoggedinState(
-            context: Context,
-            uid: String?,
-        ): Int {
-            val cursor =
-                context.contentResolver.query(
-                    LOGGED_IN_URI.buildUpon().appendPath(uid).build(),
-                    null, // projection
-                    null, // selection clause
-                    null, // selection args
-                    null,
-                )
-                    ?: // DropboxApp not installed
-                    return NO_USER // sort order
+        private fun getLoggedinState(context: Context, uid: String?): Int {
+            val cursor = context.contentResolver.query(
+                LOGGED_IN_URI.buildUpon().appendPath(uid).build(), null,  // projection
+                null,  // selection clause
+                null,  // selection args
+                null
+            )
+                ?: // DropboxApp not installed
+                return NO_USER // sort order
             cursor.moveToFirst()
             val columnIndex = cursor.getColumnIndex("logged_in")
             return if (columnIndex < 0) {
                 // Column Doesn't Exist
                 NO_USER
-            } else {
-                cursor.getInt(columnIndex)
-            }
+            } else cursor.getInt(columnIndex)
         }
 
         /**
@@ -247,57 +226,53 @@ public class DbxOfficialAppConnector(
          */
         @JvmStatic
         public fun getDropboxPlayStoreIntent(): Intent {
-            val intent = Intent(Intent.ACTION_VIEW)
-            intent.data = Uri.parse("market://details?id=com.dropbox.android")
-            return intent
-        }
+                val intent = Intent(Intent.ACTION_VIEW)
+                intent.data = Uri.parse("market://details?id=com.dropbox.android")
+                return intent
+            }
 
-        // Begin internal functions
-        private val DROPBOX_APP_SIGNATURES =
-            arrayOf(
-                "308202223082018b02044bd207bd300d06092a864886f70d01010405003058310b3" +
-                    "009060355040613025553310b300906035504081302434131163014060355040713" +
-                    "0d53616e204672616e636973636f3110300e060355040a130744726f70626f78311" +
-                    "2301006035504031309546f6d204d65796572301e170d3130303432333230343930" +
-                    "315a170d3430303431353230343930315a3058310b3009060355040613025553310" +
-                    "b3009060355040813024341311630140603550407130d53616e204672616e636973" +
-                    "636f3110300e060355040a130744726f70626f783112301006035504031309546f6" +
-                    "d204d6579657230819f300d06092a864886f70d010101050003818d003081890281" +
-                    "8100ac1595d0ab278a9577f0ca5a14144f96eccde75f5616f36172c562fab0e98c4" +
-                    "8ad7d64f1091c6cc11ce084a4313d522f899378d312e112a748827545146a779def" +
-                    "a7c31d8c00c2ed73135802f6952f59798579859e0214d4e9c0554b53b26032a4d2d" +
-                    "fc2f62540d776df2ea70e2a6152945fb53fef5bac5344251595b729d48102030100" +
-                    "01300d06092a864886f70d01010405000381810055c425d94d036153203dc0bbeb3" +
-                    "516f94563b102fff39c3d4ed91278db24fc4424a244c2e59f03bbfea59404512b8b" +
-                    "f74662f2a32e37eafa2ac904c31f99cfc21c9ff375c977c432d3b6ec22776f28767" +
-                    "d0f292144884538c3d5669b568e4254e4ed75d9054f75229ac9d4ccd0b7c3c74a34" +
-                    "f07b7657083b2aa76225c0c56ffc",
-                "308201e53082014ea00302010202044e17e115300d06092a864886f70d010105050" +
-                    "03037310b30090603550406130255533110300e060355040a1307416e64726f6964" +
-                    "311630140603550403130d416e64726f6964204465627567301e170d31313037303" +
-                    "93035303331375a170d3431303730313035303331375a3037310b30090603550406" +
-                    "130255533110300e060355040a1307416e64726f6964311630140603550403130d4" +
-                    "16e64726f696420446562756730819f300d06092a864886f70d010101050003818d" +
-                    "003081890281810096759fe5abea6a0757039b92adc68d672efa84732c3f959408e" +
-                    "12efa264545c61f23141026a6d01eceeeaa13ec7087087e5894a3363da8bf5c69ed" +
-                    "93657a6890738a80998e4ca22dc94848f30e2d0e1890000ae2cddf543b20c0c3828" +
-                    "deca6c7944b5ecd21a9d18c988b2b3e54517dafbc34b48e801bb1321e0fa49e4d57" +
-                    "5d7f0203010001300d06092a864886f70d0101050500038181002b6d4b65bcfa6ec" +
-                    "7bac97ae6d878064d47b3f9f8da654995b8ef4c385bc4fbfbb7a987f60783ef0348" +
-                    "760c0708acd4b7e63f0235c35a4fbcd5ec41b3b4cb295feaa7d5c27fa562a02562b" +
-                    "7e1f4776b85147be3e295714986c4a9a07183f48ea09ae4d3ea31b88d0016c65b93" +
-                    "526b9c45f2967c3d28dee1aff5a5b29b9c2c8639",
-            )
+        /* Begin internal functions */
+        private val DROPBOX_APP_SIGNATURES = arrayOf(
+            "308202223082018b02044bd207bd300d06092a864886f70d01010405003058310b3"
+                    + "009060355040613025553310b300906035504081302434131163014060355040713"
+                    + "0d53616e204672616e636973636f3110300e060355040a130744726f70626f78311"
+                    + "2301006035504031309546f6d204d65796572301e170d3130303432333230343930"
+                    + "315a170d3430303431353230343930315a3058310b3009060355040613025553310"
+                    + "b3009060355040813024341311630140603550407130d53616e204672616e636973"
+                    + "636f3110300e060355040a130744726f70626f783112301006035504031309546f6"
+                    + "d204d6579657230819f300d06092a864886f70d010101050003818d003081890281"
+                    + "8100ac1595d0ab278a9577f0ca5a14144f96eccde75f5616f36172c562fab0e98c4"
+                    + "8ad7d64f1091c6cc11ce084a4313d522f899378d312e112a748827545146a779def"
+                    + "a7c31d8c00c2ed73135802f6952f59798579859e0214d4e9c0554b53b26032a4d2d"
+                    + "fc2f62540d776df2ea70e2a6152945fb53fef5bac5344251595b729d48102030100"
+                    + "01300d06092a864886f70d01010405000381810055c425d94d036153203dc0bbeb3"
+                    + "516f94563b102fff39c3d4ed91278db24fc4424a244c2e59f03bbfea59404512b8b"
+                    + "f74662f2a32e37eafa2ac904c31f99cfc21c9ff375c977c432d3b6ec22776f28767"
+                    + "d0f292144884538c3d5669b568e4254e4ed75d9054f75229ac9d4ccd0b7c3c74a34"
+                    + "f07b7657083b2aa76225c0c56ffc",
+            "308201e53082014ea00302010202044e17e115300d06092a864886f70d010105050"
+                    + "03037310b30090603550406130255533110300e060355040a1307416e64726f6964"
+                    + "311630140603550403130d416e64726f6964204465627567301e170d31313037303"
+                    + "93035303331375a170d3431303730313035303331375a3037310b30090603550406"
+                    + "130255533110300e060355040a1307416e64726f6964311630140603550403130d4"
+                    + "16e64726f696420446562756730819f300d06092a864886f70d010101050003818d"
+                    + "003081890281810096759fe5abea6a0757039b92adc68d672efa84732c3f959408e"
+                    + "12efa264545c61f23141026a6d01eceeeaa13ec7087087e5894a3363da8bf5c69ed"
+                    + "93657a6890738a80998e4ca22dc94848f30e2d0e1890000ae2cddf543b20c0c3828"
+                    + "deca6c7944b5ecd21a9d18c988b2b3e54517dafbc34b48e801bb1321e0fa49e4d57"
+                    + "5d7f0203010001300d06092a864886f70d0101050500038181002b6d4b65bcfa6ec"
+                    + "7bac97ae6d878064d47b3f9f8da654995b8ef4c385bc4fbfbb7a987f60783ef0348"
+                    + "760c0708acd4b7e63f0235c35a4fbcd5ec41b3b4cb295feaa7d5c27fa562a02562b"
+                    + "7e1f4776b85147be3e295714986c4a9a07183f48ea09ae4d3ea31b88d0016c65b93"
+                    + "526b9c45f2967c3d28dee1aff5a5b29b9c2c8639"
+        )
 
         /**
          * Verify that intent will be processed by Dropbox App
          *
          * @return PackageInfo of DropboxApp if Dropbox App can process intent, else null
          */
-        internal fun getDropboxAppPackage(
-            context: Context,
-            intent: Intent?,
-        ): PackageInfo? {
+        internal fun getDropboxAppPackage(context: Context, intent: Intent?): PackageInfo? {
             val manager = context.packageManager
             val infos = manager.queryIntentActivities(intent!!, 0)
             if (1 != infos.size) {
@@ -310,14 +285,24 @@ public class DbxOfficialAppConnector(
                 val resolveInfo = manager.resolveActivity(intent, 0) ?: return null
                 val packageInfo: PackageInfo =
                     try {
-                        manager.getPackageInfo(
-                            resolveInfo.activityInfo.packageName,
-                            PackageManager.GET_SIGNING_CERTIFICATES,
-                        )
+                        if (Build.VERSION.SDK_INT >= 28) {
+                            manager.getPackageInfo(
+                                resolveInfo.activityInfo.packageName,
+                                PackageManager.GET_SIGNING_CERTIFICATES,
+                            )
+                        } else {
+                            manager.getPackageInfo(
+                                resolveInfo.activityInfo.packageName,
+                                PackageManager.GET_SIGNATURES
+                            )
+                        }
                     } catch (e: PackageManager.NameNotFoundException) {
                         return null
                     }
-                val signatures = packageInfo.signingInfo?.signingCertificateHistory ?: return null
+                val signatures = if (Build.VERSION.SDK_INT >= 28) {
+                    packageInfo.signingInfo?.signingCertificateHistory ?: return null
+                } else packageInfo.signatures
+
                 for (signature in signatures) {
                     for (dbSignature in DROPBOX_APP_SIGNATURES) {
                         if (dbSignature == signature.toCharsString()) {
@@ -351,12 +336,11 @@ public class DbxOfficialAppConnector(
             // _uri is extracted and becomes intent's data uri
             // All other items in bundle transferred to returned intent's extras
             val b: ByteArray
-            b =
-                try {
-                    Base64.decode(UtmContent, 0)
-                } catch (ex: IllegalArgumentException) {
-                    throw DropboxParseException("UtmContent was not base64 encoded: " + ex.message)
-                }
+            b = try {
+                Base64.decode(UtmContent, 0)
+            } catch (ex: IllegalArgumentException) {
+                throw DropboxParseException("UtmContent was not base64 encoded: " + ex.message)
+            }
             val parcel = Parcel.obtain()
             parcel.unmarshall(b, 0, b.size)
             parcel.setDataPosition(0)
@@ -367,9 +351,8 @@ public class DbxOfficialAppConnector(
             }
             val action = bundle.getString("_action") ?: throw DropboxParseException("_action was not present in bundle")
             bundle.remove("_action")
-            val uri =
-                bundle.getParcelable<Uri>("_uri")
-                    ?: throw DropboxParseException("_uri was not present in bundle")
+            val uri = bundle.getParcelable<Uri>("_uri")
+                ?: throw DropboxParseException("_uri was not present in bundle")
             bundle.remove("_uri")
             val type = bundle.getString("_type") ?: throw DropboxParseException("_type was not present in bundle")
             bundle.remove("_type")

--- a/android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -17,8 +17,8 @@ internal object DropboxAuthIntent {
 
     fun Context.getTargetSdkVersion(): Int? {
         return try {
-            val packageInfo: PackageInfo = packageManager.getPackageInfo(packageName, 0) ?: return null
-            val targetSdkVersion: Int = packageInfo.applicationInfo.targetSdkVersion
+            val packageInfo: PackageInfo = packageManager.getPackageInfo(packageName, 0)
+            val targetSdkVersion: Int? = packageInfo.applicationInfo?.targetSdkVersion
             targetSdkVersion
         } catch (e: Exception) {
             null

--- a/android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -7,23 +7,20 @@ import com.dropbox.core.DbxSdkVersion
 import com.dropbox.core.android.AuthActivity
 
 internal object DropboxAuthIntent {
-
-    fun buildActionAuthenticateIntent(): Intent {
-        return Intent(AuthActivity.ACTION_AUTHENTICATE_V2)
+    fun buildActionAuthenticateIntent(): Intent =
+        Intent(AuthActivity.ACTION_AUTHENTICATE_V2)
             .apply {
                 setPackage("com.dropbox.android")
             }
-    }
 
-    fun Context.getTargetSdkVersion(): Int? {
-        return try {
+    private fun Context.getTargetSdkVersion(): Int? =
+        try {
             val packageInfo: PackageInfo = packageManager.getPackageInfo(packageName, 0)
-            val targetSdkVersion: Int = packageInfo.applicationInfo.targetSdkVersion
+            val targetSdkVersion: Int? = packageInfo.applicationInfo?.targetSdkVersion
             targetSdkVersion
         } catch (e: Exception) {
             null
         }
-    }
 
     /**
      * @return Intent to auth with official app
@@ -34,7 +31,6 @@ internal object DropboxAuthIntent {
         stateNonce: String,
         authActivity: AuthActivity,
     ): Intent {
-
         val callingActivityFullyQualifiedClassName = authActivity::class.java.name
         val packageName = authActivity.packageName
 
@@ -53,12 +49,13 @@ internal object DropboxAuthIntent {
             }
 
             mState.mTokenAccessType?.apply {
-                val queryParams = QueryParamsUtil.createExtraQueryParams(
-                    tokenAccessType = mState.mTokenAccessType,
-                    scope = mState.mScope,
-                    includeGrantedScopes = mState.mIncludeGrantedScopes,
-                    pkceManagerCodeChallenge = mState.mPKCEManager.codeChallenge
-                )
+                val queryParams =
+                    QueryParamsUtil.createExtraQueryParams(
+                        tokenAccessType = mState.mTokenAccessType,
+                        scope = mState.mScope,
+                        includeGrantedScopes = mState.mIncludeGrantedScopes,
+                        pkceManagerCodeChallenge = mState.mPKCEManager.codeChallenge,
+                    )
                 // to support legacy DBApp with V1 flow with
                 putExtra(EXTRA_AUTH_QUERY_PARAMS, queryParams)
             }
@@ -147,6 +144,4 @@ internal object DropboxAuthIntent {
      * Used for internal authentication. You won't ever have to use this.
      */
     const val EXTRA_AUTH_QUERY_PARAMS: String = "AUTH_QUERY_PARAMS"
-
-
 }

--- a/android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
+++ b/android/src/main/java/com/dropbox/core/android/internal/DropboxAuthIntent.kt
@@ -7,20 +7,23 @@ import com.dropbox.core.DbxSdkVersion
 import com.dropbox.core.android.AuthActivity
 
 internal object DropboxAuthIntent {
-    fun buildActionAuthenticateIntent(): Intent =
-        Intent(AuthActivity.ACTION_AUTHENTICATE_V2)
+
+    fun buildActionAuthenticateIntent(): Intent {
+        return Intent(AuthActivity.ACTION_AUTHENTICATE_V2)
             .apply {
                 setPackage("com.dropbox.android")
             }
+    }
 
-    private fun Context.getTargetSdkVersion(): Int? =
-        try {
-            val packageInfo: PackageInfo = packageManager.getPackageInfo(packageName, 0)
-            val targetSdkVersion: Int? = packageInfo.applicationInfo?.targetSdkVersion
+    fun Context.getTargetSdkVersion(): Int? {
+        return try {
+            val packageInfo: PackageInfo = packageManager.getPackageInfo(packageName, 0) ?: return null
+            val targetSdkVersion: Int = packageInfo.applicationInfo.targetSdkVersion
             targetSdkVersion
         } catch (e: Exception) {
             null
         }
+    }
 
     /**
      * @return Intent to auth with official app
@@ -49,13 +52,12 @@ internal object DropboxAuthIntent {
             }
 
             mState.mTokenAccessType?.apply {
-                val queryParams =
-                    QueryParamsUtil.createExtraQueryParams(
-                        tokenAccessType = mState.mTokenAccessType,
-                        scope = mState.mScope,
-                        includeGrantedScopes = mState.mIncludeGrantedScopes,
-                        pkceManagerCodeChallenge = mState.mPKCEManager.codeChallenge,
-                    )
+                val queryParams = QueryParamsUtil.createExtraQueryParams(
+                    tokenAccessType = mState.mTokenAccessType,
+                    scope = mState.mScope,
+                    includeGrantedScopes = mState.mIncludeGrantedScopes,
+                    pkceManagerCodeChallenge = mState.mPKCEManager.codeChallenge
+                )
                 // to support legacy DBApp with V1 flow with
                 putExtra(EXTRA_AUTH_QUERY_PARAMS, queryParams)
             }


### PR DESCRIPTION
Cleaning up some compiler errors and deprecations when building against the Android API 35 JAR (compileSDK = 35)

```
e: DbxOfficialAppConnector.kt:296:35 Not nullable value required to call an 'iterator()' method on for-loop range
e: DropboxAuthIntent.kt:21:68 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type ApplicationInfo?
```
`applicationInfo` returning null is now handled properly.

Added some branching to use non-deprecated package signature APIs for devices >= API 28