### PR TITLE
MF-5759 fix stability of namespace route sorting

### DIFF
--- a/core/generator/java/java.stoneg.py
+++ b/core/generator/java/java.stoneg.py
@@ -2586,7 +2586,9 @@ class JavaCodeGenerationInstance:
 
     def generate_namespace(self, namespace):
         assert isinstance(namespace, ApiNamespace), repr(namespace)
-
+        # We need a stable sort in order to keep the resultant output
+        # the same across runs.
+        namespace.routes.sort()
         j = self.j
 
         # add documentation to our packages


### PR DESCRIPTION
I went with sorting the routes in place just before we started generating a given namespace.

I would've preferred to have a stronger guarantee that routes are always sorted by doing an insort in the add_route method https://github.com/dropbox/stone/blob/83da417f780b40750b2fd6cdb9697e395cc1dd40/stone/ir/api.py#L128, but since this is even further upstream there's a barrier there.

Also just to call out there's an existing attempt to sort routes as they're added here https://github.com/dropbox/stone/blob/83da417f780b40750b2fd6cdb9697e395cc1dd40/stone/frontend/ir_generator.py#L1709 but it looks to not be sufficient.

