### PR TITLE
Add jsr 305 nullability annotations

### DIFF
--- a/android/dependencies/releaseRuntimeClasspath.txt
+++ b/android/dependencies/releaseRuntimeClasspath.txt
@@ -2,7 +2,6 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
-org.checkerframework:checker-qual:4.1.0
 org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

--- a/android/dependencies/releaseRuntimeClasspath.txt
+++ b/android/dependencies/releaseRuntimeClasspath.txt
@@ -2,6 +2,7 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
+org.checkerframework:checker-qual:4.1.0
 org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,7 +56,6 @@ sourceSets.main.java.srcDir(versionWriterTask)
 
 dependencies {
     api(dropboxJavaSdkLibs.jackson.core)
-    api(dropboxJavaSdkLibs.checker.qual)
     api(dropboxJavaSdkLibs.jsr305)
 
     compileOnly dropboxJavaSdkLibs.appengine.api

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,6 +56,7 @@ sourceSets.main.java.srcDir(versionWriterTask)
 
 dependencies {
     api(dropboxJavaSdkLibs.jackson.core)
+    api(dropboxJavaSdkLibs.checker.qual)
     api(dropboxJavaSdkLibs.jsr305)
 
     compileOnly dropboxJavaSdkLibs.appengine.api

--- a/core/dependencies/runtimeClasspath.txt
+++ b/core/dependencies/runtimeClasspath.txt
@@ -2,3 +2,4 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
+org.checkerframework:checker-qual:4.1.0

--- a/core/dependencies/runtimeClasspath.txt
+++ b/core/dependencies/runtimeClasspath.txt
@@ -2,4 +2,3 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
-org.checkerframework:checker-qual:4.1.0

--- a/core/src/main/java/com/dropbox/core/AccessErrorException.java
+++ b/core/src/main/java/com/dropbox/core/AccessErrorException.java
@@ -2,19 +2,24 @@ package com.dropbox.core;
 
 import com.dropbox.core.v2.auth.AccessError;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Gets thrown when invalid access occurs.
  */
 public class AccessErrorException extends DbxException {
     private static final long serialVersionUID = 0;
 
-    private final AccessError accessError;
+    private final @Nonnull AccessError accessError;
 
-    public AccessError getAccessError() {
+    public @Nonnull AccessError getAccessError() {
         return accessError;
     }
 
-    public AccessErrorException(String requestId, String message, AccessError accessError) {
+    public AccessErrorException(@Nullable String requestId,
+                                @Nullable String message,
+                                @Nonnull AccessError accessError) {
         super(requestId, message);
         this.accessError = accessError;
     }

--- a/core/src/main/java/com/dropbox/core/ApiErrorResponse.java
+++ b/core/src/main/java/com/dropbox/core/ApiErrorResponse.java
@@ -10,11 +10,14 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import com.dropbox.core.stone.StoneSerializer;
 
-final class ApiErrorResponse<T> {
-    private final T error;
-    private LocalizedText userMessage;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-    public ApiErrorResponse(T error, LocalizedText userMessage) {
+final class ApiErrorResponse<T> {
+    private final @Nonnull T error;
+    private @Nullable LocalizedText userMessage;
+
+    public ApiErrorResponse(@Nonnull T error, @Nullable LocalizedText userMessage) {
         if (error == null) {
             throw new NullPointerException("error");
         }
@@ -22,11 +25,11 @@ final class ApiErrorResponse<T> {
         this.userMessage = userMessage;
     }
 
-    public T getError() {
+    public @Nonnull T getError() {
         return error;
     }
 
-    public LocalizedText getUserMessage() {
+    public @Nullable LocalizedText getUserMessage() {
         return userMessage;
     }
 
@@ -34,19 +37,19 @@ final class ApiErrorResponse<T> {
      * For internal use only.
      */
     static final class Serializer<T> extends StoneSerializer<ApiErrorResponse<T>> {
-        private StoneSerializer<T> errSerializer;
+        private @Nonnull StoneSerializer<T> errSerializer;
 
-        public Serializer(StoneSerializer<T> errSerializer) {
+        public Serializer(@Nonnull StoneSerializer<T> errSerializer) {
             this.errSerializer = errSerializer;
         }
 
         @Override
-        public void serialize(ApiErrorResponse<T> value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nonnull ApiErrorResponse<T> value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             throw new UnsupportedOperationException("Error wrapper serialization not supported.");
         }
 
         @Override
-        public ApiErrorResponse<T> deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull ApiErrorResponse<T> deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             T error = null;
             LocalizedText userMessage = null;
 
@@ -73,4 +76,3 @@ final class ApiErrorResponse<T> {
         }
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/BadRequestException.java
+++ b/core/src/main/java/com/dropbox/core/BadRequestException.java
@@ -1,5 +1,8 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * This is what is thrown when the Dropbox server tells us that it didn't like something about our
  * request.  This corresponds to the HTTP 400 status code.
@@ -7,7 +10,7 @@ package com.dropbox.core;
 public class BadRequestException extends ProtocolException {
     private static final long serialVersionUID = 0;
 
-    public BadRequestException(String requestId, String message) {
+    public BadRequestException(@Nullable String requestId, @Nullable String message) {
         super(requestId, message);
     }
 }

--- a/core/src/main/java/com/dropbox/core/BadResponseCodeException.java
+++ b/core/src/main/java/com/dropbox/core/BadResponseCodeException.java
@@ -1,5 +1,8 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Thrown when the Dropbox server responds with an HTTP status code we didn't expect.
  */
@@ -8,12 +11,15 @@ public class BadResponseCodeException extends BadResponseException {
 
     private final int statusCode;
 
-    public BadResponseCodeException(String requestId, String message, int statusCode) {
+    public BadResponseCodeException(@Nullable String requestId, @Nullable String message, int statusCode) {
         super(requestId, message);
         this.statusCode = statusCode;
     }
 
-    public BadResponseCodeException(String requestId, String message, int statusCode, Throwable cause) {
+    public BadResponseCodeException(@Nullable String requestId,
+                                    @Nullable String message,
+                                    int statusCode,
+                                    @Nonnull Throwable cause) {
         super(requestId, message, cause);
         this.statusCode = statusCode;
     }
@@ -27,4 +33,3 @@ public class BadResponseCodeException extends BadResponseException {
         return statusCode;
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/BadResponseException.java
+++ b/core/src/main/java/com/dropbox/core/BadResponseException.java
@@ -1,5 +1,8 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Thrown when we the response from the Dropbox server isn't something we expect.
  * For example, if the JSON returned by the server is malformed or missing fields.
@@ -7,12 +10,11 @@ package com.dropbox.core;
 public class BadResponseException extends ProtocolException {
     private static final long serialVersionUID = 0;
 
-    public BadResponseException(String requestId, String message) {
+    public BadResponseException(@Nullable String requestId, @Nullable String message) {
         super(requestId, message);
     }
 
-    public BadResponseException(String requestId, String message, Throwable cause) {
+    public BadResponseException(@Nullable String requestId, @Nullable String message, @Nonnull Throwable cause) {
         super(requestId, message, cause);
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/DbxApiException.java
+++ b/core/src/main/java/com/dropbox/core/DbxApiException.java
@@ -33,7 +33,6 @@ public class DbxApiException extends DbxException {
      *
      * @return human-readable message to display to end user, or {@code null} if unavailable
      */
-    @Nullable
     public @Nullable LocalizedText getUserMessage() {
         return userMessage;
     }

--- a/core/src/main/java/com/dropbox/core/DbxApiException.java
+++ b/core/src/main/java/com/dropbox/core/DbxApiException.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -8,14 +9,19 @@ import javax.annotation.Nullable;
 public class DbxApiException extends DbxException {
     private static final long serialVersionUID = 0L;
 
-    private final LocalizedText userMessage;
+    private final @Nullable LocalizedText userMessage;
 
-    public DbxApiException(String requestId, LocalizedText userMessage, String message) {
+    public DbxApiException(@Nullable String requestId,
+                           @Nullable LocalizedText userMessage,
+                           @Nonnull String message) {
         super(requestId, message);
         this.userMessage = userMessage;
     }
 
-    public DbxApiException(String requestId, LocalizedText userMessage, String message, Throwable cause) {
+    public DbxApiException(@Nullable String requestId,
+                           @Nullable LocalizedText userMessage,
+                           @Nonnull String message,
+                           @Nonnull Throwable cause) {
         super(requestId, message, cause);
         this.userMessage = userMessage;
     }
@@ -28,15 +34,17 @@ public class DbxApiException extends DbxException {
      * @return human-readable message to display to end user, or {@code null} if unavailable
      */
     @Nullable
-    public LocalizedText getUserMessage() {
+    public @Nullable LocalizedText getUserMessage() {
         return userMessage;
     }
 
-    protected static String buildMessage(String routeName, LocalizedText userMessage) {
+    protected static @Nonnull String buildMessage(@Nonnull String routeName, @Nullable LocalizedText userMessage) {
         return buildMessage(routeName, userMessage, null);
     }
 
-    protected static String buildMessage(String routeName, LocalizedText userMessage, Object errorValue) {
+    protected static @Nonnull String buildMessage(@Nonnull String routeName,
+                                                  @Nullable LocalizedText userMessage,
+                                                  @Nullable Object errorValue) {
         StringBuilder sb = new StringBuilder();
         sb.append("Exception in ").append(routeName);
         if (errorValue != null) {

--- a/core/src/main/java/com/dropbox/core/DbxApiException.java
+++ b/core/src/main/java/com/dropbox/core/DbxApiException.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Base class for API-specific exceptions raised by API v2 routes.

--- a/core/src/main/java/com/dropbox/core/DbxApiException.java
+++ b/core/src/main/java/com/dropbox/core/DbxApiException.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 
 /**
  * Base class for API-specific exceptions raised by API v2 routes.

--- a/core/src/main/java/com/dropbox/core/DbxAppInfo.java
+++ b/core/src/main/java/com/dropbox/core/DbxAppInfo.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.IOException;
 
 import static com.dropbox.core.util.StringUtil.jq;
@@ -13,7 +14,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * Identifying information about your application.
@@ -125,7 +125,7 @@ public class DbxAppInfo extends Dumpable {
      * that what you passed in is an actual valid Dropbox API app key.
      * </p>
      */
-    public static /*@Nullable*/String getKeyFormatError(String key) {
+    public static @Nullable String getKeyFormatError(String key) {
         return getTokenPartError(key);
     }
 
@@ -139,7 +139,7 @@ public class DbxAppInfo extends Dumpable {
      * you passed in is an actual valid Dropbox API app key.
      * </p>
      */
-    public static /*@Nullable*/String getSecretFormatError(String key) {
+    public static @Nullable String getSecretFormatError(String key) {
         return getTokenPartError(key);
     }
 
@@ -232,7 +232,7 @@ public class DbxAppInfo extends Dumpable {
 
     };
 
-    public static /*@Nullable*/String getTokenPartError(String s)
+    public static @Nullable String getTokenPartError(String s)
     {
         if (s == null) return null;
         if (s.length() == 0) return "can't be empty";

--- a/core/src/main/java/com/dropbox/core/DbxAppInfo.java
+++ b/core/src/main/java/com/dropbox/core/DbxAppInfo.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static com.dropbox.core.util.StringUtil.jq;

--- a/core/src/main/java/com/dropbox/core/DbxAppInfo.java
+++ b/core/src/main/java/com/dropbox/core/DbxAppInfo.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
@@ -19,9 +20,9 @@ import com.fasterxml.jackson.core.JsonToken;
  * Identifying information about your application.
  */
 public class DbxAppInfo extends Dumpable {
-    private final String key;
-    private final String secret;
-    private final DbxHost host;
+    private final @Nonnull String key;
+    private final @Nullable String secret;
+    private final @Nonnull DbxHost host;
 
     /**
      *
@@ -30,7 +31,7 @@ public class DbxAppInfo extends Dumpable {
      * @param key Dropbox app key (see {@link #getKey})
      * @see com.dropbox.core.DbxPKCEWebAuth
      */
-    public DbxAppInfo(String key) {
+    public DbxAppInfo(@Nonnull String key) {
         this(key, null);
     }
 
@@ -38,7 +39,7 @@ public class DbxAppInfo extends Dumpable {
      * @param key Dropbox app key (see {@link #getKey})
      * @param secret Dropbox app secret (see {@link #getSecret})
      */
-    public DbxAppInfo(String key, String secret) {
+    public DbxAppInfo(@Nonnull String key, @Nullable String secret) {
         checkKeyArg(key);
         checkSecretArg(secret);
 
@@ -52,7 +53,7 @@ public class DbxAppInfo extends Dumpable {
      * @param secret Dropbox app secret (see {@link #getSecret})
      * @param host Dropbox host configuration (see {@link #getHost})
      */
-    public DbxAppInfo(String key, String secret, DbxHost host) {
+    public DbxAppInfo(@Nonnull String key, @Nullable String secret, @Nonnull DbxHost host) {
         checkKeyArg(key);
         checkSecretArg(secret);
 
@@ -68,7 +69,7 @@ public class DbxAppInfo extends Dumpable {
      *
      * @return Dropbox app key
      */
-    public String getKey() {
+    public @Nonnull String getKey() {
         return key;
     }
 
@@ -83,7 +84,7 @@ public class DbxAppInfo extends Dumpable {
      *
      * @return Dropbox app secret
      */
-    public String getSecret() {
+    public @Nullable String getSecret() {
         return secret;
     }
 
@@ -95,7 +96,7 @@ public class DbxAppInfo extends Dumpable {
      *
      * @return Dropbox host configuration
      */
-    public DbxHost getHost() {
+    public @Nonnull DbxHost getHost() {
         return host;
     }
 
@@ -110,7 +111,7 @@ public class DbxAppInfo extends Dumpable {
     }
 
     @Override
-    protected void dumpFields(DumpWriter out) {
+    protected void dumpFields(@Nonnull DumpWriter out) {
         out.f("key").v(key);
         out.f("secret").v(secret);
     }
@@ -125,7 +126,7 @@ public class DbxAppInfo extends Dumpable {
      * that what you passed in is an actual valid Dropbox API app key.
      * </p>
      */
-    public static @Nullable String getKeyFormatError(String key) {
+    public static @Nullable String getKeyFormatError(@Nullable String key) {
         return getTokenPartError(key);
     }
 
@@ -139,17 +140,17 @@ public class DbxAppInfo extends Dumpable {
      * you passed in is an actual valid Dropbox API app key.
      * </p>
      */
-    public static @Nullable String getSecretFormatError(String key) {
+    public static @Nullable String getSecretFormatError(@Nullable String key) {
         return getTokenPartError(key);
     }
 
     // ------------------------------------------------------
     // JSON parsing
 
-    public static final JsonReader<DbxAppInfo> Reader = new JsonReader<DbxAppInfo>()
+    public static final @Nonnull JsonReader<DbxAppInfo> Reader = new JsonReader<DbxAppInfo>()
     {
         @Override
-        public final DbxAppInfo read(JsonParser parser)
+        public final @Nonnull DbxAppInfo read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -191,10 +192,10 @@ public class DbxAppInfo extends Dumpable {
         }
     };
 
-    public static final JsonReader<String> KeyReader = new JsonReader<String>()
+    public static final @Nonnull JsonReader<String> KeyReader = new JsonReader<String>()
     {
         @Override
-        public String read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull String read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             try {
                 String v = parser.getText();
@@ -211,10 +212,10 @@ public class DbxAppInfo extends Dumpable {
         }
     };
 
-    public static final JsonReader<String> SecretReader = new JsonReader<String>()
+    public static final @Nonnull JsonReader<String> SecretReader = new JsonReader<String>()
     {
         @Override
-        public String read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull String read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             try {
                 String v = parser.getText();
@@ -232,7 +233,7 @@ public class DbxAppInfo extends Dumpable {
 
     };
 
-    public static @Nullable String getTokenPartError(String s)
+    public static @Nullable String getTokenPartError(@Nullable String s)
     {
         if (s == null) return null;
         if (s.length() == 0) return "can't be empty";
@@ -246,7 +247,7 @@ public class DbxAppInfo extends Dumpable {
         return null;
     }
 
-    public static void checkKeyArg(String key)
+    public static void checkKeyArg(@Nullable String key)
     {
         String error;
 
@@ -260,7 +261,7 @@ public class DbxAppInfo extends Dumpable {
         throw new IllegalArgumentException("Bad 'key': " + error);
     }
 
-    public static void checkSecretArg(String secret)
+    public static void checkSecretArg(@Nullable String secret)
     {
         String error = getTokenPartError(secret);
         if (error == null) return;

--- a/core/src/main/java/com/dropbox/core/DbxAuthFinish.java
+++ b/core/src/main/java/com/dropbox/core/DbxAuthFinish.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
@@ -18,15 +19,15 @@ import static com.dropbox.core.util.StringUtil.jq;
  * this information to you.
  */
 public final class DbxAuthFinish {
-    private final String accessToken;
-    private final Long expiresIn;
-    private final String refreshToken;
-    private final String userId;
-    private final String accountId;
-    private final String teamId;
+    private final @Nonnull String accessToken;
+    private final @Nullable Long expiresIn;
+    private final @Nullable String refreshToken;
+    private final @Nonnull String userId;
+    private final @Nullable String accountId;
+    private final @Nullable String teamId;
     private final @Nullable String urlState;
     private long issueTime;
-    private final String scope;
+    private final @Nullable String scope;
 
     /**
      * @param accessToken OAuth access token
@@ -35,7 +36,11 @@ public final class DbxAuthFinish {
      * was passed
      */
     @Deprecated
-    public DbxAuthFinish(String accessToken, String userId, String accountId, String teamId, @Nullable String urlState) {
+    public DbxAuthFinish(@Nonnull String accessToken,
+                         @Nonnull String userId,
+                         @Nullable String accountId,
+                         @Nullable String teamId,
+                         @Nullable String urlState) {
         this(accessToken, null, null, userId, teamId, accountId, urlState);
     }
 
@@ -52,8 +57,13 @@ public final class DbxAuthFinish {
      * @param urlState State data passed in to {@link DbxWebAuth#start} or {@code null} if no state
      * was passed
      */
-    public DbxAuthFinish(String accessToken, Long expiresIn, String refreshToken, String userId,
-                         String teamId, String accountId, @Nullable String urlState) {
+    public DbxAuthFinish(@Nonnull String accessToken,
+                         @Nullable Long expiresIn,
+                         @Nullable String refreshToken,
+                         @Nonnull String userId,
+                         @Nullable String teamId,
+                         @Nullable String accountId,
+                         @Nullable String urlState) {
         this(accessToken, expiresIn, refreshToken, userId, teamId, accountId, urlState, null);
     }
 
@@ -73,9 +83,14 @@ public final class DbxAuthFinish {
      * API endpoints. To call one API endpoint you have to obtains the scope first otherwise you
      * will get HTTP 401.
      */
-    public DbxAuthFinish(String accessToken, Long expiresIn, String refreshToken, String userId,
-                         String teamId, String accountId, @Nullable String urlState, String
-                             scope) {
+    public DbxAuthFinish(@Nonnull String accessToken,
+                         @Nullable Long expiresIn,
+                         @Nullable String refreshToken,
+                         @Nonnull String userId,
+                         @Nullable String teamId,
+                         @Nullable String accountId,
+                         @Nullable String urlState,
+                         @Nullable String scope) {
         this.accessToken = accessToken;
         this.expiresIn = expiresIn;
         this.refreshToken = refreshToken;
@@ -93,7 +108,7 @@ public final class DbxAuthFinish {
      *
      * @return OAuth access token used for authorization with Dropbox servers
      */
-    public String getAccessToken() {
+    public @Nonnull String getAccessToken() {
         return accessToken;
     }
 
@@ -106,7 +121,7 @@ public final class DbxAuthFinish {
      *
      * @return OAuth access token used for authorization with Dropbox servers
      */
-    public Long getExpiresAt() {
+    public @Nullable Long getExpiresAt() {
         if (expiresIn == null) {
             return null;
         }
@@ -122,7 +137,7 @@ public final class DbxAuthFinish {
      *
      * @return OAuth access token used for authorization with Dropbox servers
      */
-    public String getRefreshToken() {
+    public @Nullable String getRefreshToken() {
         return refreshToken;
     }
 
@@ -132,7 +147,7 @@ public final class DbxAuthFinish {
      *
      * @return Dropbox user ID of user that approved your app for access to their account
      */
-    public String getUserId() {
+    public @Nonnull String getUserId() {
         return userId;
     }
 
@@ -142,7 +157,7 @@ public final class DbxAuthFinish {
      *
      * @return Dropbox account ID of user that approved your app for access to their account
      */
-    public String getAccountId() {
+    public @Nullable String getAccountId() {
         return accountId;
     }
 
@@ -152,7 +167,7 @@ public final class DbxAuthFinish {
      *
      * @return Dropbox team ID of team's that approved your app for access to their account
      */
-    public String getTeamId() {
+    public @Nullable String getTeamId() {
         return teamId;
     }
 
@@ -164,7 +179,7 @@ public final class DbxAuthFinish {
      * API endpoints. To call one API endpoint you have to obtains the scope first otherwise you
      * will get HTTP 401.
      */
-    public String getScope() {
+    public @Nullable String getScope() {
         return scope;
     }
 
@@ -192,6 +207,7 @@ public final class DbxAuthFinish {
      *
      * @param urlState Custom state passed into /oauth2/authorize
      */
+    @Nonnull
     DbxAuthFinish withUrlState(@Nullable String urlState) {
         if (this.urlState != null) {
             throw new IllegalStateException("Already have URL state.");
@@ -207,8 +223,8 @@ public final class DbxAuthFinish {
     /**
      * For JSON parsing.
      */
-    public static final JsonReader<DbxAuthFinish> Reader = new JsonReader<DbxAuthFinish>() {
-        public DbxAuthFinish read(JsonParser parser) throws IOException, JsonReadException {
+    public static final @Nonnull JsonReader<DbxAuthFinish> Reader = new JsonReader<DbxAuthFinish>() {
+        public @Nonnull DbxAuthFinish read(@Nonnull JsonParser parser) throws IOException, JsonReadException {
             JsonLocation top = JsonReader.expectObjectStart(parser);
 
             String accessToken = null;
@@ -281,9 +297,9 @@ public final class DbxAuthFinish {
         }
     };
 
-    public static final JsonReader<String> BearerTokenTypeReader = new JsonReader<String>() {
+    public static final @Nonnull JsonReader<String> BearerTokenTypeReader = new JsonReader<String>() {
         @Override
-        public String read(JsonParser parser) throws IOException, JsonReadException {
+        public @Nonnull String read(@Nonnull JsonParser parser) throws IOException, JsonReadException {
             try {
                 String v = parser.getText();
                 if (!v.equals("Bearer") && !v.equals("bearer")) {
@@ -298,9 +314,9 @@ public final class DbxAuthFinish {
 
     };
 
-    public static final JsonReader<String> AccessTokenReader = new JsonReader<String>() {
+    public static final @Nonnull JsonReader<String> AccessTokenReader = new JsonReader<String>() {
         @Override
-        public String read(JsonParser parser) throws IOException, JsonReadException {
+        public @Nonnull String read(@Nonnull JsonParser parser) throws IOException, JsonReadException {
             try {
                 String v = parser.getText();
                 String error = DbxAppInfo.getTokenPartError(v);

--- a/core/src/main/java/com/dropbox/core/DbxAuthFinish.java
+++ b/core/src/main/java/com/dropbox/core/DbxAuthFinish.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
 import com.fasterxml.jackson.core.JsonLocation;

--- a/core/src/main/java/com/dropbox/core/DbxAuthFinish.java
+++ b/core/src/main/java/com/dropbox/core/DbxAuthFinish.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
 import com.fasterxml.jackson.core.JsonLocation;
@@ -11,7 +12,6 @@ import java.io.IOException;
 
 import static com.dropbox.core.util.StringUtil.jq;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * When you successfully complete the authorization process, the Dropbox server returns
@@ -24,7 +24,7 @@ public final class DbxAuthFinish {
     private final String userId;
     private final String accountId;
     private final String teamId;
-    private final /*@Nullable*/String urlState;
+    private final @Nullable String urlState;
     private long issueTime;
     private final String scope;
 
@@ -35,7 +35,7 @@ public final class DbxAuthFinish {
      * was passed
      */
     @Deprecated
-    public DbxAuthFinish(String accessToken, String userId, String accountId, String teamId, /*@Nullable*/String urlState) {
+    public DbxAuthFinish(String accessToken, String userId, String accountId, String teamId, @Nullable String urlState) {
         this(accessToken, null, null, userId, teamId, accountId, urlState);
     }
 
@@ -53,7 +53,7 @@ public final class DbxAuthFinish {
      * was passed
      */
     public DbxAuthFinish(String accessToken, Long expiresIn, String refreshToken, String userId,
-                         String teamId, String accountId, /*@Nullable*/String urlState) {
+                         String teamId, String accountId, @Nullable String urlState) {
         this(accessToken, expiresIn, refreshToken, userId, teamId, accountId, urlState, null);
     }
 
@@ -74,7 +74,7 @@ public final class DbxAuthFinish {
      * will get HTTP 401.
      */
     public DbxAuthFinish(String accessToken, Long expiresIn, String refreshToken, String userId,
-                         String teamId, String accountId, /*@Nullable*/String urlState, String
+                         String teamId, String accountId, @Nullable String urlState, String
                              scope) {
         this.accessToken = accessToken;
         this.expiresIn = expiresIn;
@@ -175,7 +175,7 @@ public final class DbxAuthFinish {
      * @return state data passed into {@link DbxWebAuth#start}, or {@code null} if no state was
      * passed
      */
-    public /*@Nullable*/ String getUrlState() {
+    public @Nullable String getUrlState() {
         return urlState;
     }
 
@@ -192,7 +192,7 @@ public final class DbxAuthFinish {
      *
      * @param urlState Custom state passed into /oauth2/authorize
      */
-    DbxAuthFinish withUrlState(/*@Nullable*/ String urlState) {
+    DbxAuthFinish withUrlState(@Nullable String urlState) {
         if (this.urlState != null) {
             throw new IllegalStateException("Already have URL state.");
         }

--- a/core/src/main/java/com/dropbox/core/DbxAuthInfo.java
+++ b/core/src/main/java/com/dropbox/core/DbxAuthInfo.java
@@ -9,15 +9,17 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
 import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Used by the example code to remember auth information.
  */
 public final class DbxAuthInfo {
-    private final String accessToken;
-    private final Long expiresAt;
-    private final String refreshToken;
-    private final DbxHost host;
+    private final @Nonnull String accessToken;
+    private final @Nullable Long expiresAt;
+    private final @Nullable String refreshToken;
+    private final @Nonnull DbxHost host;
 
     /**
      * Creates a new instance with the given parameters.
@@ -25,7 +27,7 @@ public final class DbxAuthInfo {
      * @param accessToken OAuth access token for authorization with Dropbox servers
      * @param host Dropbox host configuration used to select Dropbox servers
      */
-    public DbxAuthInfo(String accessToken, DbxHost host) {
+    public DbxAuthInfo(@Nonnull String accessToken, @Nonnull DbxHost host) {
         this(accessToken, null, null, host);
     }
 
@@ -38,7 +40,10 @@ public final class DbxAuthInfo {
      * @param refreshToken Refresh token which can bu used to obtain new accessToken
      * @param host Dropbox host configuration used to select Dropbox servers
      */
-    public DbxAuthInfo(String accessToken, Long expiresAt, String refreshToken, DbxHost host) {
+    public DbxAuthInfo(@Nonnull String accessToken,
+                       @Nullable Long expiresAt,
+                       @Nullable String refreshToken,
+                       @Nonnull DbxHost host) {
         if (accessToken == null) throw new IllegalArgumentException("'accessToken' can't be null");
         if (host == null) throw new IllegalArgumentException("'host' can't be null");
 
@@ -53,7 +58,7 @@ public final class DbxAuthInfo {
      *
      * @return OAuth access token
      */
-    public String getAccessToken() {
+    public @Nonnull String getAccessToken() {
         return accessToken;
     }
 
@@ -63,7 +68,7 @@ public final class DbxAuthInfo {
      *
      * @return ExpiresAt in millisecond.
      */
-    public Long getExpiresAt() {
+    public @Nullable Long getExpiresAt() {
         return expiresAt;
     }
 
@@ -73,7 +78,7 @@ public final class DbxAuthInfo {
      *
      * @return Refresh Token.
      */
-    public String getRefreshToken() {
+    public @Nullable String getRefreshToken() {
         return refreshToken;
     }
 
@@ -82,14 +87,14 @@ public final class DbxAuthInfo {
      *
      * @return Dropbox host configuration
      */
-    public DbxHost getHost() {
+    public @Nonnull DbxHost getHost() {
         return host;
     }
 
-    public static final JsonReader<DbxAuthInfo> Reader = new JsonReader<DbxAuthInfo>()
+    public static final @Nonnull JsonReader<DbxAuthInfo> Reader = new JsonReader<DbxAuthInfo>()
     {
         @Override
-        public final DbxAuthInfo read(JsonParser parser)
+        public final @Nonnull DbxAuthInfo read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -135,10 +140,10 @@ public final class DbxAuthInfo {
         }
     };
 
-    public static final JsonWriter<DbxAuthInfo> Writer = new JsonWriter<DbxAuthInfo>()
+    public static final @Nonnull JsonWriter<DbxAuthInfo> Writer = new JsonWriter<DbxAuthInfo>()
     {
         @Override
-        public void write(DbxAuthInfo authInfo, JsonGenerator g) throws IOException
+        public void write(@Nonnull DbxAuthInfo authInfo, @Nonnull JsonGenerator g) throws IOException
         {
             g.writeStartObject();
             g.writeStringField("access_token", authInfo.accessToken);

--- a/core/src/main/java/com/dropbox/core/DbxDownloader.java
+++ b/core/src/main/java/com/dropbox/core/DbxDownloader.java
@@ -8,6 +8,9 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Class for handling download requests.
  *
@@ -38,13 +41,13 @@ import java.io.OutputStream;
  *</code></pre>
  */
 public class DbxDownloader<R> implements Closeable {
-    private final R result;
-    private final InputStream body;
-    private final String contentType;
+    private final @Nullable R result;
+    private final @Nonnull InputStream body;
+    private final @Nullable String contentType;
 
     private boolean closed;
 
-    public DbxDownloader(R result, InputStream body, String contentType) {
+    public DbxDownloader(@Nullable R result, @Nonnull InputStream body, @Nullable String contentType) {
         this.result = result;
         this.body = body;
         this.contentType = contentType;
@@ -52,7 +55,7 @@ public class DbxDownloader<R> implements Closeable {
         this.closed = false;
     }
 
-    public DbxDownloader(R result, InputStream body) {
+    public DbxDownloader(@Nullable R result, @Nonnull InputStream body) {
         this(result, body, null);
     }
 
@@ -64,7 +67,7 @@ public class DbxDownloader<R> implements Closeable {
      *
      * @return Response from server
      */
-    public R getResult() {
+    public @Nullable R getResult() {
         return result;
     }
 
@@ -73,7 +76,7 @@ public class DbxDownloader<R> implements Closeable {
      *
      * @return the content type, or null if not known.
      */
-    public String getContentType() {
+    public @Nullable String getContentType() {
         return contentType;
     }
 
@@ -87,7 +90,7 @@ public class DbxDownloader<R> implements Closeable {
      *
      * @throws IllegalStateException if this downloader has already been closed (see {@link #close})
      */
-    public InputStream getInputStream() {
+    public @Nonnull InputStream getInputStream() {
         assertOpen();
         return body;
     }
@@ -120,7 +123,7 @@ public class DbxDownloader<R> implements Closeable {
      * @throws IOException if an error occurs writing the response body to the output stream.
      * @throws IllegalStateException if this downloader has already been closed (see {@link #close})
      */
-    public R download(OutputStream out) throws DbxException,  IOException {
+    public @Nullable R download(@Nonnull OutputStream out) throws DbxException,  IOException {
         try {
             IOUtil.copyStreamToStream(getInputStream(), out);
         } catch (IOUtil.WriteException ex) {
@@ -146,7 +149,7 @@ public class DbxDownloader<R> implements Closeable {
      * @throws DbxException if an error occurs reading the response or response body.
      * @throws IOException if an error occurs writing the response body to the output stream.
      */
-    public R download(OutputStream out, IOUtil.ProgressListener progressListener)
+    public @Nullable R download(@Nonnull OutputStream out, @Nullable IOUtil.ProgressListener progressListener)
             throws DbxException,  IOException {
         return download(new ProgressOutputStream(out, progressListener));
     }

--- a/core/src/main/java/com/dropbox/core/DbxException.java
+++ b/core/src/main/java/com/dropbox/core/DbxException.java
@@ -2,6 +2,9 @@ package com.dropbox.core;
 
 import java.io.IOException;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * The base exception thrown by Dropbox API calls.  Normally, you'll need to do something specific
  * for {@link InvalidAccessTokenException} and possibly for {@link RetryException}.  The rest you
@@ -10,22 +13,22 @@ import java.io.IOException;
 public class DbxException extends Exception {
     private static final long serialVersionUID = 0L;
 
-    private final String requestId;
+    private final @Nullable String requestId;
 
-    public DbxException(String message) {
+    public DbxException(@Nullable String message) {
         this(null, message);
     }
 
-    public DbxException(String requestId, String message) {
+    public DbxException(@Nullable String requestId, @Nullable String message) {
         super(message);
         this.requestId = requestId;
     }
 
-    public DbxException(String message, Throwable cause) {
+    public DbxException(@Nullable String message, @Nonnull Throwable cause) {
         this(null, message, cause);
     }
 
-    public DbxException(String requestId, String message, Throwable cause) {
+    public DbxException(@Nullable String requestId, @Nullable String message, @Nonnull Throwable cause) {
         super(message, cause);
         this.requestId = requestId;
     }
@@ -41,7 +44,7 @@ public class DbxException extends Exception {
      * @return unique ID associated with the request that caused this exception, or {@code null} if
      * one is not available.
      */
-    public String getRequestId() {
+    public @Nullable String getRequestId() {
         return requestId;
     }
 }

--- a/core/src/main/java/com/dropbox/core/DbxHost.java
+++ b/core/src/main/java/com/dropbox/core/DbxHost.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
 import com.dropbox.core.json.JsonWriter;

--- a/core/src/main/java/com/dropbox/core/DbxHost.java
+++ b/core/src/main/java/com/dropbox/core/DbxHost.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
 import com.dropbox.core.json.JsonWriter;
@@ -11,7 +12,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
 import java.util.Arrays;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * This is for mocking things out during testing.  Most of the time you won't have to deal with
@@ -93,7 +93,7 @@ public final class DbxHost {
     }
 
     @Override
-    public boolean equals(/*@Nullable*/Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this) {
             return true;
         } else if(obj instanceof DbxHost) {
@@ -168,7 +168,7 @@ public final class DbxHost {
         }
     };
 
-    private /*@Nullable*/String inferBaseHost() {
+    private @Nullable String inferBaseHost() {
         if (web.startsWith("meta-") && api.startsWith("api-") && content.startsWith("api-content-") && notify.startsWith("api-notify-")) {
             String webBase = web.substring("meta-".length());
             String apiBase = api.substring("api-".length());

--- a/core/src/main/java/com/dropbox/core/DbxHost.java
+++ b/core/src/main/java/com/dropbox/core/DbxHost.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
@@ -22,17 +23,17 @@ public final class DbxHost {
      * The standard Dropbox hosts: "api.dropbox.com", "api-content.dropbox.com",
      * and "www.dropbox.com"
      */
-    public static final DbxHost DEFAULT = new DbxHost(
+    public static final @Nonnull DbxHost DEFAULT = new DbxHost(
         "api.dropboxapi.com",
         "content.dropboxapi.com",
         "www.dropbox.com",
         "notify.dropboxapi.com"
     );
 
-    private final String api;
-    private final String content;
-    private final String web;
-    private final String notify;
+    private final @Nonnull String api;
+    private final @Nonnull String content;
+    private final @Nonnull String web;
+    private final @Nonnull String notify;
 
     /**
      * @param api main Dropbox API server host name
@@ -40,7 +41,7 @@ public final class DbxHost {
      * @param web Dropbox web server host name
      * @param notify Dropbox notification server host name
      */
-    public DbxHost(String api, String content, String web, String notify) {
+    public DbxHost(@Nonnull String api, @Nonnull String content, @Nonnull String web, @Nonnull String notify) {
         this.api = api;
         this.content = content;
         this.web = web;
@@ -53,7 +54,7 @@ public final class DbxHost {
      *
      * @return host name of main Dropbox API server
      */
-    public String getApi() {
+    public @Nonnull String getApi() {
         return api;
     }
 
@@ -63,7 +64,7 @@ public final class DbxHost {
      *
      * @return host name of Dropbox API content server
      */
-    public String getContent() {
+    public @Nonnull String getContent() {
         return content;
     }
 
@@ -73,7 +74,7 @@ public final class DbxHost {
      *
      * @return host name of Dropbox API web server used during user authorization
      */
-    public String getWeb() {
+    public @Nonnull String getWeb() {
         return web;
     }
 
@@ -83,7 +84,7 @@ public final class DbxHost {
      *
      * @return host name of Dropbox notification server used for longpolling
      */
-    public String getNotify() {
+    public @Nonnull String getNotify() {
         return notify;
     }
 
@@ -107,13 +108,13 @@ public final class DbxHost {
         }
     }
 
-    private static DbxHost fromBaseHost(String s) {
+    private static @Nonnull DbxHost fromBaseHost(@Nonnull String s) {
         return new DbxHost("api-" + s, "api-content-" + s, "meta-" + s, "api-notify-" + s);
     }
 
-    public static final JsonReader<DbxHost> Reader = new JsonReader<DbxHost>() {
+    public static final @Nonnull JsonReader<DbxHost> Reader = new JsonReader<DbxHost>() {
         @Override
-        public DbxHost read(JsonParser parser) throws IOException, JsonReadException {
+        public @Nonnull DbxHost read(@Nonnull JsonParser parser) throws IOException, JsonReadException {
             JsonToken t = parser.getCurrentToken();
             if (t == JsonToken.VALUE_STRING) {
                 String s = parser.getText();
@@ -181,9 +182,9 @@ public final class DbxHost {
         return null;
     }
 
-    public static final JsonWriter<DbxHost> Writer = new JsonWriter<DbxHost>() {
+    public static final @Nonnull JsonWriter<DbxHost> Writer = new JsonWriter<DbxHost>() {
         @Override
-        public void write(DbxHost host, JsonGenerator g) throws IOException {
+        public void write(@Nonnull DbxHost host, @Nonnull JsonGenerator g) throws IOException {
             String base = host.inferBaseHost();
             if (base != null) {
                 g.writeString(base);

--- a/core/src/main/java/com/dropbox/core/DbxOAuth1AccessToken.java
+++ b/core/src/main/java/com/dropbox/core/DbxOAuth1AccessToken.java
@@ -1,19 +1,21 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+
 /**
  * Use with {@link DbxOAuth1Upgrader} to convert old OAuth 1 access tokens
  * to OAuth 2 access tokens.  This SDK doesn't support using OAuth 1 access
  * tokens for regular API calls.
  */
 public final class DbxOAuth1AccessToken {
-    private final String key;
-    private final String secret;
+    private final @Nonnull String key;
+    private final @Nonnull String secret;
 
     /**
      * @param key OAuth 1 access token key
      * @param secret OAuth 2 access token secret
      */
-    public DbxOAuth1AccessToken(String key, String secret) {
+    public DbxOAuth1AccessToken(@Nonnull String key, @Nonnull String secret) {
         this.key = key;
         this.secret = secret;
     }
@@ -23,7 +25,7 @@ public final class DbxOAuth1AccessToken {
      *
      * @return OAuth 1 access token key
      */
-    public String getKey() {
+    public @Nonnull String getKey() {
         return key;
     }
 
@@ -32,7 +34,7 @@ public final class DbxOAuth1AccessToken {
      *
      * @return OAuth 1 access token secret
      */
-    public String getSecret() {
+    public @Nonnull String getSecret() {
         return secret;
     }
 }

--- a/core/src/main/java/com/dropbox/core/DbxOAuth1Upgrader.java
+++ b/core/src/main/java/com/dropbox/core/DbxOAuth1Upgrader.java
@@ -15,6 +15,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 
+import javax.annotation.Nonnull;
+
 /**
  * Lets you convert OAuth 1 access tokens to OAuth 2 access tokens. First call {@link
  * #createOAuth2AccessToken} to get an OAuth 2 access token.  If that succeeds, call {@link
@@ -22,14 +24,14 @@ import java.util.ArrayList;
  */
 public final class DbxOAuth1Upgrader
 {
-    private final DbxRequestConfig requestConfig;
-    private final DbxAppInfo appInfo;
+    private final @Nonnull DbxRequestConfig requestConfig;
+    private final @Nonnull DbxAppInfo appInfo;
 
     /**
      * @param appInfo
      *     Your application's Dropbox API information (the app key and secret).
      */
-    public DbxOAuth1Upgrader(DbxRequestConfig requestConfig, DbxAppInfo appInfo)
+    public DbxOAuth1Upgrader(@Nonnull DbxRequestConfig requestConfig, @Nonnull DbxAppInfo appInfo)
     {
         if (requestConfig == null) throw new IllegalArgumentException("'requestConfig' is null");
         if (appInfo == null) throw new IllegalArgumentException("'appInfo' is null");
@@ -42,7 +44,7 @@ public final class DbxOAuth1Upgrader
      * Given an existing active OAuth 1 access token, make a Dropbox API call to get a new OAuth 2
      * access token that represents the same user and app.
      */
-    public String createOAuth2AccessToken(DbxOAuth1AccessToken token)
+    public @Nonnull String createOAuth2AccessToken(@Nonnull DbxOAuth1AccessToken token)
         throws DbxException
     {
         if (token == null) throw new IllegalArgumentException("'token' can't be null");
@@ -55,7 +57,7 @@ public final class DbxOAuth1Upgrader
             getHeaders(token),
             new DbxRequestUtil.ResponseHandler<String>() {
                 @Override
-                public String handle(HttpRequestor.Response response) throws DbxException {
+                public @Nonnull String handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                     if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
                     return DbxRequestUtil.readJsonFromResponse(ResponseReader, response);
                 }
@@ -66,7 +68,7 @@ public final class DbxOAuth1Upgrader
     /**
      * Tell the Dropbox API server to disable an OAuth 1 access token.
      */
-    public void disableOAuth1AccessToken(DbxOAuth1AccessToken token)
+    public void disableOAuth1AccessToken(@Nonnull DbxOAuth1AccessToken token)
         throws DbxException
     {
         if (token == null) throw new IllegalArgumentException("'token' can't be null");
@@ -79,7 +81,7 @@ public final class DbxOAuth1Upgrader
             getHeaders(token),
             new DbxRequestUtil.ResponseHandler<Void>() {
                 @Override
-                public Void handle(HttpRequestor.Response response) throws DbxException {
+                public Void handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                     if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
                     return null;
                 }
@@ -87,24 +89,29 @@ public final class DbxOAuth1Upgrader
         );
     }
 
-    private ArrayList<HttpRequestor.Header> getHeaders(DbxOAuth1AccessToken token)
+    private @Nonnull ArrayList<HttpRequestor.Header> getHeaders(@Nonnull DbxOAuth1AccessToken token)
     {
         ArrayList<HttpRequestor.Header> headers = new ArrayList<HttpRequestor.Header>(1);
         headers.add(new HttpRequestor.Header("Authorization", buildOAuth1Header(token)));
         return headers;
     }
 
-    private String buildOAuth1Header(DbxOAuth1AccessToken token)
+    private @Nonnull String buildOAuth1Header(@Nonnull DbxOAuth1AccessToken token)
     {
+        String appSecret = this.appInfo.getSecret();
+        if (appSecret == null) {
+            throw new IllegalStateException("OAuth 1 token upgrade requires an app secret.");
+        }
+
         StringBuilder buf = new StringBuilder();
         buf.append("OAuth oauth_version=\"1.0\", oauth_signature_method=\"PLAINTEXT\"");
         buf.append(", oauth_consumer_key=\"").append(encode(this.appInfo.getKey())).append("\"");
         buf.append(", oauth_token=\"").append(encode(token.getKey())).append("\"");
-        buf.append(", oauth_signature=\"").append(encode(this.appInfo.getSecret())).append("&").append(encode(token.getSecret())).append("\"");
+        buf.append(", oauth_signature=\"").append(encode(appSecret)).append("&").append(encode(token.getSecret())).append("\"");
         return buf.toString();
     }
 
-    private static String encode(String s)
+    private static @Nonnull String encode(@Nonnull String s)
     {
         try {
             return URLEncoder.encode(s, "UTF-8");
@@ -117,9 +124,9 @@ public final class DbxOAuth1Upgrader
     /**
      * For JSON parsing.
      */
-    public static final JsonReader<String> ResponseReader = new JsonReader<String>()
+    public static final @Nonnull JsonReader<String> ResponseReader = new JsonReader<String>()
     {
-        public String read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull String read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);
 

--- a/core/src/main/java/com/dropbox/core/DbxPKCEManager.java
+++ b/core/src/main/java/com/dropbox/core/DbxPKCEManager.java
@@ -13,6 +13,9 @@ import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import static com.dropbox.core.util.StringUtil.urlSafeBase64Encode;
 
 /**
@@ -23,15 +26,15 @@ import static com.dropbox.core.util.StringUtil.urlSafeBase64Encode;
  * @see <a href="https://tools.ietf.org/html/rfc7636">https://tools.ietf.org/html/rfc7636</a>
  */
 public class DbxPKCEManager {
-    public static final String CODE_CHALLENGE_METHODS = "S256";
+    public static final @Nonnull String CODE_CHALLENGE_METHODS = "S256";
     public static final int CODE_VERIFIER_SIZE = 128;
 
     private static final SecureRandom RAND = new SecureRandom();
-    private static final String CODE_VERIFIER_CHAR_SET =
+    private static final @Nonnull String CODE_VERIFIER_CHAR_SET =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
 
-    private String codeVerifier;
-    private String codeChallenge;
+    private @Nonnull String codeVerifier;
+    private @Nonnull String codeChallenge;
 
     /**
      *  This class has state. Each instance has a randomly generated codeVerifier in it. Just
@@ -43,11 +46,12 @@ public class DbxPKCEManager {
         this.codeChallenge = generateCodeChallenge(this.codeVerifier);
     }
 
-    public DbxPKCEManager(String codeVerifier) {
+    public DbxPKCEManager(@Nonnull String codeVerifier) {
         this.codeVerifier = codeVerifier;
         this.codeChallenge = generateCodeChallenge(this.codeVerifier);
     }
 
+    @Nonnull
     String generateCodeVerifier() {
         StringBuilder sb = new StringBuilder();
 
@@ -58,7 +62,7 @@ public class DbxPKCEManager {
         return sb.toString();
     }
 
-    static String generateCodeChallenge(String codeVerifier) {
+    static @Nonnull String generateCodeChallenge(@Nonnull String codeVerifier) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] signiture = digest.digest(codeVerifier.getBytes("US-ASCII"));
@@ -73,14 +77,14 @@ public class DbxPKCEManager {
     /**
      * @return The randomly generate code verifier in this instance.
      */
-    public String getCodeVerifier() {
+    public @Nonnull String getCodeVerifier() {
         return this.codeVerifier;
     }
 
     /**
      * @return The code challenge, which is a hashed code verifier.
      */
-    public String getCodeChallenge() {
+    public @Nonnull String getCodeChallenge() {
         return this.codeChallenge;
     }
 
@@ -96,11 +100,11 @@ public class DbxPKCEManager {
      * refresh token.
      * @throws DbxException If reqeust is invalid, or code expired, or server error.
      */
-    public DbxAuthFinish makeTokenRequest(DbxRequestConfig requestConfig,
-                                   String oauth2Code,
-                                   String appKey,
-                                   String redirectUri,
-                                   DbxHost host) throws DbxException {
+    public @Nonnull DbxAuthFinish makeTokenRequest(@Nonnull DbxRequestConfig requestConfig,
+                                   @Nonnull String oauth2Code,
+                                   @Nonnull String appKey,
+                                   @Nullable String redirectUri,
+                                   @Nonnull DbxHost host) throws DbxException {
         Map<String, String> params = new HashMap<String, String>();
         params.put("grant_type", "authorization_code");
         params.put("code", oauth2Code);
@@ -121,7 +125,7 @@ public class DbxPKCEManager {
             null,
             new DbxRequestUtil.ResponseHandler<DbxAuthFinish>() {
                 @Override
-                public DbxAuthFinish handle(HttpRequestor.Response response) throws DbxException {
+                public @Nonnull DbxAuthFinish handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                     if (response.getStatusCode() != 200) {
                         throw DbxRequestUtil.unexpectedStatus(response);
                     }

--- a/core/src/main/java/com/dropbox/core/DbxPKCEWebAuth.java
+++ b/core/src/main/java/com/dropbox/core/DbxPKCEWebAuth.java
@@ -11,6 +11,9 @@ import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import static com.dropbox.core.util.StringUtil.urlSafeBase64Encode;
 
 /**
@@ -38,10 +41,10 @@ import static com.dropbox.core.util.StringUtil.urlSafeBase64Encode;
  * new <a href="https://www.dropbox.com/lp/developers/reference/oauth-guide.html">dropbox oauth guide</a>
  */
 public class DbxPKCEWebAuth {
-    private final DbxRequestConfig requestConfig;
-    private final DbxAppInfo appInfo;
-    private final DbxWebAuth dbxWebAuth;
-    private final DbxPKCEManager dbxPKCEManager;
+    private final @Nonnull DbxRequestConfig requestConfig;
+    private final @Nonnull DbxAppInfo appInfo;
+    private final @Nonnull DbxWebAuth dbxWebAuth;
+    private final @Nonnull DbxPKCEManager dbxPKCEManager;
     private boolean started;
     private boolean consumed;
 
@@ -54,7 +57,7 @@ public class DbxPKCEWebAuth {
      *
      * @throws IllegalStateException if appInfo contains app secret.
      */
-    public DbxPKCEWebAuth(DbxRequestConfig requestConfig, DbxAppInfo appInfo) {
+    public DbxPKCEWebAuth(@Nonnull DbxRequestConfig requestConfig, @Nonnull DbxAppInfo appInfo) {
         if (appInfo.hasSecret()) {
             throw new IllegalStateException("PKCE cdoe flow doesn't require app secret, if you " +
                 "decide to embed it in your app, please use regular DbxWebAuth instead.");
@@ -88,7 +91,7 @@ public class DbxPKCEWebAuth {
      * @return Authorization URL of website user can use to authorize your app.
      *
      */
-    public String authorize(DbxWebAuth.Request request) {
+    public @Nonnull String authorize(@Nonnull DbxWebAuth.Request request) {
         if (consumed) {
             throw new IllegalStateException("This DbxPKCEWebAuth instance has been consumed " +
                 "already. To start a new PKCE OAuth flow, please create a new instance.");
@@ -112,7 +115,7 @@ public class DbxPKCEWebAuth {
      * URL, or if an error occurs communicating with Dropbox.
      * @see DbxWebAuth#finishFromCode(String)
      */
-    public DbxAuthFinish finishFromCode(String code) throws DbxException {
+    public @Nonnull DbxAuthFinish finishFromCode(@Nonnull String code) throws DbxException {
         return finish(code, null, null);
     }
 
@@ -134,18 +137,22 @@ public class DbxPKCEWebAuth {
      * @throws DbxException if the instance is not the same one used to generate authorization
      * URL, or if an error occurs communicating with Dropbox.
      */
-    public DbxAuthFinish finishFromRedirect(String redirectUri,
-                                            DbxSessionStore sessionStore,
-                                            Map<String, String[]> params)
+    public @Nonnull DbxAuthFinish finishFromRedirect(@Nonnull String redirectUri,
+                                            @Nonnull DbxSessionStore sessionStore,
+                                            @Nonnull Map<String, String[]> params)
         throws DbxException, DbxWebAuth.BadRequestException, DbxWebAuth.BadStateException,
         DbxWebAuth.CsrfException, DbxWebAuth.NotApprovedException, DbxWebAuth.ProviderException {
 
-        String strippedState = DbxWebAuth.validateRedirectUri(redirectUri, sessionStore, params);
+        @Nullable String strippedState = DbxWebAuth.validateRedirectUri(redirectUri, sessionStore, params);
         String code = DbxWebAuth.getParam(params, "code");
+        if (code == null) {
+            throw new DbxWebAuth.BadRequestException("Missing required parameter: \"code\".");
+        }
         return finish(code, redirectUri, strippedState);
     }
 
-    DbxAuthFinish finish(String code, String redirectUri, final String state) throws DbxException {
+    @Nonnull
+    DbxAuthFinish finish(@Nonnull String code, @Nullable String redirectUri, final @Nullable String state) throws DbxException {
         if (code == null) throw new NullPointerException("code");
         if (!this.started) {
             throw new IllegalStateException("Must initialize the PKCE flow by calling authorize " +

--- a/core/src/main/java/com/dropbox/core/DbxRequestConfig.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequestConfig.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import java.util.Locale;
 
 import com.dropbox.core.http.HttpRequestor;

--- a/core/src/main/java/com/dropbox/core/DbxRequestConfig.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequestConfig.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Locale;
 
@@ -12,12 +13,15 @@ import com.dropbox.core.http.StandardHttpRequestor;
  * Dropbox servers.
  */
 public class DbxRequestConfig {
-    private final String clientIdentifier;
+    private final @Nonnull String clientIdentifier;
     private final @Nullable String userLocale;
-    private final HttpRequestor httpRequestor;
+    private final @Nonnull HttpRequestor httpRequestor;
     private final int maxRetries;
 
-    private DbxRequestConfig(String clientIdentifier, @Nullable String userLocale, HttpRequestor httpRequestor, int maxRetries) {
+    private DbxRequestConfig(@Nonnull String clientIdentifier,
+                             @Nullable String userLocale,
+                             @Nonnull HttpRequestor httpRequestor,
+                             int maxRetries) {
         if (clientIdentifier == null) throw new NullPointerException("clientIdentifier");
         if (httpRequestor == null) throw new NullPointerException("httpRequestor");
         if (maxRetries < 0) throw new IllegalArgumentException("maxRetries");
@@ -33,7 +37,7 @@ public class DbxRequestConfig {
      *
      * @param clientIdentifier see {@link #getClientIdentifier}
      */
-    public DbxRequestConfig(String clientIdentifier) {
+    public DbxRequestConfig(@Nonnull String clientIdentifier) {
         this(clientIdentifier, null);
     }
 
@@ -46,7 +50,7 @@ public class DbxRequestConfig {
      * @deprecated Use {@link #newBuilder} to customize configuration
      */
     @Deprecated
-    public DbxRequestConfig(String clientIdentifier, @Nullable String userLocale) {
+    public DbxRequestConfig(@Nonnull String clientIdentifier, @Nullable String userLocale) {
         this(clientIdentifier, userLocale, StandardHttpRequestor.INSTANCE);
     }
 
@@ -60,7 +64,9 @@ public class DbxRequestConfig {
      * @deprecated Use {@link #newBuilder} to customize configuration
      */
     @Deprecated
-    public DbxRequestConfig(String clientIdentifier, @Nullable String userLocale, HttpRequestor httpRequestor) {
+    public DbxRequestConfig(@Nonnull String clientIdentifier,
+                            @Nullable String userLocale,
+                            @Nonnull HttpRequestor httpRequestor) {
         this(clientIdentifier, userLocale, httpRequestor, 0);
     }
 
@@ -82,7 +88,7 @@ public class DbxRequestConfig {
      * debugging things later.
      * </p>
      */
-    public String getClientIdentifier() {
+    public @Nonnull String getClientIdentifier() {
         return clientIdentifier;
     }
 
@@ -106,7 +112,7 @@ public class DbxRequestConfig {
      * to the user's configured locale setting.
      * </p>
      */
-    public String getUserLocale() {
+    public @Nullable String getUserLocale() {
         return userLocale;
     }
 
@@ -114,7 +120,7 @@ public class DbxRequestConfig {
      * Returns the {@link HttpRequestor} you passed in when constructing this object, which
      * defaults to {@link StandardHttpRequestor#INSTANCE}.
      */
-    public HttpRequestor getHttpRequestor() {
+    public @Nonnull HttpRequestor getHttpRequestor() {
         return httpRequestor;
     }
 
@@ -162,7 +168,7 @@ public class DbxRequestConfig {
      *
      * @return builder configured to build a copy of this instance
      */
-    public Builder copy() {
+    public @Nonnull Builder copy() {
         return new Builder(clientIdentifier, userLocale, httpRequestor, maxRetries);
     }
 
@@ -172,13 +178,13 @@ public class DbxRequestConfig {
      *
      * @param clientIdentifier see {@link #getClientIdentifier}
      */
-    public static Builder newBuilder(String clientIdentifier) {
+    public static @Nonnull Builder newBuilder(@Nonnull String clientIdentifier) {
         if (clientIdentifier == null) throw new NullPointerException("clientIdentifier");
         return new Builder(clientIdentifier);
     }
 
     // Available in Java 7, but not in Java 6. Do a hacky version of it here.
-    private static String toLanguageTag(Locale locale) {
+    private static @Nullable String toLanguageTag(@Nullable Locale locale) {
         if (locale == null) {
             return null;
         }
@@ -197,7 +203,7 @@ public class DbxRequestConfig {
     // APIv1 accepts Locale.toString() formatted locales (e.g. 'en_US'), but APIv2 will return an
     // error if the locale is not in proper Language Tag format. Attempt to convert old locale
     // formats to the new one.
-    private static String toLanguageTag(String locale) {
+    private static @Nullable String toLanguageTag(@Nullable String locale) {
         if (locale == null) {
             return null;
         }
@@ -226,15 +232,15 @@ public class DbxRequestConfig {
      * Builder for {@link DbxRequestConfig}.
      */
     public static final class Builder {
-        private final String clientIdentifier;
+        private final @Nonnull String clientIdentifier;
 
         private @Nullable String userLocale;
-        private HttpRequestor httpRequestor;
+        private @Nonnull HttpRequestor httpRequestor;
         private int maxRetries;
 
-        private Builder(String clientIdentifier,
+        private Builder(@Nonnull String clientIdentifier,
                         @Nullable String userLocale,
-                        HttpRequestor httpRequestor,
+                        @Nonnull HttpRequestor httpRequestor,
                         int maxRetries) {
             this.clientIdentifier = clientIdentifier;
             this.userLocale = userLocale;
@@ -242,7 +248,7 @@ public class DbxRequestConfig {
             this.maxRetries = maxRetries;
         }
 
-        private Builder(String clientIdentifier) {
+        private Builder(@Nonnull String clientIdentifier) {
             this.clientIdentifier = clientIdentifier;
 
             this.userLocale = null;
@@ -262,7 +268,7 @@ public class DbxRequestConfig {
          *
          * @return this builder
          */
-        public Builder withUserLocale(@Nullable String userLocale) {
+        public @Nonnull Builder withUserLocale(@Nullable String userLocale) {
             this.userLocale = userLocale;
             return this;
         }
@@ -276,7 +282,7 @@ public class DbxRequestConfig {
          *
          * @return this builder
          */
-        public Builder withUserLocaleFromPreferences() {
+        public @Nonnull Builder withUserLocaleFromPreferences() {
             this.userLocale = null;
             return this;
         }
@@ -292,7 +298,7 @@ public class DbxRequestConfig {
          *
          * @return this builder
          */
-        public Builder withUserLocaleFrom(@Nullable Locale userLocale) { // not named withUserLocale because of ambiguous calls when passing 'null'
+        public @Nonnull Builder withUserLocaleFrom(@Nullable Locale userLocale) { // not named withUserLocale because of ambiguous calls when passing 'null'
             this.userLocale = toLanguageTag(userLocale);
             return this;
         }
@@ -306,7 +312,7 @@ public class DbxRequestConfig {
          *
          * @return this builder
          */
-        public Builder withHttpRequestor(HttpRequestor httpRequestor) {
+        public @Nonnull Builder withHttpRequestor(@Nonnull HttpRequestor httpRequestor) {
             if (httpRequestor == null) throw new NullPointerException("httpRequestor");
             this.httpRequestor = httpRequestor;
             return this;
@@ -324,7 +330,7 @@ public class DbxRequestConfig {
          *
          * @return this builder
          */
-        public Builder withAutoRetryEnabled() {
+        public @Nonnull Builder withAutoRetryEnabled() {
             return withAutoRetryEnabled(3);
         }
 
@@ -338,7 +344,7 @@ public class DbxRequestConfig {
          *
          * @see #withAutoRetryEnabled
          */
-        public Builder withAutoRetryDisabled() {
+        public @Nonnull Builder withAutoRetryDisabled() {
             this.maxRetries = 0;
             return this;
         }
@@ -365,7 +371,7 @@ public class DbxRequestConfig {
          *
          * @throws IllegalArgumentException if {@code maxRetries} is not positive.
          */
-        public Builder withAutoRetryEnabled(int maxRetries) {
+        public @Nonnull Builder withAutoRetryEnabled(int maxRetries) {
             if (maxRetries <= 0) throw new IllegalArgumentException("maxRetries must be positive");
             this.maxRetries = maxRetries;
             return this;
@@ -377,7 +383,7 @@ public class DbxRequestConfig {
          *
          * @return new {@code DbxRequestConfig} instance.
          */
-        public DbxRequestConfig build() {
+        public @Nonnull DbxRequestConfig build() {
             return new DbxRequestConfig(clientIdentifier, userLocale, httpRequestor, maxRetries);
         }
     }

--- a/core/src/main/java/com/dropbox/core/DbxRequestConfig.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequestConfig.java
@@ -1,11 +1,11 @@
 package com.dropbox.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.Locale;
 
 import com.dropbox.core.http.HttpRequestor;
 import com.dropbox.core.http.StandardHttpRequestor;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * A grouping of a few configuration parameters for how we should make requests to the
@@ -13,11 +13,11 @@ import com.dropbox.core.http.StandardHttpRequestor;
  */
 public class DbxRequestConfig {
     private final String clientIdentifier;
-    private final /*@Nullable*/String userLocale;
+    private final @Nullable String userLocale;
     private final HttpRequestor httpRequestor;
     private final int maxRetries;
 
-    private DbxRequestConfig(String clientIdentifier, /*@Nullable*/ String userLocale, HttpRequestor httpRequestor, int maxRetries) {
+    private DbxRequestConfig(String clientIdentifier, @Nullable String userLocale, HttpRequestor httpRequestor, int maxRetries) {
         if (clientIdentifier == null) throw new NullPointerException("clientIdentifier");
         if (httpRequestor == null) throw new NullPointerException("httpRequestor");
         if (maxRetries < 0) throw new IllegalArgumentException("maxRetries");
@@ -46,7 +46,7 @@ public class DbxRequestConfig {
      * @deprecated Use {@link #newBuilder} to customize configuration
      */
     @Deprecated
-    public DbxRequestConfig(String clientIdentifier, /*@Nullable*/ String userLocale) {
+    public DbxRequestConfig(String clientIdentifier, @Nullable String userLocale) {
         this(clientIdentifier, userLocale, StandardHttpRequestor.INSTANCE);
     }
 
@@ -60,7 +60,7 @@ public class DbxRequestConfig {
      * @deprecated Use {@link #newBuilder} to customize configuration
      */
     @Deprecated
-    public DbxRequestConfig(String clientIdentifier, /*@Nullable*/ String userLocale, HttpRequestor httpRequestor) {
+    public DbxRequestConfig(String clientIdentifier, @Nullable String userLocale, HttpRequestor httpRequestor) {
         this(clientIdentifier, userLocale, httpRequestor, 0);
     }
 
@@ -228,12 +228,12 @@ public class DbxRequestConfig {
     public static final class Builder {
         private final String clientIdentifier;
 
-        private /*@Nullable*/ String userLocale;
+        private @Nullable String userLocale;
         private HttpRequestor httpRequestor;
         private int maxRetries;
 
         private Builder(String clientIdentifier,
-                        /*@Nullable*/ String userLocale,
+                        @Nullable String userLocale,
                         HttpRequestor httpRequestor,
                         int maxRetries) {
             this.clientIdentifier = clientIdentifier;
@@ -262,7 +262,7 @@ public class DbxRequestConfig {
          *
          * @return this builder
          */
-        public Builder withUserLocale(/*@Nullable*/ String userLocale) {
+        public Builder withUserLocale(@Nullable String userLocale) {
             this.userLocale = userLocale;
             return this;
         }
@@ -292,7 +292,7 @@ public class DbxRequestConfig {
          *
          * @return this builder
          */
-        public Builder withUserLocaleFrom(/*@Nullable*/ Locale userLocale) { // not named withUserLocale because of ambiguous calls when passing 'null'
+        public Builder withUserLocaleFrom(@Nullable Locale userLocale) { // not named withUserLocale because of ambiguous calls when passing 'null'
             this.userLocale = toLanguageTag(userLocale);
             return this;
         }

--- a/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -50,7 +50,7 @@ public final class DbxRequestUtil {
     public static String buildUrlWithParams(@Nullable String userLocale,
                                             String host,
                                             String path,
-                                            @Nullable String @Nullable [] params) {
+                                            @Nullable String[] params) {
         return buildUri(host, path) + "?" + encodeUrlParams(userLocale, params);
     }
 
@@ -75,7 +75,7 @@ public final class DbxRequestUtil {
     }
 
     private static String encodeUrlParams(@Nullable String userLocale,
-                                          @Nullable String @Nullable [] params) {
+                                          @Nullable String[] params) {
         StringBuilder buf = new StringBuilder();
         String sep = "";
         if (userLocale != null) {
@@ -198,7 +198,7 @@ public final class DbxRequestUtil {
                                                   String sdkUserAgentIdentifier,
                                                   String host,
                                                   String path,
-                                                  @Nullable String @Nullable [] params,
+                                                  @Nullable String[] params,
                                                   @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         headers = copyHeaders(headers);
@@ -221,7 +221,7 @@ public final class DbxRequestUtil {
                                                   String accessToken,
                                                   String sdkUserAgentIdentifier,
                                                   String host, String path,
-                                                  @Nullable String @Nullable [] params,
+                                                  @Nullable String[] params,
                                                   @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         headers = copyHeaders(headers);
@@ -244,7 +244,7 @@ public final class DbxRequestUtil {
                                                          String sdkUserAgentIdentifier,
                                                          String host,
                                                          String path,
-                                                         @Nullable String @Nullable [] params,
+                                                         @Nullable String[] params,
                                                          @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         byte[] encodedParams = StringUtil.stringToUtf8(encodeUrlParams(requestConfig.getUserLocale(), params));
@@ -459,7 +459,7 @@ public final class DbxRequestUtil {
                               final String sdkUserAgentIdentifier,
                               final String host,
                               final String path,
-                              final @Nullable String @Nullable [] params,
+                              final @Nullable String[] params,
                               final @Nullable List<HttpRequestor.Header> headers,
                               final ResponseHandler<T> handler)
         throws DbxException {
@@ -486,7 +486,7 @@ public final class DbxRequestUtil {
                                String sdkUserAgentIdentifier,
                                String host,
                                String path,
-                               @Nullable String @Nullable [] params,
+                               @Nullable String[] params,
                                @Nullable List<HttpRequestor.Header> headers,
                                ResponseHandler<T> handler)
         throws DbxException {
@@ -499,7 +499,7 @@ public final class DbxRequestUtil {
                                      final String sdkUserAgentIdentifier,
                                      final String host,
                                      final String path,
-                                     final @Nullable String @Nullable [] params,
+                                     final @Nullable String[] params,
                                      final @Nullable List<HttpRequestor.Header> headers,
                                      final ResponseHandler<T> handler)
         throws DbxException {

--- a/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -37,9 +38,9 @@ import static com.dropbox.core.util.LangUtil.mkAssert;
 public final class DbxRequestUtil {
     private static final Random RAND = new Random();
 
-    public static DbxGlobalCallbackFactory sharedCallbackFactory;
+    public static @Nullable DbxGlobalCallbackFactory sharedCallbackFactory;
 
-    public static String encodeUrlParam(String s) {
+    public static @Nonnull String encodeUrlParam(@Nonnull String s) {
         try {
             return URLEncoder.encode(s, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
@@ -47,14 +48,14 @@ public final class DbxRequestUtil {
         }
     }
 
-    public static String buildUrlWithParams(@Nullable String userLocale,
-                                            String host,
-                                            String path,
+    public static @Nonnull String buildUrlWithParams(@Nullable String userLocale,
+                                            @Nonnull String host,
+                                            @Nonnull String path,
                                             @Nullable String[] params) {
         return buildUri(host, path) + "?" + encodeUrlParams(userLocale, params);
     }
 
-    public static String [] toParamsArray(Map<String, String> params) {
+    public static @Nonnull String [] toParamsArray(@Nonnull Map<String, String> params) {
         String [] arr = new String[2 * params.size()];
         int i = 0;
         for (Map.Entry<String, String> entry : params.entrySet()) {
@@ -65,7 +66,7 @@ public final class DbxRequestUtil {
         return arr;
     }
 
-    public static String buildUri(String host, String path) {
+    public static @Nonnull String buildUri(@Nonnull String host, @Nonnull String path) {
         try {
             return new URI("https", host, "/" + path, null).toASCIIString();
         }
@@ -74,7 +75,7 @@ public final class DbxRequestUtil {
         }
     }
 
-    private static String encodeUrlParams(@Nullable String userLocale,
+    private static @Nonnull String encodeUrlParams(@Nullable String userLocale,
                                           @Nullable String[] params) {
         StringBuilder buf = new StringBuilder();
         String sep = "";
@@ -104,7 +105,8 @@ public final class DbxRequestUtil {
         return buf.toString();
     }
 
-    public static List<HttpRequestor.Header> addAuthHeader(@Nullable List<HttpRequestor.Header> headers, String accessToken) {
+    public static @Nonnull List<HttpRequestor.Header> addAuthHeader(@Nullable List<HttpRequestor.Header> headers,
+                                                                    @Nonnull String accessToken) {
         if (accessToken == null) throw new NullPointerException("accessToken");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
 
@@ -112,7 +114,8 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addSelectUserHeader(@Nullable List<HttpRequestor.Header> headers, String memberId) {
+    public static @Nonnull List<HttpRequestor.Header> addSelectUserHeader(@Nullable List<HttpRequestor.Header> headers,
+                                                                          @Nonnull String memberId) {
         if (memberId == null) throw new NullPointerException("memberId");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
 
@@ -120,7 +123,8 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addSelectAdminHeader(@Nullable List<HttpRequestor.Header> headers, String adminId) {
+    public static @Nonnull List<HttpRequestor.Header> addSelectAdminHeader(@Nullable List<HttpRequestor.Header> headers,
+                                                                           @Nonnull String adminId) {
         if (adminId == null) throw new NullPointerException("adminId");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
 
@@ -128,7 +132,9 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addBasicAuthHeader(@Nullable List<HttpRequestor.Header> headers, String username, String password) {
+    public static @Nonnull List<HttpRequestor.Header> addBasicAuthHeader(@Nullable List<HttpRequestor.Header> headers,
+                                                                         @Nonnull String username,
+                                                                         @Nonnull String password) {
         if (username == null) throw new NullPointerException("username");
         if (password == null) throw new NullPointerException("password");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
@@ -139,17 +145,18 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addUserAgentHeader(
+    public static @Nonnull List<HttpRequestor.Header> addUserAgentHeader(
         @Nullable List<HttpRequestor.Header> headers,
-        DbxRequestConfig requestConfig,
-        String sdkUserAgentIdentifier
+        @Nonnull DbxRequestConfig requestConfig,
+        @Nonnull String sdkUserAgentIdentifier
     ) {
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
         headers.add(buildUserAgentHeader(requestConfig, sdkUserAgentIdentifier));
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addUserLocaleHeader(@Nullable List<HttpRequestor.Header> headers, DbxRequestConfig requestConfig) {
+    public static @Nullable List<HttpRequestor.Header> addUserLocaleHeader(@Nullable List<HttpRequestor.Header> headers,
+                                                                           @Nonnull DbxRequestConfig requestConfig) {
         if (requestConfig.getUserLocale() == null) {
             return headers;
         }
@@ -159,11 +166,13 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static HttpRequestor.Header buildUserAgentHeader(DbxRequestConfig requestConfig, String sdkUserAgentIdentifier) {
+    public static @Nonnull HttpRequestor.Header buildUserAgentHeader(@Nonnull DbxRequestConfig requestConfig,
+                                                                     @Nonnull String sdkUserAgentIdentifier) {
         return new HttpRequestor.Header("User-Agent",  requestConfig.getClientIdentifier() + " " + sdkUserAgentIdentifier + "/" + DbxSdkVersion.Version);
     }
 
-    public static List<HttpRequestor.Header> addPathRootHeader(@Nullable List<HttpRequestor.Header> headers, PathRoot pathRoot) {
+    public static @Nullable List<HttpRequestor.Header> addPathRootHeader(@Nullable List<HttpRequestor.Header> headers,
+                                                                         @Nullable PathRoot pathRoot) {
         if (pathRoot == null) {
             return headers;
         }
@@ -173,7 +182,7 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> removeAuthHeader(@Nullable List<HttpRequestor.Header> headers) {
+    public static @Nonnull List<HttpRequestor.Header> removeAuthHeader(@Nullable List<HttpRequestor.Header> headers) {
         if (headers == null) {
             return new ArrayList<HttpRequestor.Header>();
         }
@@ -193,11 +202,11 @@ public final class DbxRequestUtil {
     /**
      * Convenience function for making HTTP GET requests.
      */
-    public static HttpRequestor.Response startGet(DbxRequestConfig requestConfig,
-                                                  String accessToken,
-                                                  String sdkUserAgentIdentifier,
-                                                  String host,
-                                                  String path,
+    public static @Nonnull HttpRequestor.Response startGet(@Nonnull DbxRequestConfig requestConfig,
+                                                  @Nonnull String accessToken,
+                                                  @Nonnull String sdkUserAgentIdentifier,
+                                                  @Nonnull String host,
+                                                  @Nonnull String path,
                                                   @Nullable String[] params,
                                                   @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
@@ -217,10 +226,10 @@ public final class DbxRequestUtil {
     /**
      * Convenience function for making HTTP PUT requests.
      */
-    public static HttpRequestor.Uploader startPut(DbxRequestConfig requestConfig,
-                                                  String accessToken,
-                                                  String sdkUserAgentIdentifier,
-                                                  String host, String path,
+    public static @Nonnull HttpRequestor.Uploader startPut(@Nonnull DbxRequestConfig requestConfig,
+                                                  @Nonnull String accessToken,
+                                                  @Nonnull String sdkUserAgentIdentifier,
+                                                  @Nonnull String host, @Nonnull String path,
                                                   @Nullable String[] params,
                                                   @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
@@ -240,10 +249,10 @@ public final class DbxRequestUtil {
     /**
      * Convenience function for making HTTP POST requests.
      */
-    public static HttpRequestor.Response startPostNoAuth(DbxRequestConfig requestConfig,
-                                                         String sdkUserAgentIdentifier,
-                                                         String host,
-                                                         String path,
+    public static @Nonnull HttpRequestor.Response startPostNoAuth(@Nonnull DbxRequestConfig requestConfig,
+                                                         @Nonnull String sdkUserAgentIdentifier,
+                                                         @Nonnull String host,
+                                                         @Nonnull String path,
                                                          @Nullable String[] params,
                                                          @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
@@ -259,11 +268,11 @@ public final class DbxRequestUtil {
     /**
      * Convenience function for making HTTP POST requests.  Like startPostNoAuth but takes byte[] instead of params.
      */
-    public static HttpRequestor.Response startPostRaw(DbxRequestConfig requestConfig,
-                                                      String sdkUserAgentIdentifier,
-                                                      String host,
-                                                      String path,
-                                                      byte[] body,
+    public static @Nonnull HttpRequestor.Response startPostRaw(@Nonnull DbxRequestConfig requestConfig,
+                                                      @Nonnull String sdkUserAgentIdentifier,
+                                                      @Nonnull String host,
+                                                      @Nonnull String path,
+                                                      @Nonnull byte[] body,
                                                       @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         String uri = buildUri(host, path);
@@ -285,7 +294,7 @@ public final class DbxRequestUtil {
         }
     }
 
-    private static List<HttpRequestor.Header> copyHeaders(List<HttpRequestor.Header> headers) {
+    private static @Nonnull List<HttpRequestor.Header> copyHeaders(@Nullable List<HttpRequestor.Header> headers) {
         if (headers == null) {
             return new ArrayList<HttpRequestor.Header>();
         } else {
@@ -293,7 +302,7 @@ public final class DbxRequestUtil {
         }
     }
 
-    public static byte[] loadErrorBody(HttpRequestor.Response response)
+    public static @Nonnull byte[] loadErrorBody(@Nonnull HttpRequestor.Response response)
         throws NetworkIOException {
         if (response.getBody() == null) {
             return new byte[0];
@@ -308,7 +317,7 @@ public final class DbxRequestUtil {
 
     }
 
-    public static String parseErrorBody(String requestId, int statusCode, byte[] body)
+    public static @Nonnull String parseErrorBody(@Nullable String requestId, int statusCode, @Nonnull byte[] body)
         throws BadResponseException {
         // Read the error message from the body.
         // TODO: Get charset from the HTTP Content-Type header.  It's wrong to just assume UTF-8.
@@ -320,11 +329,11 @@ public final class DbxRequestUtil {
         }
     }
 
-    public static DbxException unexpectedStatus(HttpRequestor.Response response) throws NetworkIOException, BadResponseException {
+    public static @Nonnull DbxException unexpectedStatus(@Nonnull HttpRequestor.Response response) throws NetworkIOException, BadResponseException {
         return DbxRequestUtil.unexpectedStatus(response, null);
     }
 
-    public static DbxException unexpectedStatus(HttpRequestor.Response response, String userId)
+    public static @Nonnull DbxException unexpectedStatus(@Nonnull HttpRequestor.Response response, @Nullable String userId)
         throws NetworkIOException, BadResponseException {
 
         String requestId = getRequestId(response);
@@ -426,13 +435,15 @@ public final class DbxRequestUtil {
         return networkError;
     }
 
-    private static String messageFromResponse(HttpRequestor.Response response, String requestId) throws NetworkIOException, BadResponseException {
+    private static @Nonnull String messageFromResponse(@Nonnull HttpRequestor.Response response,
+                                                       @Nullable String requestId) throws NetworkIOException, BadResponseException {
         byte[] body = loadErrorBody(response);
         String message = parseErrorBody(requestId, response.getStatusCode(), body);
         return message;
     }
 
-    public static <T> T readJsonFromResponse(JsonReader<T> reader, HttpRequestor.Response response)
+    public static <T> @Nullable T readJsonFromResponse(@Nonnull JsonReader<T> reader,
+                                                       @Nonnull HttpRequestor.Response response)
         throws BadResponseException, NetworkIOException {
         try {
             return reader.readFully(response.getBody());
@@ -444,75 +455,73 @@ public final class DbxRequestUtil {
         }
     }
 
-    public static <T> T readJsonFromErrorMessage(StoneSerializer<T> serializer, String message, String requestId)
+    public static <T> @Nonnull T readJsonFromErrorMessage(@Nonnull StoneSerializer<T> serializer,
+                                                          @Nonnull String message,
+                                                          @Nullable String requestId)
         throws JsonParseException {
         ApiErrorResponse<T> errorResponse = new ApiErrorResponse.Serializer<T>(serializer).deserialize(message);
         return errorResponse.getError();
     }
 
     public static abstract class ResponseHandler<T> {
-        public abstract T handle(HttpRequestor.Response response) throws DbxException;
+        public abstract @Nullable T handle(@Nonnull HttpRequestor.Response response) throws DbxException;
     }
 
-    public static <T> T doGet(final DbxRequestConfig requestConfig,
-                              final String accessToken,
-                              final String sdkUserAgentIdentifier,
-                              final String host,
-                              final String path,
+    public static <T> @Nullable T doGet(final @Nonnull DbxRequestConfig requestConfig,
+                              final @Nonnull String accessToken,
+                              final @Nonnull String sdkUserAgentIdentifier,
+                              final @Nonnull String host,
+                              final @Nonnull String path,
                               final @Nullable String[] params,
                               final @Nullable List<HttpRequestor.Header> headers,
-                              final ResponseHandler<T> handler)
+                              final @Nonnull ResponseHandler<T> handler)
         throws DbxException {
         return runAndRetry(requestConfig.getMaxRetries(), new RequestMaker<T, DbxException>() {
             @Override
-            public T run() throws DbxException {
+            public @Nullable T run() throws DbxException {
                 HttpRequestor.Response response = startGet(requestConfig, accessToken, sdkUserAgentIdentifier, host, path, params, headers);
                 try {
                     return handler.handle(response);
                 } finally {
-                    try {
-                        response.getBody().close();
-                    } catch (IOException ex) {
-                        //noinspection ThrowFromFinallyBlock
-                        throw new NetworkIOException(ex);
-                    }
+                    IOUtil.closeInput(response.getBody());
                 }
             }
         });
     }
 
-    public static <T> T doPost(DbxRequestConfig requestConfig,
-                               String accessToken,
-                               String sdkUserAgentIdentifier,
-                               String host,
-                               String path,
+    public static <T> @Nullable T doPost(@Nonnull DbxRequestConfig requestConfig,
+                               @Nonnull String accessToken,
+                               @Nonnull String sdkUserAgentIdentifier,
+                               @Nonnull String host,
+                               @Nonnull String path,
                                @Nullable String[] params,
                                @Nullable List<HttpRequestor.Header> headers,
-                               ResponseHandler<T> handler)
+                               @Nonnull ResponseHandler<T> handler)
         throws DbxException {
         headers = copyHeaders(headers);
         headers = addAuthHeader(headers, accessToken);
         return doPostNoAuth(requestConfig, sdkUserAgentIdentifier, host, path, params, headers, handler);
     }
 
-    public static <T> T doPostNoAuth(final DbxRequestConfig requestConfig,
-                                     final String sdkUserAgentIdentifier,
-                                     final String host,
-                                     final String path,
+    public static <T> @Nullable T doPostNoAuth(final @Nonnull DbxRequestConfig requestConfig,
+                                     final @Nonnull String sdkUserAgentIdentifier,
+                                     final @Nonnull String host,
+                                     final @Nonnull String path,
                                      final @Nullable String[] params,
                                      final @Nullable List<HttpRequestor.Header> headers,
-                                     final ResponseHandler<T> handler)
+                                     final @Nonnull ResponseHandler<T> handler)
         throws DbxException {
         return runAndRetry(requestConfig.getMaxRetries(), new RequestMaker<T, DbxException>() {
             @Override
-            public T run() throws DbxException {
+            public @Nullable T run() throws DbxException {
                 HttpRequestor.Response response = startPostNoAuth(requestConfig, sdkUserAgentIdentifier, host, path, params, headers);
                 return finishResponse(response, handler);
             }
         });
     }
 
-    public static <T> T finishResponse(HttpRequestor.Response response, ResponseHandler<T> handler) throws DbxException {
+    public static <T> @Nullable T finishResponse(@Nonnull HttpRequestor.Response response,
+                                                 @Nonnull ResponseHandler<T> handler) throws DbxException {
         try {
             return handler.handle(response);
         } finally {
@@ -522,7 +531,8 @@ public final class DbxRequestUtil {
         }
     }
 
-    public static String getFirstHeader(HttpRequestor.Response response, String name) throws BadResponseException {
+    public static @Nonnull String getFirstHeader(@Nonnull HttpRequestor.Response response,
+                                                 @Nonnull String name) throws BadResponseException {
         List<String> values = response.getHeaders().get(name);
         if (values == null || values.isEmpty()) {
             throw new BadResponseException(getRequestId(response), "missing HTTP header \"" + name + "\"");
@@ -530,7 +540,7 @@ public final class DbxRequestUtil {
         return values.get(0);
     }
 
-    public static @Nullable String getFirstHeaderMaybe(HttpRequestor.Response response, String name) {
+    public static @Nullable String getFirstHeaderMaybe(@Nonnull HttpRequestor.Response response, @Nonnull String name) {
         List<String> values = response.getHeaders().get(name);
         if (values == null || values.isEmpty()) {
             return null;
@@ -538,19 +548,20 @@ public final class DbxRequestUtil {
         return values.get(0);
     }
 
-    public static @Nullable String getRequestId(HttpRequestor.Response response) {
+    public static @Nullable String getRequestId(@Nonnull HttpRequestor.Response response) {
         return DbxRequestUtil.getFirstHeaderMaybe(response, "X-Dropbox-Request-Id");
     }
 
-    public static @Nullable String getContentType(HttpRequestor.Response response) {
+    public static @Nullable String getContentType(@Nonnull HttpRequestor.Response response) {
         return DbxRequestUtil.getFirstHeaderMaybe(response, "Content-Type");
     }
 
     public static abstract class RequestMaker<T, E extends Throwable> {
-        public abstract T run() throws DbxException, E;
+        public abstract @Nullable T run() throws DbxException, E;
     }
 
-    public static <T, E extends Throwable> T runAndRetry(int maxRetries, RequestMaker<T,E> requestMaker)
+    public static <T, E extends Throwable> @Nullable T runAndRetry(int maxRetries,
+                                                                   @Nonnull RequestMaker<T,E> requestMaker)
         throws DbxException, E {
         int numRetries = 0;
         while (true) {

--- a/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -32,7 +33,6 @@ import com.dropbox.core.v2.common.PathRootError.Serializer;
 import static com.dropbox.core.util.StringUtil.jq;
 import static com.dropbox.core.util.LangUtil.mkAssert;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 public final class DbxRequestUtil {
     private static final Random RAND = new Random();
@@ -47,10 +47,10 @@ public final class DbxRequestUtil {
         }
     }
 
-    public static String buildUrlWithParams(/*@Nullable*/String userLocale,
+    public static String buildUrlWithParams(@Nullable String userLocale,
                                             String host,
                                             String path,
-                                            /*@Nullable*/String/*@Nullable*/[] params) {
+                                            @Nullable String @Nullable [] params) {
         return buildUri(host, path) + "?" + encodeUrlParams(userLocale, params);
     }
 
@@ -74,8 +74,8 @@ public final class DbxRequestUtil {
         }
     }
 
-    private static String encodeUrlParams(/*@Nullable*/String userLocale,
-                                          /*@Nullable*/String/*@Nullable*/[] params) {
+    private static String encodeUrlParams(@Nullable String userLocale,
+                                          @Nullable String @Nullable [] params) {
         StringBuilder buf = new StringBuilder();
         String sep = "";
         if (userLocale != null) {
@@ -104,7 +104,7 @@ public final class DbxRequestUtil {
         return buf.toString();
     }
 
-    public static List<HttpRequestor.Header> addAuthHeader(/*@Nullable*/List<HttpRequestor.Header> headers, String accessToken) {
+    public static List<HttpRequestor.Header> addAuthHeader(@Nullable List<HttpRequestor.Header> headers, String accessToken) {
         if (accessToken == null) throw new NullPointerException("accessToken");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
 
@@ -112,7 +112,7 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addSelectUserHeader(/*@Nullable*/List<HttpRequestor.Header> headers, String memberId) {
+    public static List<HttpRequestor.Header> addSelectUserHeader(@Nullable List<HttpRequestor.Header> headers, String memberId) {
         if (memberId == null) throw new NullPointerException("memberId");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
 
@@ -120,7 +120,7 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addSelectAdminHeader(/*@Nullable*/List<HttpRequestor.Header> headers, String adminId) {
+    public static List<HttpRequestor.Header> addSelectAdminHeader(@Nullable List<HttpRequestor.Header> headers, String adminId) {
         if (adminId == null) throw new NullPointerException("adminId");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
 
@@ -128,7 +128,7 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addBasicAuthHeader(/*@Nullable*/List<HttpRequestor.Header> headers, String username, String password) {
+    public static List<HttpRequestor.Header> addBasicAuthHeader(@Nullable List<HttpRequestor.Header> headers, String username, String password) {
         if (username == null) throw new NullPointerException("username");
         if (password == null) throw new NullPointerException("password");
         if (headers == null) headers = new ArrayList<HttpRequestor.Header>();
@@ -140,7 +140,7 @@ public final class DbxRequestUtil {
     }
 
     public static List<HttpRequestor.Header> addUserAgentHeader(
-        /*@Nullable*/List<HttpRequestor.Header> headers,
+        @Nullable List<HttpRequestor.Header> headers,
         DbxRequestConfig requestConfig,
         String sdkUserAgentIdentifier
     ) {
@@ -149,7 +149,7 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> addUserLocaleHeader(/*@Nullable*/List<HttpRequestor.Header> headers, DbxRequestConfig requestConfig) {
+    public static List<HttpRequestor.Header> addUserLocaleHeader(@Nullable List<HttpRequestor.Header> headers, DbxRequestConfig requestConfig) {
         if (requestConfig.getUserLocale() == null) {
             return headers;
         }
@@ -163,7 +163,7 @@ public final class DbxRequestUtil {
         return new HttpRequestor.Header("User-Agent",  requestConfig.getClientIdentifier() + " " + sdkUserAgentIdentifier + "/" + DbxSdkVersion.Version);
     }
 
-    public static List<HttpRequestor.Header> addPathRootHeader(/*@Nullable*/List<HttpRequestor.Header> headers, PathRoot pathRoot) {
+    public static List<HttpRequestor.Header> addPathRootHeader(@Nullable List<HttpRequestor.Header> headers, PathRoot pathRoot) {
         if (pathRoot == null) {
             return headers;
         }
@@ -173,7 +173,7 @@ public final class DbxRequestUtil {
         return headers;
     }
 
-    public static List<HttpRequestor.Header> removeAuthHeader(/*@Nullable*/List<HttpRequestor.Header> headers) {
+    public static List<HttpRequestor.Header> removeAuthHeader(@Nullable List<HttpRequestor.Header> headers) {
         if (headers == null) {
             return new ArrayList<HttpRequestor.Header>();
         }
@@ -198,8 +198,8 @@ public final class DbxRequestUtil {
                                                   String sdkUserAgentIdentifier,
                                                   String host,
                                                   String path,
-                                                  /*@Nullable*/String/*@Nullable*/[] params,
-                                                  /*@Nullable*/List<HttpRequestor.Header> headers)
+                                                  @Nullable String @Nullable [] params,
+                                                  @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         headers = copyHeaders(headers);
         headers = addUserAgentHeader(headers, requestConfig, sdkUserAgentIdentifier);
@@ -221,8 +221,8 @@ public final class DbxRequestUtil {
                                                   String accessToken,
                                                   String sdkUserAgentIdentifier,
                                                   String host, String path,
-                                                  /*@Nullable*/String/*@Nullable*/[] params,
-                                                  /*@Nullable*/List<HttpRequestor.Header> headers)
+                                                  @Nullable String @Nullable [] params,
+                                                  @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         headers = copyHeaders(headers);
         headers = addUserAgentHeader(headers, requestConfig, sdkUserAgentIdentifier);
@@ -244,8 +244,8 @@ public final class DbxRequestUtil {
                                                          String sdkUserAgentIdentifier,
                                                          String host,
                                                          String path,
-                                                         /*@Nullable*/String/*@Nullable*/[] params,
-                                                         /*@Nullable*/List<HttpRequestor.Header> headers)
+                                                         @Nullable String @Nullable [] params,
+                                                         @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         byte[] encodedParams = StringUtil.stringToUtf8(encodeUrlParams(requestConfig.getUserLocale(), params));
 
@@ -264,7 +264,7 @@ public final class DbxRequestUtil {
                                                       String host,
                                                       String path,
                                                       byte[] body,
-                                                      /*@Nullable*/List<HttpRequestor.Header> headers)
+                                                      @Nullable List<HttpRequestor.Header> headers)
         throws NetworkIOException {
         String uri = buildUri(host, path);
 
@@ -459,8 +459,8 @@ public final class DbxRequestUtil {
                               final String sdkUserAgentIdentifier,
                               final String host,
                               final String path,
-                              final /*@Nullable*/String/*@Nullable*/[] params,
-                              final /*@Nullable*/List<HttpRequestor.Header> headers,
+                              final @Nullable String @Nullable [] params,
+                              final @Nullable List<HttpRequestor.Header> headers,
                               final ResponseHandler<T> handler)
         throws DbxException {
         return runAndRetry(requestConfig.getMaxRetries(), new RequestMaker<T, DbxException>() {
@@ -486,8 +486,8 @@ public final class DbxRequestUtil {
                                String sdkUserAgentIdentifier,
                                String host,
                                String path,
-                               /*@Nullable*/String/*@Nullable*/[] params,
-                               /*@Nullable*/List<HttpRequestor.Header> headers,
+                               @Nullable String @Nullable [] params,
+                               @Nullable List<HttpRequestor.Header> headers,
                                ResponseHandler<T> handler)
         throws DbxException {
         headers = copyHeaders(headers);
@@ -499,8 +499,8 @@ public final class DbxRequestUtil {
                                      final String sdkUserAgentIdentifier,
                                      final String host,
                                      final String path,
-                                     final /*@Nullable*/String/*@Nullable*/[] params,
-                                     final /*@Nullable*/List<HttpRequestor.Header> headers,
+                                     final @Nullable String @Nullable [] params,
+                                     final @Nullable List<HttpRequestor.Header> headers,
                                      final ResponseHandler<T> handler)
         throws DbxException {
         return runAndRetry(requestConfig.getMaxRetries(), new RequestMaker<T, DbxException>() {
@@ -530,7 +530,7 @@ public final class DbxRequestUtil {
         return values.get(0);
     }
 
-    public static /*@Nullable*/String getFirstHeaderMaybe(HttpRequestor.Response response, String name) {
+    public static @Nullable String getFirstHeaderMaybe(HttpRequestor.Response response, String name) {
         List<String> values = response.getHeaders().get(name);
         if (values == null || values.isEmpty()) {
             return null;
@@ -538,11 +538,11 @@ public final class DbxRequestUtil {
         return values.get(0);
     }
 
-    public static /*@Nullable*/ String getRequestId(HttpRequestor.Response response) {
+    public static @Nullable String getRequestId(HttpRequestor.Response response) {
         return DbxRequestUtil.getFirstHeaderMaybe(response, "X-Dropbox-Request-Id");
     }
 
-    public static /*@Nullable*/ String getContentType(HttpRequestor.Response response) {
+    public static @Nullable String getContentType(HttpRequestor.Response response) {
         return DbxRequestUtil.getFirstHeaderMaybe(response, "Content-Type");
     }
 

--- a/core/src/main/java/com/dropbox/core/DbxSessionStore.java
+++ b/core/src/main/java/com/dropbox/core/DbxSessionStore.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-/*>>> import checkers.nullness.quals.Nullable; */
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An interface that lets you save, retrieve, and clear a single value in the user's web
@@ -12,7 +12,7 @@ package com.dropbox.core;
  * </pre>
  */
 public interface DbxSessionStore {
-    public /*@Nullable*/String get();
+    public @Nullable String get();
     public void set(String value);
     public void clear();
 }

--- a/core/src/main/java/com/dropbox/core/DbxSessionStore.java
+++ b/core/src/main/java/com/dropbox/core/DbxSessionStore.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 
 /**
  * An interface that lets you save, retrieve, and clear a single value in the user's web

--- a/core/src/main/java/com/dropbox/core/DbxSessionStore.java
+++ b/core/src/main/java/com/dropbox/core/DbxSessionStore.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -13,6 +14,6 @@ import javax.annotation.Nullable;
  */
 public interface DbxSessionStore {
     public @Nullable String get();
-    public void set(String value);
+    public void set(@Nonnull String value);
     public void clear();
 }

--- a/core/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
+++ b/core/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jakarta.servlet.http.HttpSession;
 
@@ -20,19 +21,19 @@ import jakarta.servlet.http.HttpSession;
  * </pre>
  */
 public final class DbxStandardSessionStore implements DbxSessionStore {
-    private final HttpSession session;
-    private final String key;
+    private final @Nonnull HttpSession session;
+    private final @Nonnull String key;
 
-    public DbxStandardSessionStore(HttpSession session, String key) {
+    public DbxStandardSessionStore(@Nonnull HttpSession session, @Nonnull String key) {
         this.session = session;
         this.key = key;
     }
 
-    public HttpSession getSession() {
+    public @Nonnull HttpSession getSession() {
         return session;
     }
 
-    public String getKey() {
+    public @Nonnull String getKey() {
         return key;
     }
 
@@ -44,7 +45,7 @@ public final class DbxStandardSessionStore implements DbxSessionStore {
     }
 
     @Override
-    public void set(String value) {
+    public void set(@Nonnull String value) {
         session.setAttribute(key, value);
     }
 

--- a/core/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
+++ b/core/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
@@ -1,8 +1,8 @@
 package com.dropbox.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import jakarta.servlet.http.HttpSession;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * A {@link DbxSessionStore} implementation that stores the value using the standard
@@ -37,7 +37,7 @@ public final class DbxStandardSessionStore implements DbxSessionStore {
     }
 
     @Override
-    public /*@Nullable*/String get() {
+    public @Nullable String get() {
         Object v = session.getAttribute(key);
         if (v instanceof String) return (String) v;
         return null;

--- a/core/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
+++ b/core/src/main/java/com/dropbox/core/DbxStandardSessionStore.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import jakarta.servlet.http.HttpSession;
 
 

--- a/core/src/main/java/com/dropbox/core/DbxStreamReader.java
+++ b/core/src/main/java/com/dropbox/core/DbxStreamReader.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+
 /**
  * A callback for streaming data from an {@link InputStream}.
  *
@@ -21,7 +23,7 @@ public abstract class DbxStreamReader<E extends Throwable>
      * call {@link InputStream#close close()} on the stream (the stream will
      * be closed automatically).
      */
-    public abstract void read(NoThrowInputStream in) throws E;
+    public abstract void read(@Nonnull NoThrowInputStream in) throws E;
 
     /**
      * A {@link DbxStreamReader} that gets its source data from the given {@code OutputStream}.
@@ -29,14 +31,14 @@ public abstract class DbxStreamReader<E extends Throwable>
      */
     public static final class OutputStreamCopier extends DbxStreamReader<IOException>
     {
-        private final OutputStream dest;
+        private final @Nonnull OutputStream dest;
 
-        public OutputStreamCopier(OutputStream dest)
+        public OutputStreamCopier(@Nonnull OutputStream dest)
         {
             this.dest = dest;
         }
 
-        public void read(NoThrowInputStream source) throws IOException
+        public void read(@Nonnull NoThrowInputStream source) throws IOException
         {
             IOUtil.copyStreamToStream(source, dest);
         }
@@ -44,11 +46,11 @@ public abstract class DbxStreamReader<E extends Throwable>
 
     public static final class ByteArrayCopier extends DbxStreamReader<RuntimeException>
     {
-        private final byte[] data;
+        private final @Nonnull byte[] data;
         private final int offset;
         private final int length;
 
-        public ByteArrayCopier(byte[] data, int offset, int length)
+        public ByteArrayCopier(@Nonnull byte[] data, int offset, int length)
         {
             if (data == null) throw new IllegalArgumentException("'data' can't be null");
             if (offset < 0 || offset >= data.length) throw new IllegalArgumentException("'offset' is out of bounds");
@@ -58,13 +60,13 @@ public abstract class DbxStreamReader<E extends Throwable>
             this.length = length;
         }
 
-        public ByteArrayCopier(byte[] data)
+        public ByteArrayCopier(@Nonnull byte[] data)
         {
             this(data, 0, data.length);
         }
 
         @Override
-        public void read(NoThrowInputStream in)
+        public void read(@Nonnull NoThrowInputStream in)
         {
             in.read(this.data, this.offset, this.length);
         }

--- a/core/src/main/java/com/dropbox/core/DbxStreamWriter.java
+++ b/core/src/main/java/com/dropbox/core/DbxStreamWriter.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+
 /**
  * A callback for streaming data to an {@link OutputStream}.
  *
@@ -21,7 +23,7 @@ public abstract class DbxStreamWriter<E extends Throwable>
      * call {@link OutputStream#close close()} on the stream (the stream will
      * be closed automatically).
      */
-    public abstract void write(NoThrowOutputStream out) throws E;
+    public abstract void write(@Nonnull NoThrowOutputStream out) throws E;
 
     /**
      * A {@link DbxStreamWriter} that gets its source data from the given {@code InputStream}.
@@ -29,14 +31,14 @@ public abstract class DbxStreamWriter<E extends Throwable>
      */
     public static final class InputStreamCopier extends DbxStreamWriter<IOException>
     {
-        private final InputStream source;
+        private final @Nonnull InputStream source;
 
-        public InputStreamCopier(InputStream source)
+        public InputStreamCopier(@Nonnull InputStream source)
         {
             this.source = source;
         }
 
-        public void write(NoThrowOutputStream out) throws IOException
+        public void write(@Nonnull NoThrowOutputStream out) throws IOException
         {
             IOUtil.copyStreamToStream(source, out);
         }
@@ -44,11 +46,11 @@ public abstract class DbxStreamWriter<E extends Throwable>
 
     public static final class ByteArrayCopier extends DbxStreamWriter<RuntimeException>
     {
-        private final byte[] data;
+        private final @Nonnull byte[] data;
         private final int offset;
         private final int length;
 
-        public ByteArrayCopier(byte[] data, int offset, int length)
+        public ByteArrayCopier(@Nonnull byte[] data, int offset, int length)
         {
             if (data == null) throw new IllegalArgumentException("'data' can't be null");
             if (offset < 0 || offset >= data.length) throw new IllegalArgumentException("'offset' is out of bounds");
@@ -58,13 +60,13 @@ public abstract class DbxStreamWriter<E extends Throwable>
             this.length = length;
         }
 
-        public ByteArrayCopier(byte[] data)
+        public ByteArrayCopier(@Nonnull byte[] data)
         {
             this(data, 0, data.length);
         }
 
         @Override
-        public void write(NoThrowOutputStream out)
+        public void write(@Nonnull NoThrowOutputStream out)
         {
             out.write(this.data, this.offset, this.length);
         }

--- a/core/src/main/java/com/dropbox/core/DbxUploader.java
+++ b/core/src/main/java/com/dropbox/core/DbxUploader.java
@@ -11,6 +11,9 @@ import com.dropbox.core.stone.StoneSerializer;
 import com.dropbox.core.http.HttpRequestor;
 import com.dropbox.core.util.IOUtil;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Class for completing upload requests.
  *
@@ -43,16 +46,19 @@ import com.dropbox.core.util.IOUtil;
  * @param <X> exception type returned by server on request failure
  */
 public abstract class DbxUploader<R, E, X extends DbxApiException> implements Closeable {
-    private final HttpRequestor.Uploader httpUploader;
-    private final StoneSerializer<R> responseSerializer;
-    private final StoneSerializer<E> errorSerializer;
+    private final @Nonnull HttpRequestor.Uploader httpUploader;
+    private final @Nonnull StoneSerializer<R> responseSerializer;
+    private final @Nonnull StoneSerializer<E> errorSerializer;
 
     private boolean closed;
     private boolean finished;
 
-    private final String userId;
+    private final @Nullable String userId;
 
-    protected DbxUploader(HttpRequestor.Uploader httpUploader, StoneSerializer<R> responseSerializer, StoneSerializer<E> errorSerializer, String userId) {
+    protected DbxUploader(@Nonnull HttpRequestor.Uploader httpUploader,
+                          @Nonnull StoneSerializer<R> responseSerializer,
+                          @Nonnull StoneSerializer<E> errorSerializer,
+                          @Nullable String userId) {
         this.httpUploader = httpUploader;
         this.responseSerializer = responseSerializer;
         this.errorSerializer = errorSerializer;
@@ -62,7 +68,7 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
         this.userId = userId;
     }
 
-    protected abstract X newException(DbxWrappedException error);
+    protected abstract @Nonnull X newException(@Nonnull DbxWrappedException error);
 
     /**
      * Uploads all bytes read from the given {@link InputStream} and returns the response.
@@ -92,7 +98,7 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
      * @throws IOException if an error occurs reading the input stream.
      * @throws IllegalStateException if this uploader has already been closed (see {@link #close}) or finished (see {@link #finish})
      */
-    public R uploadAndFinish(InputStream in) throws X, DbxException, IOException {
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in) throws X, DbxException, IOException {
         return uploadAndFinish(in, null);
     }
 
@@ -111,7 +117,8 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
      * @throws IOException if an error occurs reading the input stream.
      * @throws IllegalStateException if this uploader has already been closed (see {@link #close}) or finished (see {@link #finish})
      */
-    public R uploadAndFinish(InputStream in, IOUtil.ProgressListener progressListener) throws X, DbxException, IOException {
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in,
+                                       @Nullable IOUtil.ProgressListener progressListener) throws X, DbxException, IOException {
         try {
             try {
                 httpUploader.setProgressListener(progressListener);
@@ -163,7 +170,7 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
      * @throws IOException if an error occurs reading the input stream.
      * @throws IllegalStateException if this uploader has already been closed (see {@link #close}) or finished (see {@link #finish})
      */
-    public R uploadAndFinish(InputStream in, long limit) throws X, DbxException, IOException {
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in, long limit) throws X, DbxException, IOException {
         return uploadAndFinish(IOUtil.limit(in, limit));
     }
 
@@ -183,7 +190,9 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
      * @throws IOException if an error occurs reading the input stream.
      * @throws IllegalStateException if this uploader has already been closed (see {@link #close}) or finished (see {@link #finish})
      */
-    public R uploadAndFinish(InputStream in, long limit, IOUtil.ProgressListener progressListener) throws X, DbxException, IOException {
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in,
+                                       long limit,
+                                       @Nullable IOUtil.ProgressListener progressListener) throws X, DbxException, IOException {
         return uploadAndFinish(IOUtil.limit(in, limit), progressListener);
     }
 
@@ -232,7 +241,7 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
      *
      * @see #uploadAndFinish(InputStream)
      */
-    public OutputStream getOutputStream() {
+    public @Nonnull OutputStream getOutputStream() {
         assertOpenAndUnfinished();
         return this.httpUploader.getBody();
     }
@@ -254,7 +263,7 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
      *
      * @see #uploadAndFinish(InputStream)
      */
-    public OutputStream getOutputStream(IOUtil.ProgressListener progressListener) {
+    public @Nonnull OutputStream getOutputStream(@Nullable IOUtil.ProgressListener progressListener) {
         this.httpUploader.setProgressListener(progressListener);
         return getOutputStream();
     }
@@ -271,7 +280,7 @@ public abstract class DbxUploader<R, E, X extends DbxApiException> implements Cl
      * @throws DbxException if an error occurs sending the upload or reading the response
      * @throws IllegalStateException if this uploader has already been closed (see {@link #close}) or finished (see {@link #finish})
      */
-    public R finish() throws X, DbxException {
+    public @Nullable R finish() throws X, DbxException {
         assertOpenAndUnfinished();
 
         HttpRequestor.Response response = null;

--- a/core/src/main/java/com/dropbox/core/DbxWebAuth.java
+++ b/core/src/main/java/com/dropbox/core/DbxWebAuth.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import static com.dropbox.core.util.StringUtil.jq;
 
@@ -141,13 +142,13 @@ public class DbxWebAuth {
     private static final int CSRF_STRING_SIZE = StringUtil.urlSafeBase64Encode(new byte[CSRF_BYTES_SIZE]).length();
 
     /** Role representing the team account associated with a user. Used by {@link Request.Builder#withRequireRole}. */
-    public static final String ROLE_WORK = "work";
+    public static final @Nonnull String ROLE_WORK = "work";
     /** Role representing the personal account associated with a user. Used by {@link Request.Builder#withRequireRole}. */
-    public static final String ROLE_PERSONAL = "personal";
+    public static final @Nonnull String ROLE_PERSONAL = "personal";
 
-    final DbxRequestConfig requestConfig;
-    final DbxAppInfo appInfo;
-    final Request deprecatedRequest;
+    final @Nonnull DbxRequestConfig requestConfig;
+    final @Nonnull DbxAppInfo appInfo;
+    final @Nullable Request deprecatedRequest;
 
     /**
      * Creates a new instance that will perform the OAuth2 authorization flow using a redirect URI.
@@ -162,7 +163,10 @@ public class DbxWebAuth {
      * instead
      */
     @Deprecated
-    public DbxWebAuth(DbxRequestConfig requestConfig, DbxAppInfo appInfo, String redirectUri, DbxSessionStore sessionStore) {
+    public DbxWebAuth(@Nonnull DbxRequestConfig requestConfig,
+                      @Nonnull DbxAppInfo appInfo,
+                      @Nonnull String redirectUri,
+                      @Nonnull DbxSessionStore sessionStore) {
         if (requestConfig == null) throw new NullPointerException("requestConfig");
         if (appInfo == null) throw new NullPointerException("appInfo");
 
@@ -182,7 +186,7 @@ public class DbxWebAuth {
      * @param appInfo Your application's Dropbox API information (the app key and secret), never
      * {@code null}.
      */
-    public DbxWebAuth(DbxRequestConfig requestConfig, DbxAppInfo appInfo) {
+    public DbxWebAuth(@Nonnull DbxRequestConfig requestConfig, @Nonnull DbxAppInfo appInfo) {
         if (requestConfig == null) throw new NullPointerException("requestConfig");
         if (appInfo == null) throw new NullPointerException("appInfo");
 
@@ -214,7 +218,7 @@ public class DbxWebAuth {
      * instead.
      */
     @Deprecated
-    public String start(@Nullable String urlState) {
+    public @Nonnull String start(@Nullable String urlState) {
         if (deprecatedRequest == null) {
             throw new IllegalStateException("Must use DbxWebAuth.authorize instead.");
         }
@@ -248,7 +252,7 @@ public class DbxWebAuth {
      * constructor, or if this (@link DbxWebAuth} instance was created with {@link DbxAppInfo}
      * without app secret.
      */
-    public String authorize(Request request) {
+    public @Nonnull String authorize(@Nonnull Request request) {
         if (deprecatedRequest != null) {
             throw new IllegalStateException("Must create this instance using DbxWebAuth(DbxRequestConfig,DbxAppInfo) to call this method.");
         }
@@ -260,11 +264,12 @@ public class DbxWebAuth {
         return authorizeImpl(request);
     }
 
-    private String authorizeImpl(Request request) {
+    private @Nonnull String authorizeImpl(@Nonnull Request request) {
         return authorizeImpl(request, null);
     }
 
-    String authorizeImpl(Request request, Map<String, String> pkceParams) {
+    @Nonnull
+    String authorizeImpl(@Nonnull Request request, @Nullable Map<String, String> pkceParams) {
         Map<String, String> params = new HashMap<String, String>();
 
         params.put("client_id", appInfo.getKey());
@@ -319,7 +324,7 @@ public class DbxWebAuth {
      *
      * @throws DbxException if an error occurs communicating with Dropbox.
      */
-    public DbxAuthFinish finishFromCode(String code) throws DbxException {
+    public @Nonnull DbxAuthFinish finishFromCode(@Nonnull String code) throws DbxException {
         return finish(code);
     }
 
@@ -333,7 +338,7 @@ public class DbxWebAuth {
      *
      * @throws DbxException if an error occurs communicating with Dropbox.
      */
-    public DbxAuthFinish finishFromCode(String code, String redirectUri) throws DbxException {
+    public @Nonnull DbxAuthFinish finishFromCode(@Nonnull String code, @Nonnull String redirectUri) throws DbxException {
         return finish(code, redirectUri, null);
     }
 
@@ -359,17 +364,19 @@ public class DbxWebAuth {
      * set.
      * @throws DbxException If an error occurs communicating with Dropbox.
      */
-    public DbxAuthFinish finishFromRedirect(String redirectUri,
-                                            DbxSessionStore sessionStore,
-                                            Map<String, String[]> params)
+    public @Nonnull DbxAuthFinish finishFromRedirect(@Nonnull String redirectUri,
+                                            @Nonnull DbxSessionStore sessionStore,
+                                            @Nonnull Map<String, String[]> params)
         throws DbxException, BadRequestException, BadStateException, CsrfException, NotApprovedException, ProviderException {
 
-        String strippedState = validateRedirectUri(redirectUri, sessionStore, params);
+        @Nullable String strippedState = validateRedirectUri(redirectUri, sessionStore, params);
         String code = getParam(params, "code");
         return finish(code, redirectUri, strippedState);
     }
 
-    static String validateRedirectUri(String redirectUri, DbxSessionStore sessionStore, Map<String, String[]> params)
+    static @Nullable String validateRedirectUri(@Nonnull String redirectUri,
+                                                @Nonnull DbxSessionStore sessionStore,
+                                                @Nonnull Map<String, String[]> params)
         throws BadRequestException, BadStateException, CsrfException, NotApprovedException, ProviderException
     {
         if (redirectUri == null) throw new NullPointerException("redirectUri");
@@ -416,11 +423,12 @@ public class DbxWebAuth {
         return state;
     }
 
-    private DbxAuthFinish finish(String code) throws DbxException {
+    private @Nonnull DbxAuthFinish finish(@Nonnull String code) throws DbxException {
         return finish(code, null, null);
     }
 
-    DbxAuthFinish finish(String code, String redirectUri, final String state) throws
+    @Nonnull
+    DbxAuthFinish finish(@Nonnull String code, @Nullable String redirectUri, final @Nullable String state) throws
             DbxException {
         if (code == null) throw new NullPointerException("code");
         if (!appInfo.hasSecret()) {
@@ -437,7 +445,11 @@ public class DbxWebAuth {
         }
 
         List<HttpRequestor.Header> headers = new ArrayList<HttpRequestor.Header>();
-        DbxRequestUtil.addBasicAuthHeader(headers, appInfo.getKey(), appInfo.getSecret());
+        String appSecret = appInfo.getSecret();
+        if (appSecret == null) {
+            throw new IllegalStateException("App secret is required for non-PKCE OAuth.");
+        }
+        DbxRequestUtil.addBasicAuthHeader(headers, appInfo.getKey(), appSecret);
 
         return DbxRequestUtil.doPostNoAuth(
             requestConfig,
@@ -448,7 +460,7 @@ public class DbxWebAuth {
             headers,
             new DbxRequestUtil.ResponseHandler<DbxAuthFinish>() {
                 @Override
-                public DbxAuthFinish handle(HttpRequestor.Response response) throws DbxException {
+                public @Nonnull DbxAuthFinish handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                     if (response.getStatusCode() != 200) {
                         throw DbxRequestUtil.unexpectedStatus(response);
                     }
@@ -481,7 +493,7 @@ public class DbxWebAuth {
      * @deprecated use {@link #finishFromRedirect finishFromRedirect(..)} instead.
      */
     @Deprecated
-    public DbxAuthFinish finish(Map<String, String[]> queryParams)
+    public @Nonnull DbxAuthFinish finish(@Nonnull Map<String, String[]> queryParams)
         throws DbxException, BadRequestException, BadStateException, CsrfException, NotApprovedException, ProviderException {
         if (deprecatedRequest == null) {
             throw new IllegalStateException("Must use DbxWebAuth.finishFromRedirect(..) instead.");
@@ -493,7 +505,7 @@ public class DbxWebAuth {
         );
     }
 
-    private static String appendCsrfToken(Request request) {
+    private static @Nonnull String appendCsrfToken(@Nonnull Request request) {
         // add a CSRF nonce for security
         byte[] csrf = new byte[CSRF_BYTES_SIZE];
         RAND.nextBytes(csrf);
@@ -518,7 +530,7 @@ public class DbxWebAuth {
         }
     }
 
-    private static String verifyAndStripCsrfToken(String state, DbxSessionStore sessionStore)
+    private static @Nullable String verifyAndStripCsrfToken(@Nonnull String state, @Nonnull DbxSessionStore sessionStore)
         throws CsrfException, BadStateException {
         String expected = sessionStore.get();
         if (expected == null) {
@@ -544,7 +556,7 @@ public class DbxWebAuth {
         return stripped.isEmpty() ? null : stripped;
     }
 
-    static @Nullable String getParam(Map<String,String[]> params, String name) throws BadRequestException {
+    static @Nullable String getParam(@Nonnull Map<String,String[]> params, @Nonnull String name) throws BadRequestException {
         String[] v = params.get(name);
 
         if (v == null) {
@@ -564,7 +576,7 @@ public class DbxWebAuth {
      */
     public static abstract class Exception extends java.lang.Exception {
         private static final long serialVersionUID = 0L;
-        public Exception(String message) { super(message); }
+        public Exception(@Nonnull String message) { super(message); }
     }
 
     /**
@@ -580,7 +592,7 @@ public class DbxWebAuth {
      */
     public static final class BadRequestException extends Exception {
         private static final long serialVersionUID = 0L;
-        public BadRequestException(String message) { super(message); }
+        public BadRequestException(@Nonnull String message) { super(message); }
     }
 
     /**
@@ -598,7 +610,7 @@ public class DbxWebAuth {
      */
     public static final class BadStateException extends Exception {
         private static final long serialVersionUID = 0L;
-        public BadStateException(String message) { super(message); }
+        public BadStateException(@Nonnull String message) { super(message); }
     }
 
     /**
@@ -615,7 +627,7 @@ public class DbxWebAuth {
      */
     public static final class CsrfException extends Exception {
         private static final long serialVersionUID = 0L;
-        public CsrfException(String message) { super(message); }
+        public CsrfException(@Nonnull String message) { super(message); }
     }
 
     /**
@@ -628,7 +640,7 @@ public class DbxWebAuth {
      */
     public static final class NotApprovedException extends Exception {
         private static final long serialVersionUID = 0L;
-        public NotApprovedException(String message) { super(message); }
+        public NotApprovedException(@Nonnull String message) { super(message); }
     }
 
     /**
@@ -640,7 +652,7 @@ public class DbxWebAuth {
      */
     public static final class ProviderException extends Exception {
         private static final long serialVersionUID = 0L;
-        public ProviderException(String message) { super(message); }
+        public ProviderException(@Nonnull String message) { super(message); }
     }
 
     /**
@@ -648,7 +660,7 @@ public class DbxWebAuth {
      *
      * @return new request builder with default values
      */
-    public static Request.Builder newRequestBuilder() {
+    public static @Nonnull Request.Builder newRequestBuilder() {
         return Request.newBuilder();
     }
 
@@ -661,26 +673,26 @@ public class DbxWebAuth {
         private static final Charset UTF8 = Charset.forName("UTF-8");
         private static final int MAX_STATE_SIZE = 500;
 
-        private final String redirectUri;
-        private final String state;
-        private final String requireRole;
-        private final Boolean forceReapprove;
-        private final Boolean disableSignup;
-        private final DbxSessionStore sessionStore;
-        private final TokenAccessType tokenAccessType;
-        private final String scope;
-        private final IncludeGrantedScopes includeGrantedScopes;
+        private final @Nullable String redirectUri;
+        private final @Nullable String state;
+        private final @Nullable String requireRole;
+        private final @Nullable Boolean forceReapprove;
+        private final @Nullable Boolean disableSignup;
+        private final @Nullable DbxSessionStore sessionStore;
+        private final @Nullable TokenAccessType tokenAccessType;
+        private final @Nullable String scope;
+        private final @Nullable IncludeGrantedScopes includeGrantedScopes;
 
 
-        private Request(String redirectUri,
-                        String state,
-                        String requireRole,
-                        Boolean forceReapprove,
-                        Boolean disableSignup,
-                        DbxSessionStore sessionStore,
-                        TokenAccessType tokenAccessType,
-                        String scope,
-                        IncludeGrantedScopes includeGrantedScopes) {
+        private Request(@Nullable String redirectUri,
+                        @Nullable String state,
+                        @Nullable String requireRole,
+                        @Nullable Boolean forceReapprove,
+                        @Nullable Boolean disableSignup,
+                        @Nullable DbxSessionStore sessionStore,
+                        @Nullable TokenAccessType tokenAccessType,
+                        @Nullable String scope,
+                        @Nullable IncludeGrantedScopes includeGrantedScopes) {
             this.redirectUri = redirectUri;
             this.state = state;
             this.requireRole = requireRole;
@@ -697,7 +709,7 @@ public class DbxWebAuth {
          *
          * @return copy of this request
          */
-        public Builder copy() {
+        public @Nonnull Builder copy() {
             return new Builder(
                     redirectUri,
                     state,
@@ -716,7 +728,7 @@ public class DbxWebAuth {
          *
          * @return new request builder with default values
          */
-        public static Builder newBuilder() {
+        public static @Nonnull Builder newBuilder() {
             return new Builder();
         }
 
@@ -724,29 +736,29 @@ public class DbxWebAuth {
          * Builder for OAuth2 requests. Use this builder to configure the OAuth authorization flow.
          */
         public static final class Builder {
-            private String redirectUri;
-            private String state;
-            private String requireRole;
-            private Boolean forceReapprove;
-            private Boolean disableSignup;
-            private DbxSessionStore sessionStore;
-            private TokenAccessType tokenAccessType;
-            private String scope;
-            private IncludeGrantedScopes includeGrantedScopes;
+            private @Nullable String redirectUri;
+            private @Nullable String state;
+            private @Nullable String requireRole;
+            private @Nullable Boolean forceReapprove;
+            private @Nullable Boolean disableSignup;
+            private @Nullable DbxSessionStore sessionStore;
+            private @Nullable TokenAccessType tokenAccessType;
+            private @Nullable String scope;
+            private @Nullable IncludeGrantedScopes includeGrantedScopes;
 
             private Builder() {
                 this(null, null, null, null, null, null, null, null, null);
             }
 
-            private Builder(String redirectUri,
-                            String state,
-                            String requireRole,
-                            Boolean forceReapprove,
-                            Boolean disableSignup,
-                            DbxSessionStore sessionStore,
-                            TokenAccessType tokenAccessType,
-                            String scope,
-                            IncludeGrantedScopes includeGrantedScopes) {
+            private Builder(@Nullable String redirectUri,
+                            @Nullable String state,
+                            @Nullable String requireRole,
+                            @Nullable Boolean forceReapprove,
+                            @Nullable Boolean disableSignup,
+                            @Nullable DbxSessionStore sessionStore,
+                            @Nullable TokenAccessType tokenAccessType,
+                            @Nullable String scope,
+                            @Nullable IncludeGrantedScopes includeGrantedScopes) {
                 this.redirectUri = redirectUri;
                 this.state = state;
                 this.requireRole = requireRole;
@@ -768,7 +780,7 @@ public class DbxWebAuth {
              *
              * @return this builder
              */
-            public Builder withNoRedirect() {
+            public @Nonnull Builder withNoRedirect() {
                 this.redirectUri = null;
                 this.sessionStore = null;
                 return this;
@@ -797,7 +809,7 @@ public class DbxWebAuth {
              *
              * @throws NullPointerException if either redirectUri or sessionStore is {@code null}
              */
-            public Builder withRedirectUri(String redirectUri, DbxSessionStore sessionStore) {
+            public @Nonnull Builder withRedirectUri(@Nonnull String redirectUri, @Nonnull DbxSessionStore sessionStore) {
                 if (redirectUri == null) throw new NullPointerException("redirectUri");
                 if (sessionStore == null) throw new NullPointerException("sessionStore");
 
@@ -824,7 +836,7 @@ public class DbxWebAuth {
              *
              * @throws IllegalArgumentException if state is greater than 476 bytes
              */
-            public Builder withState(String state) {
+            public @Nonnull Builder withState(@Nullable String state) {
                 if (state != null && (state.getBytes(UTF8).length + CSRF_STRING_SIZE) > MAX_STATE_SIZE) {
                     throw new IllegalArgumentException("UTF-8 encoded state cannot be greater than " + (MAX_STATE_SIZE - CSRF_STRING_SIZE) + " bytes.");
                 }
@@ -846,7 +858,7 @@ public class DbxWebAuth {
              * @see DbxWebAuth#ROLE_WORK
              * @see DbxWebAuth#ROLE_PERSONAL
              */
-            public Builder withRequireRole(String requireRole) {
+            public @Nonnull Builder withRequireRole(@Nullable String requireRole) {
                 this.requireRole = requireRole;
                 return this;
             }
@@ -864,7 +876,7 @@ public class DbxWebAuth {
              * @param forceReapprove whether to force a user to re-approve this app, or {@code null}
              * for default behavior
              */
-            public Builder withForceReapprove(Boolean forceReapprove) {
+            public @Nonnull Builder withForceReapprove(@Nullable Boolean forceReapprove) {
                 this.forceReapprove = forceReapprove;
                 return this;
             }
@@ -882,7 +894,7 @@ public class DbxWebAuth {
              *
              * @return this builder
              */
-            public Builder withDisableSignup(Boolean disableSignup) {
+            public @Nonnull Builder withDisableSignup(@Nullable Boolean disableSignup) {
                 this.disableSignup = disableSignup;
                 return this;
             }
@@ -902,7 +914,7 @@ public class DbxWebAuth {
              *
              * @return this builder
              */
-            public Builder withTokenAccessType(TokenAccessType tokenAccessType) {
+            public @Nonnull Builder withTokenAccessType(@Nullable TokenAccessType tokenAccessType) {
                 this.tokenAccessType = tokenAccessType;
                 return this;
             }
@@ -914,7 +926,7 @@ public class DbxWebAuth {
              * API endpoints. To call one API endpoint you have to obtains the scope first otherwise you
              * will get HTTP 401. Example: "account_info.read files.content.read"
              */
-            public Builder withScope(Collection<String> scope) {
+            public @Nonnull Builder withScope(@Nullable Collection<String> scope) {
                 if (scope != null) {
                     this.scope = StringUtil.join(scope, " ");
                 }
@@ -931,7 +943,7 @@ public class DbxWebAuth {
              *                            scopes user previously granted your app together with
              *                             the new scopes.
              */
-            public Builder withIncludeGrantedScopes(IncludeGrantedScopes includeGrantedScopes) {
+            public @Nonnull Builder withIncludeGrantedScopes(@Nullable IncludeGrantedScopes includeGrantedScopes) {
                 this.includeGrantedScopes = includeGrantedScopes;
                 return this;
             }
@@ -945,7 +957,7 @@ public class DbxWebAuth {
              * @throws IllegalStateException if {@link #withState} was called with a non-{@code
              * null} value, but no redirect URI was specified.
              */
-            public Request build() {
+            public @Nonnull Request build() {
                 if (redirectUri == null && state != null) {
                     throw new IllegalStateException("Cannot specify a state without a redirect URI.");
                 }

--- a/core/src/main/java/com/dropbox/core/DbxWebAuth.java
+++ b/core/src/main/java/com/dropbox/core/DbxWebAuth.java
@@ -1,5 +1,6 @@
 package com.dropbox.core;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import static com.dropbox.core.util.StringUtil.jq;
 
 import java.nio.charset.Charset;
@@ -14,7 +15,6 @@ import com.dropbox.core.http.HttpRequestor;
 import com.dropbox.core.util.StringUtil;
 import com.dropbox.core.v2.DbxRawClientV2;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * Does the OAuth 2 "authorization code" flow.  (This SDK does not support the "token" flow.)
@@ -214,7 +214,7 @@ public class DbxWebAuth {
      * instead.
      */
     @Deprecated
-    public String start(/*@Nullable*/String urlState) {
+    public String start(@Nullable String urlState) {
         if (deprecatedRequest == null) {
             throw new IllegalStateException("Must use DbxWebAuth.authorize instead.");
         }
@@ -544,7 +544,7 @@ public class DbxWebAuth {
         return stripped.isEmpty() ? null : stripped;
     }
 
-    static /*@Nullable*/String getParam(Map<String,String[]> params, String name) throws BadRequestException {
+    static @Nullable String getParam(Map<String,String[]> params, String name) throws BadRequestException {
         String[] v = params.get(name);
 
         if (v == null) {

--- a/core/src/main/java/com/dropbox/core/DbxWebAuth.java
+++ b/core/src/main/java/com/dropbox/core/DbxWebAuth.java
@@ -1,6 +1,6 @@
 package com.dropbox.core;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import static com.dropbox.core.util.StringUtil.jq;
 
 import java.nio.charset.Charset;

--- a/core/src/main/java/com/dropbox/core/DbxWebAuthNoRedirect.java
+++ b/core/src/main/java/com/dropbox/core/DbxWebAuthNoRedirect.java
@@ -2,6 +2,8 @@ package com.dropbox.core;
 
 import com.dropbox.core.v2.DbxClientV2;
 
+import javax.annotation.Nonnull;
+
 /**
  * Does the OAuth web-based authorization flow for apps that can't provide a redirect URI (such as
  * the command-line example apps that come with this SDK).  If you're a normal website, use the
@@ -47,13 +49,13 @@ import com.dropbox.core.v2.DbxClientV2;
  */
 @Deprecated
 public class DbxWebAuthNoRedirect {
-    private final DbxWebAuth auth;
+    private final @Nonnull DbxWebAuth auth;
 
     /**
      * @param appInfo
      *     Your application's Dropbox API information (the app key and secret).
      */
-    public DbxWebAuthNoRedirect(DbxRequestConfig requestConfig, DbxAppInfo appInfo) {
+    public DbxWebAuthNoRedirect(@Nonnull DbxRequestConfig requestConfig, @Nonnull DbxAppInfo appInfo) {
         this.auth = new DbxWebAuth(requestConfig, appInfo);
     }
 
@@ -67,7 +69,7 @@ public class DbxWebAuthNoRedirect {
      * access token.
      * </p>
      */
-    public String start() {
+    public @Nonnull String start() {
         DbxWebAuth.Request request = DbxWebAuth.newRequestBuilder()
             .withNoRedirect()
             .build();
@@ -82,7 +84,7 @@ public class DbxWebAuthNoRedirect {
      *    The authorization code shown to the user when they clicked "Allow" on the authorization
      *    page on the Dropbox website.
      */
-    public DbxAuthFinish finish(String code) throws DbxException {
+    public @Nonnull DbxAuthFinish finish(@Nonnull String code) throws DbxException {
         return auth.finishFromCode(code);
     }
 }

--- a/core/src/main/java/com/dropbox/core/DbxWrappedException.java
+++ b/core/src/main/java/com/dropbox/core/DbxWrappedException.java
@@ -11,35 +11,42 @@ import com.dropbox.core.http.HttpRequestor;
 import com.dropbox.core.v2.callbacks.DbxGlobalCallbackFactory;
 import com.dropbox.core.v2.callbacks.DbxRouteErrorCallback;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * For internal use only.
  */
 public final class DbxWrappedException extends Exception {
     private static final long serialVersionUID = 0L;
 
-    private final Object errValue;  // Really an ErrT instance, but Throwable does not allow generic subclasses.
-    private final String requestId;
-    private final LocalizedText userMessage;
+    private final @Nonnull Object errValue;  // Really an ErrT instance, but Throwable does not allow generic subclasses.
+    private final @Nullable String requestId;
+    private final @Nullable LocalizedText userMessage;
 
-    public DbxWrappedException(Object errValue, String requestId, LocalizedText userMessage) {
+    public DbxWrappedException(@Nonnull Object errValue,
+                               @Nullable String requestId,
+                               @Nullable LocalizedText userMessage) {
         this.errValue = errValue;
         this.requestId = requestId;
         this.userMessage = userMessage;
     }
 
-    public Object getErrorValue() {
+    public @Nonnull Object getErrorValue() {
         return errValue;
     }
 
-    public String getRequestId() {
+    public @Nullable String getRequestId() {
         return requestId;
     }
 
-    public LocalizedText getUserMessage() {
+    public @Nullable LocalizedText getUserMessage() {
         return userMessage;
     }
 
-    public static <T> DbxWrappedException fromResponse(StoneSerializer<T> errSerializer, HttpRequestor.Response response, String userId)
+    public static <T> @Nonnull DbxWrappedException fromResponse(@Nonnull StoneSerializer<T> errSerializer,
+                                                                @Nonnull HttpRequestor.Response response,
+                                                                @Nullable String userId)
         throws IOException, JsonParseException {
         String requestId = DbxRequestUtil.getRequestId(response);
 
@@ -55,7 +62,9 @@ public final class DbxWrappedException extends Exception {
         return new DbxWrappedException(routeError, requestId, apiResponse.getUserMessage());
     }
 
-    public static void executeOtherBlocks(DbxGlobalCallbackFactory factory, String userId, Object routeError) {
+    public static void executeOtherBlocks(@Nullable DbxGlobalCallbackFactory factory,
+                                          @Nullable String userId,
+                                          @Nullable Object routeError) {
         try {
             // Recursively looks at union errors and the union's current tag type. If there is a handler
             // for the current tag type, it is executed.
@@ -75,7 +84,9 @@ public final class DbxWrappedException extends Exception {
         }
     }
 
-    public static <T> void executeBlockForObject(DbxGlobalCallbackFactory factory, String userId, T routeError) {
+    public static <T> void executeBlockForObject(@Nullable DbxGlobalCallbackFactory factory,
+                                                 @Nullable String userId,
+                                                 @Nullable T routeError) {
         if (factory != null) {
             DbxRouteErrorCallback<T> callback = factory.createRouteErrorCallback(userId, routeError);
             if (callback != null) {

--- a/core/src/main/java/com/dropbox/core/IncludeGrantedScopes.java
+++ b/core/src/main/java/com/dropbox/core/IncludeGrantedScopes.java
@@ -1,5 +1,7 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+
 /**
  *  If this field is present, Dropbox server will return a token with all scopes user previously
  *  granted your app.
@@ -17,7 +19,7 @@ public enum IncludeGrantedScopes {
     TEAM;
 
     @Override
-    public String toString() {
+    public @Nonnull String toString() {
         return this.name().toLowerCase();
     }
 }

--- a/core/src/main/java/com/dropbox/core/InvalidAccessTokenException.java
+++ b/core/src/main/java/com/dropbox/core/InvalidAccessTokenException.java
@@ -2,6 +2,9 @@ package com.dropbox.core;
 
 import com.dropbox.core.v2.auth.AuthError;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Gets thrown when the access token you're using to make API calls is invalid.
  *
@@ -15,14 +18,16 @@ import com.dropbox.core.v2.auth.AuthError;
  */
 public class InvalidAccessTokenException extends DbxException {
     private static final long serialVersionUID = 0;
-    private AuthError authError;
+    private @Nonnull AuthError authError;
 
-    public InvalidAccessTokenException(String requestId, String message, AuthError authError) {
+    public InvalidAccessTokenException(@Nullable String requestId,
+                                       @Nullable String message,
+                                       @Nonnull AuthError authError) {
         super(requestId, message);
         this.authError = authError;
     }
 
-    public AuthError getAuthError() {
+    public @Nonnull AuthError getAuthError() {
         return this.authError;
     }
 }

--- a/core/src/main/java/com/dropbox/core/LocalizedText.java
+++ b/core/src/main/java/com/dropbox/core/LocalizedText.java
@@ -11,12 +11,14 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonToken;
 
+import javax.annotation.Nonnull;
+
 /**
  * Human-readable text localized to a specific locale.
  */
 public final class LocalizedText {
-    private final String text;
-    private final String locale;
+    private final @Nonnull String text;
+    private final @Nonnull String locale;
 
     /**
      * Create a {@link LocalizedText} object that contains the given {@code text} already localized
@@ -25,7 +27,7 @@ public final class LocalizedText {
      * @param text    Localized, human-readable text. Must not be {@code null}
      * @param locale  IETF BCP 47 language tag of text locale. Must not be {@code null}
      */
-    public LocalizedText(String text, String locale) {
+    public LocalizedText(@Nonnull String text, @Nonnull String locale) {
         if (text == null) {
             throw new NullPointerException("text");
         }
@@ -42,7 +44,7 @@ public final class LocalizedText {
      *
      * @return localized, human-readable text, never {@code null}
      */
-    public String getText() {
+    public @Nonnull String getText() {
         return text;
     }
 
@@ -51,12 +53,12 @@ public final class LocalizedText {
      *
      * @return locale of text in IETF BCP 47 language tag format, never {@code null}
      */
-    public String getLocale() {
+    public @Nonnull String getLocale() {
         return locale;
     }
 
     @Override
-    public String toString() {
+    public @Nonnull String toString() {
         return text;
     }
 
@@ -65,12 +67,12 @@ public final class LocalizedText {
      */
     static final StoneSerializer<LocalizedText> STONE_SERIALIZER = new StoneSerializer<LocalizedText>() {
         @Override
-        public void serialize(LocalizedText value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nonnull LocalizedText value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             throw new UnsupportedOperationException("Error wrapper serialization not supported.");
         }
 
         @Override
-        public LocalizedText deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull LocalizedText deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             String text = null;
             String locale = null;
 

--- a/core/src/main/java/com/dropbox/core/NetworkIOException.java
+++ b/core/src/main/java/com/dropbox/core/NetworkIOException.java
@@ -3,6 +3,8 @@ package com.dropbox.core;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
 import java.security.cert.CertPathValidatorException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * This gets thrown when there's an {@link IOException} when reading or writing to the
@@ -15,12 +17,15 @@ import java.security.cert.CertPathValidatorException;
 public class NetworkIOException extends DbxException {
     private static final long serialVersionUID = 0L;
 
-    public NetworkIOException(IOException cause) {
+    public NetworkIOException(@Nonnull IOException cause) {
         super(computeMessage(cause), cause);
     }
 
-    private static String computeMessage(IOException ex) {
-        String message = ex.getMessage();
+    private static @Nonnull String computeMessage(@Nonnull IOException ex) {
+        @Nullable String message = ex.getMessage();
+        if (message == null) {
+            message = ex.toString();
+        }
 
         // For CertPathValidationErrors, the CertPath is in the exception object but not
         // in the exception message.  Pull it out into the message, because it would be
@@ -37,9 +42,8 @@ public class NetworkIOException extends DbxException {
     }
 
     @Override
-    public IOException getCause() {
+    public @Nonnull IOException getCause() {
         // guaranteed to be an IOException
         return (IOException) super.getCause();
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/NoThrowInputStream.java
+++ b/core/src/main/java/com/dropbox/core/NoThrowInputStream.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+
 /**
  * Wraps an existing input stream, converting all the underlying stream's {@code IOException}s
  * to our own {@link HiddenException}, which is a subclass of {@code RuntimeException}.  This
@@ -21,10 +23,10 @@ import java.io.OutputStream;
  * </p>
  */
 public final class NoThrowInputStream extends InputStream {
-    private final InputStream underlying;
+    private final @Nonnull InputStream underlying;
     private long bytesRead = 0;
 
-    public NoThrowInputStream(InputStream underlying) {
+    public NoThrowInputStream(@Nonnull InputStream underlying) {
         this.underlying = underlying;
     }
 
@@ -44,7 +46,7 @@ public final class NoThrowInputStream extends InputStream {
     }
 
     @Override
-    public int read(byte[] b, int off, int len) {
+    public int read(@Nonnull byte[] b, int off, int len) {
         try {
             int bytesReadNow = underlying.read(b, off, len);
             this.bytesRead += bytesReadNow;
@@ -56,7 +58,7 @@ public final class NoThrowInputStream extends InputStream {
     }
 
     @Override
-    public int read(byte[] b) {
+    public int read(@Nonnull byte[] b) {
         try {
             int bytesReadNow = underlying.read(b);
             this.bytesRead += bytesReadNow;
@@ -69,12 +71,12 @@ public final class NoThrowInputStream extends InputStream {
     public static final class HiddenException extends RuntimeException {
         private static final long serialVersionUID = 0L;
 
-        public HiddenException(IOException underlying) {
+        public HiddenException(@Nonnull IOException underlying) {
             super(underlying);
         }
 
         @Override
-        public IOException getCause() {
+        public @Nonnull IOException getCause() {
             return (IOException) super.getCause();
         }
     }

--- a/core/src/main/java/com/dropbox/core/NoThrowOutputStream.java
+++ b/core/src/main/java/com/dropbox/core/NoThrowOutputStream.java
@@ -3,6 +3,8 @@ package com.dropbox.core;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+
 /**
  * Wraps an existing output stream, converting all the underlying stream's {@code IOException}s
  * to our own {@link HiddenException}, which is a subclass of {@code RuntimeException}.  This
@@ -21,10 +23,10 @@ import java.io.OutputStream;
  */
 public final class NoThrowOutputStream extends OutputStream
 {
-    private final OutputStream underlying;
+    private final @Nonnull OutputStream underlying;
     private long bytesWritten = 0;
 
-    public NoThrowOutputStream(OutputStream underlying)
+    public NoThrowOutputStream(@Nonnull OutputStream underlying)
     {
         this.underlying = underlying;
     }
@@ -47,7 +49,7 @@ public final class NoThrowOutputStream extends OutputStream
     }
 
     @Override
-    public void write(byte[] b, int off, int len)
+    public void write(@Nonnull byte[] b, int off, int len)
     {
         try {
             bytesWritten += len;
@@ -59,7 +61,7 @@ public final class NoThrowOutputStream extends OutputStream
     }
 
     @Override
-    public void write(byte[] b)
+    public void write(@Nonnull byte[] b)
     {
         try {
             bytesWritten += b.length;
@@ -84,16 +86,16 @@ public final class NoThrowOutputStream extends OutputStream
 
     public static final class HiddenException extends RuntimeException
     {
-        public final NoThrowOutputStream owner;
+        public final @Nonnull NoThrowOutputStream owner;
 
-        public HiddenException(NoThrowOutputStream owner, IOException underlying)
+        public HiddenException(@Nonnull NoThrowOutputStream owner, @Nonnull IOException underlying)
         {
             super(underlying);
             this.owner = owner;
         }
 
         @Override
-        public IOException getCause()
+        public @Nonnull IOException getCause()
         {
             return (IOException) super.getCause();
         }

--- a/core/src/main/java/com/dropbox/core/PathRootErrorException.java
+++ b/core/src/main/java/com/dropbox/core/PathRootErrorException.java
@@ -2,19 +2,24 @@ package com.dropbox.core;
 
 import com.dropbox.core.v2.common.PathRootError;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Gets thrown when an invalid path rood is supplied.
  */
 public class PathRootErrorException extends DbxException {
     private static final long serialVersionUID = 0;
 
-    private final PathRootError pathRootError;
+    private final @Nonnull PathRootError pathRootError;
 
-    public PathRootError getPathRootError() {
+    public @Nonnull PathRootError getPathRootError() {
         return pathRootError;
     }
 
-    public PathRootErrorException(String requestId, String message, PathRootError pathRootError) {
+    public PathRootErrorException(@Nullable String requestId,
+                                  @Nullable String message,
+                                  @Nonnull PathRootError pathRootError) {
         super(requestId, message);
         this.pathRootError = pathRootError;
     }

--- a/core/src/main/java/com/dropbox/core/ProtocolException.java
+++ b/core/src/main/java/com/dropbox/core/ProtocolException.java
@@ -1,5 +1,8 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Something unexpected happened with either the request or the response.
  * This can happen if there's a bug in the client code (including this
@@ -15,12 +18,11 @@ package com.dropbox.core;
 public abstract class ProtocolException extends DbxException {
     private static final long serialVersionUID = 0;
 
-    public ProtocolException(String requestId, String message) {
+    public ProtocolException(@Nullable String requestId, @Nullable String message) {
         super(requestId, message);
     }
 
-    public ProtocolException(String requestId, String message, Throwable cause) {
+    public ProtocolException(@Nullable String requestId, @Nullable String message, @Nonnull Throwable cause) {
         super(requestId, message, cause);
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/RateLimitException.java
+++ b/core/src/main/java/com/dropbox/core/RateLimitException.java
@@ -2,6 +2,9 @@ package com.dropbox.core;
 
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * The server is overloaded, or you have hit a rate limit.  Try again later after the designated
  * backoff (see {@link #getBackoffMillis}).
@@ -9,8 +12,7 @@ import java.util.concurrent.TimeUnit;
 public class RateLimitException extends RetryException {
     private static final long serialVersionUID = 0L;
 
-    public RateLimitException(String requestId, String message, long backoff, TimeUnit unit) {
+    public RateLimitException(@Nullable String requestId, @Nullable String message, long backoff, @Nonnull TimeUnit unit) {
         super(requestId, message, backoff, unit);
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/RetryException.java
+++ b/core/src/main/java/com/dropbox/core/RetryException.java
@@ -2,6 +2,9 @@ package com.dropbox.core;
 
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * A transient exception has occurred and the request should be retried. Clients should only retry
  * requests after waiting the requested backoff duration (see {@link #getBackoffMillis}).
@@ -17,7 +20,7 @@ public class RetryException extends DbxException {
      * @param requestId ID assigned to request by Dropbox servers
      * @param message Error message
      */
-    public RetryException(String requestId, String message) {
+    public RetryException(@Nullable String requestId, @Nullable String message) {
         this(requestId, message, 0L, TimeUnit.MILLISECONDS);
     }
 
@@ -29,7 +32,7 @@ public class RetryException extends DbxException {
      * @param backoff amount of time to backoff before retrying the request
      * @param unit unit of time for {@code backoff}
      */
-    public RetryException(String requestId, String message, long backoff, TimeUnit unit) {
+    public RetryException(@Nullable String requestId, @Nullable String message, long backoff, @Nonnull TimeUnit unit) {
         super(requestId, message);
 
         this.backoffMillis = unit.toMillis(backoff);
@@ -45,4 +48,3 @@ public class RetryException extends DbxException {
         return backoffMillis;
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/ServerException.java
+++ b/core/src/main/java/com/dropbox/core/ServerException.java
@@ -1,5 +1,8 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * The server said that something went wrong on its end (HTTP 500 error code).
  * This indicates bug on the Dropbox server, but there are multiple potential causes.
@@ -26,8 +29,7 @@ package com.dropbox.core;
 public class ServerException extends DbxException {
     private static final long serialVersionUID = 0;
 
-    public ServerException(String requestId, String message) {
+    public ServerException(@Nullable String requestId, @Nullable String message) {
         super(requestId, message);
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/TokenAccessType.java
+++ b/core/src/main/java/com/dropbox/core/TokenAccessType.java
@@ -1,5 +1,7 @@
 package com.dropbox.core;
 
+import javax.annotation.Nonnull;
+
 /**
  *  Whether or not to include refresh token in {@link DbxAuthFinish}
  *  Non-mobile apps use it in {@link DbxWebAuth}.
@@ -15,14 +17,14 @@ public enum TokenAccessType{
      */
     OFFLINE("offline");
 
-    private String string;
+    private @Nonnull String string;
 
-    TokenAccessType(String string) {
+    TokenAccessType(@Nonnull String string) {
         this.string = string;
     }
 
     @Override
-    public String toString() {
+    public @Nonnull String toString() {
         return string;
     }
 }

--- a/core/src/main/java/com/dropbox/core/http/GoogleAppEngineRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/GoogleAppEngineRequestor.java
@@ -19,7 +19,6 @@ import com.google.appengine.api.urlfetch.HTTPResponse;
 import com.google.appengine.api.urlfetch.URLFetchService;
 import com.google.appengine.api.urlfetch.URLFetchServiceFactory;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * {@link HttpRequestor} implementation that uses Google App Engine URL fetch service.

--- a/core/src/main/java/com/dropbox/core/http/GoogleAppEngineRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/GoogleAppEngineRequestor.java
@@ -19,6 +19,9 @@ import com.google.appengine.api.urlfetch.HTTPResponse;
 import com.google.appengine.api.urlfetch.URLFetchService;
 import com.google.appengine.api.urlfetch.URLFetchServiceFactory;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 
 /**
  * {@link HttpRequestor} implementation that uses Google App Engine URL fetch service.
@@ -46,45 +49,45 @@ public class GoogleAppEngineRequestor extends HttpRequestor {
         this(newDefaultOptions());
     }
 
-    public GoogleAppEngineRequestor(FetchOptions options) {
+    public GoogleAppEngineRequestor(@Nonnull FetchOptions options) {
         this(options, URLFetchServiceFactory.getURLFetchService());
     }
 
-    public GoogleAppEngineRequestor(FetchOptions options, URLFetchService service) {
+    public GoogleAppEngineRequestor(@Nonnull FetchOptions options, @Nonnull URLFetchService service) {
         if (options == null) throw new NullPointerException("options");
         if (service == null) throw new NullPointerException("service");
         this.options = options;
         this.service = service;
     }
 
-    public FetchOptions getOptions() {
+    public @Nonnull FetchOptions getOptions() {
         return options;
     }
 
-    public URLFetchService getService() {
+    public @Nonnull URLFetchService getService() {
         return service;
     }
 
     @Override
-    public Response doGet(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Response doGet(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         HTTPRequest request = newRequest(url, HTTPMethod.GET, headers);
         HTTPResponse response = service.fetch(request);
         return toRequestorResponse(response);
     }
 
     @Override
-    public Uploader startPost(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Uploader startPost(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         HTTPRequest request = newRequest(url, HTTPMethod.POST, headers);
         return new FetchServiceUploader(service, request, new ByteArrayOutputStream());
     }
 
     @Override
-    public Uploader startPut(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Uploader startPut(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         HTTPRequest request = newRequest(url, HTTPMethod.POST, headers);
         return new FetchServiceUploader(service, request, new ByteArrayOutputStream());
     }
 
-    private HTTPRequest newRequest(String url, HTTPMethod method, Iterable<Header> headers) throws IOException {
+    private @Nonnull HTTPRequest newRequest(@Nonnull String url, @Nonnull HTTPMethod method, @Nonnull Iterable<Header> headers) throws IOException {
         HTTPRequest request = new HTTPRequest(new URL(url), method, options);
         for (Header header : headers) {
             request.addHeader(new HTTPHeader(header.getKey(), header.getValue()));
@@ -98,7 +101,7 @@ public class GoogleAppEngineRequestor extends HttpRequestor {
      *
      * @return new instance of default fetch options used by this requestor.
      */
-    public static FetchOptions newDefaultOptions() {
+    public static @Nonnull FetchOptions newDefaultOptions() {
         return FetchOptions.Builder.withDefaults()
             .validateCertificate()
             .doNotFollowRedirects()
@@ -107,7 +110,7 @@ public class GoogleAppEngineRequestor extends HttpRequestor {
             .setDeadline((DEFAULT_CONNECT_TIMEOUT_MILLIS + DEFAULT_READ_TIMEOUT_MILLIS)/1000.0);
     }
 
-    private static Response toRequestorResponse(HTTPResponse response) {
+    private static @Nonnull Response toRequestorResponse(@Nonnull HTTPResponse response) {
         Map<String, List<String>> headers = new HashMap<String, List<String>>();
         for (HTTPHeader header : response.getHeadersUncombined()) {
             List<String> existing = headers.get(header.getName());
@@ -127,16 +130,18 @@ public class GoogleAppEngineRequestor extends HttpRequestor {
         private final URLFetchService service;
         private final ByteArrayOutputStream body;
 
-        private HTTPRequest request;
+        private @Nullable HTTPRequest request;
 
-        public FetchServiceUploader(URLFetchService service, HTTPRequest request, ByteArrayOutputStream body) {
+        public FetchServiceUploader(@Nonnull URLFetchService service,
+                                    @Nonnull HTTPRequest request,
+                                    @Nonnull ByteArrayOutputStream body) {
             this.service = service;
             this.request = request;
             this.body = body;
         }
 
         @Override
-        public OutputStream getBody() {
+        public @Nonnull OutputStream getBody() {
             return body;
         }
 
@@ -164,16 +169,17 @@ public class GoogleAppEngineRequestor extends HttpRequestor {
         }
 
         @Override
-        public Response finish() throws IOException {
+        public @Nonnull Response finish() throws IOException {
             if (request == null) {
                 throw new IllegalStateException("Uploader already closed.");
             }
-            request.setPayload(body.toByteArray());
+            byte[] payload = body.toByteArray();
+            request.setPayload(payload);
             HTTPResponse response = service.fetch(request);
             Response requestorResponse = toRequestorResponse(response);
             close();
             if (progressListener != null) {
-                progressListener.onProgress(request.getPayload().length);
+                progressListener.onProgress(payload.length);
             }
             return requestorResponse;
         }

--- a/core/src/main/java/com/dropbox/core/http/HttpRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/HttpRequestor.java
@@ -14,6 +14,9 @@ import java.util.concurrent.TimeUnit;
 
 import com.dropbox.core.util.IOUtil;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * An interface that the Dropbox client library uses to make HTTP requests.
  * If you're fine with the standard Java {@link java.net.HttpURLConnection}
@@ -36,12 +39,12 @@ public abstract class HttpRequestor
     // server.
     public static final long DEFAULT_READ_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(2);
 
-    public abstract Response doGet(String url, Iterable<Header> headers) throws IOException;
-    public abstract Uploader startPost(String url, Iterable<Header> headers) throws IOException;
-    public Uploader startPostInStreamingMode(String url, Iterable<Header> headers) throws IOException {
+    public abstract @Nonnull Response doGet(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException;
+    public abstract @Nonnull Uploader startPost(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException;
+    public @Nonnull Uploader startPostInStreamingMode(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         return startPost(url, headers);
     }
-    public abstract Uploader startPut(String url, Iterable<Header> headers) throws IOException;
+    public abstract @Nonnull Uploader startPut(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException;
 
     /**
      * A simple structure holding an HTTP header, which is key/value pair.
@@ -51,7 +54,7 @@ public abstract class HttpRequestor
         private final String key;
         private final String value;
 
-        public Header(String key, String value) {
+        public Header(@Nonnull String key, @Nonnull String value) {
             this.key = key;
             this.value = value;
         }
@@ -61,7 +64,7 @@ public abstract class HttpRequestor
          *
          * @return header name
          */
-        public String getKey() {
+        public @Nonnull String getKey() {
             return key;
         }
 
@@ -70,20 +73,20 @@ public abstract class HttpRequestor
          *
          * @return header value
          */
-        public String getValue() {
+        public @Nonnull String getValue() {
             return value;
         }
     }
 
     public static abstract class Uploader {
-        protected IOUtil.ProgressListener progressListener;
+        protected @Nullable IOUtil.ProgressListener progressListener;
 
-        public abstract OutputStream getBody();
+        public abstract @Nonnull OutputStream getBody();
         public abstract void close();
         public abstract void abort();
-        public abstract Response finish() throws IOException;
+        public abstract @Nonnull Response finish() throws IOException;
 
-        public void upload(File file) throws IOException {
+        public void upload(@Nonnull File file) throws IOException {
             try {
                 upload(new FileInputStream(file));
             } catch (IOUtil.ReadException ex) {
@@ -93,11 +96,11 @@ public abstract class HttpRequestor
             }
         }
 
-        public void upload(InputStream in, long limit) throws IOException {
+        public void upload(@Nonnull InputStream in, long limit) throws IOException {
             upload(IOUtil.limit(in, limit));
         }
 
-        public void upload(InputStream in) throws IOException {
+        public void upload(@Nonnull InputStream in) throws IOException {
             OutputStream out = getBody();
             try {
                 IOUtil.copyStreamToStream(in, out);
@@ -106,7 +109,7 @@ public abstract class HttpRequestor
             }
         }
 
-        public void upload(byte [] body) throws IOException {
+        public void upload(@Nonnull byte [] body) throws IOException {
             OutputStream out = getBody();
             try {
                 out.write(body);
@@ -115,17 +118,17 @@ public abstract class HttpRequestor
             }
         }
 
-        public void setProgressListener(IOUtil.ProgressListener progressListener) {
+        public void setProgressListener(@Nullable IOUtil.ProgressListener progressListener) {
             this.progressListener = progressListener;
         }
     }
 
     public static final class Response {
         private final int statusCode;
-        private final InputStream body;
+        private final @Nullable InputStream body;
         private final Map<String, List<String>> headers;
 
-        public Response(int statusCode, InputStream body, Map<String, ? extends List<String>> headers) {
+        public Response(int statusCode, @Nullable InputStream body, @Nonnull Map<String, ? extends List<String>> headers) {
             this.statusCode = statusCode;
             this.body = body;
             this.headers = asUnmodifiableCaseInsensitiveMap(headers);
@@ -147,7 +150,7 @@ public abstract class HttpRequestor
          *
          * @return HTTP response body
          */
-        public InputStream getBody() {
+        public @Nullable InputStream getBody() {
             return body;
         }
 
@@ -156,11 +159,12 @@ public abstract class HttpRequestor
          *
          * @return case-insensitive, unmodifiable headers
          */
-        public Map<String, List<String>> getHeaders() {
+        public @Nonnull Map<String, List<String>> getHeaders() {
             return headers;
         }
 
-        private static final Map<String, List<String>> asUnmodifiableCaseInsensitiveMap(Map<String, ? extends List<String>> original) {
+        private static @Nonnull Map<String, List<String>> asUnmodifiableCaseInsensitiveMap(
+            @Nonnull Map<String, ? extends List<String>> original) {
             Map<String, List<String>> insensitive = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
             for (Map.Entry<String, ? extends List<String>> entry : original.entrySet()) {
                 // Java HttpURLConnection puts status line as the 'null' key, e.g.:

--- a/core/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
+++ b/core/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import okio.*;
 
 
@@ -30,14 +33,14 @@ public class OkHttp3Requestor extends HttpRequestor {
     /**
      * Returns an {@code OkHttpClient} instance with the default settings for this SDK.
      */
-    public static OkHttpClient defaultOkHttpClient() {
+    public static @Nonnull OkHttpClient defaultOkHttpClient() {
         return defaultOkHttpClientBuilder().build();
     }
 
     /**
      * Returns an {@code OkHttpClient.Builder} instance with the default settings for this SDK.
      */
-    public static OkHttpClient.Builder defaultOkHttpClientBuilder() {
+    public static @Nonnull OkHttpClient.Builder defaultOkHttpClientBuilder() {
         return new OkHttpClient.Builder()
             .connectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
             .readTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
@@ -66,7 +69,7 @@ public class OkHttp3Requestor extends HttpRequestor {
      * </pre>
      *
      */
-    public OkHttp3Requestor(OkHttpClient client) {
+    public OkHttp3Requestor(@Nonnull OkHttpClient client) {
         if (client == null) throw new NullPointerException("client");
         OkHttpUtil.assertNotSameThreadExecutor(client.dispatcher().executorService());
         this.client = client;
@@ -80,7 +83,7 @@ public class OkHttp3Requestor extends HttpRequestor {
      *
      * @return underlying {@code OkHttpClient} used by this requestor.
      */
-    public OkHttpClient getClient() {
+    public @Nonnull OkHttpClient getClient() {
         return client;
     }
 
@@ -92,7 +95,7 @@ public class OkHttp3Requestor extends HttpRequestor {
      *
      * @param request Builder of request to be executed
      */
-    protected void configureRequest(Request.Builder request) { }
+    protected void configureRequest(@Nonnull Request.Builder request) { }
 
     /**
      * Called before returning {@link Response} from a request.
@@ -106,12 +109,12 @@ public class OkHttp3Requestor extends HttpRequestor {
      *
      * @return OkHttp response
      */
-    protected okhttp3.Response interceptResponse(okhttp3.Response response) {
+    protected @Nonnull okhttp3.Response interceptResponse(@Nonnull okhttp3.Response response) {
         return response;
     }
 
     @Override
-    public Response doGet(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Response doGet(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         Request.Builder builder = new Request.Builder().get().url(url);
         toOkHttpHeaders(headers, builder);
         configureRequest(builder);
@@ -122,29 +125,33 @@ public class OkHttp3Requestor extends HttpRequestor {
     }
 
     @Override
-    public HttpRequestor.Uploader startPost(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull HttpRequestor.Uploader startPost(@Nonnull String url,
+                                                     @Nonnull Iterable<Header> headers) throws IOException {
         return startUpload(url, headers, "POST");
     }
 
     @Override
-    public HttpRequestor.Uploader startPut(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull HttpRequestor.Uploader startPut(@Nonnull String url,
+                                                    @Nonnull Iterable<Header> headers) throws IOException {
         return startUpload(url, headers, "PUT");
     }
 
-    private BufferedUploader startUpload(String url, Iterable<Header> headers, String method) {
+    private @Nonnull BufferedUploader startUpload(@Nonnull String url,
+                                                  @Nonnull Iterable<Header> headers,
+                                                  @Nonnull String method) {
         Request.Builder builder = new Request.Builder()
             .url(url);
         toOkHttpHeaders(headers, builder);
         return new BufferedUploader(method, builder);
     }
 
-    private static void toOkHttpHeaders(Iterable<Header> headers, Request.Builder builder) {
+    private static void toOkHttpHeaders(@Nonnull Iterable<Header> headers, @Nonnull Request.Builder builder) {
         for (Header header : headers) {
             builder.addHeader(header.getKey(), header.getValue());
         }
     }
 
-    private static Map<String, List<String>> fromOkHttpHeaders(Headers headers) {
+    private static @Nonnull Map<String, List<String>> fromOkHttpHeaders(@Nonnull Headers headers) {
         Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>(headers.size());
         for (String name : headers.names()) {
             responseHeaders.put(name, headers.values(name));
@@ -173,7 +180,7 @@ public class OkHttp3Requestor extends HttpRequestor {
         private boolean closed;
         private boolean cancelled;
 
-        public BufferedUploader(String method, Request.Builder request) {
+        public BufferedUploader(@Nonnull String method, @Nonnull Request.Builder request) {
             this.method = method;
             this.request = request;
 
@@ -192,7 +199,7 @@ public class OkHttp3Requestor extends HttpRequestor {
         }
 
         @Override
-        public OutputStream getBody() {
+        public @Nonnull OutputStream getBody() {
             // getBody() can be called multiple times to get access to the output stream. Don't
             // error if this is the case.
             if (body instanceof PipedRequestBody) {
@@ -213,7 +220,7 @@ public class OkHttp3Requestor extends HttpRequestor {
             }
         }
 
-        private void setBody(RequestBody body) {
+        private void setBody(@Nonnull RequestBody body) {
             assertNoBody();
             this.body = body;
             this.request.method(method, body);
@@ -221,12 +228,12 @@ public class OkHttp3Requestor extends HttpRequestor {
         }
 
         @Override
-        public void upload(File file) {
+        public void upload(@Nonnull File file) {
             setBody(RequestBody.Companion.create(file, null));
         }
 
         @Override
-        public void upload(byte [] body) {
+        public void upload(@Nonnull byte [] body) {
             setBody(RequestBody.Companion.create(body, null));
         }
 
@@ -252,7 +259,7 @@ public class OkHttp3Requestor extends HttpRequestor {
         }
 
         @Override
-        public Response finish() throws IOException {
+        public @Nonnull Response finish() throws IOException {
             if (cancelled) {
                 throw new IllegalStateException("Already aborted");
             }
@@ -279,17 +286,17 @@ public class OkHttp3Requestor extends HttpRequestor {
     }
 
     public static final class AsyncCallback implements Callback {
-        private PipedRequestBody body;
-        private IOException error;
-        private okhttp3.Response response;
+        private @Nonnull PipedRequestBody body;
+        private @Nullable IOException error;
+        private @Nullable okhttp3.Response response;
 
-        private AsyncCallback(PipedRequestBody body) {
+        private AsyncCallback(@Nonnull PipedRequestBody body) {
             this.body = body;
             this.error = null;
             this.response = null;
         }
 
-        public synchronized okhttp3.Response getResponse() throws IOException {
+        public synchronized @Nonnull okhttp3.Response getResponse() throws IOException {
             while (error == null && response == null) {
                 try {
                     wait();
@@ -305,14 +312,14 @@ public class OkHttp3Requestor extends HttpRequestor {
         }
 
         @Override
-        public synchronized void onFailure(Call call, IOException ex) {
+        public synchronized void onFailure(@Nonnull Call call, @Nonnull IOException ex) {
             this.error = ex;
             this.body.close();
             notifyAll();
         }
 
         @Override
-        public synchronized void onResponse(Call call, okhttp3.Response response) throws IOException {
+        public synchronized void onResponse(@Nonnull Call call, @Nonnull okhttp3.Response response) throws IOException {
             this.response = response;
             notifyAll();
         }
@@ -321,15 +328,15 @@ public class OkHttp3Requestor extends HttpRequestor {
     private static class PipedRequestBody extends RequestBody implements Closeable {
         private final OkHttpUtil.PipedStream stream;
 
-        private IOUtil.ProgressListener listener;
+        private @Nullable IOUtil.ProgressListener listener;
 
         public PipedRequestBody() {
             this.stream = new OkHttpUtil.PipedStream();
         }
 
-        public void setListener(IOUtil.ProgressListener listener) { this.listener = listener; }
+        public void setListener(@Nullable IOUtil.ProgressListener listener) { this.listener = listener; }
 
-        public OutputStream getOutputStream() {
+        public @Nonnull OutputStream getOutputStream() {
             return stream.getOutputStream();
         }
 
@@ -344,7 +351,7 @@ public class OkHttp3Requestor extends HttpRequestor {
         }
 
         @Override
-        public MediaType contentType() {
+        public @Nullable MediaType contentType() {
             return null;
         }
 
@@ -354,7 +361,7 @@ public class OkHttp3Requestor extends HttpRequestor {
         }
 
         @Override
-        public void writeTo(BufferedSink sink) throws IOException {
+        public void writeTo(@Nonnull BufferedSink sink) throws IOException {
             CountingSink countingSink = new CountingSink(sink);
             BufferedSink bufferedSink = Okio.buffer(countingSink);
             stream.writeTo(bufferedSink);
@@ -365,12 +372,12 @@ public class OkHttp3Requestor extends HttpRequestor {
         private final class CountingSink extends ForwardingSink {
             private long bytesWritten = 0;
 
-            public CountingSink(Sink delegate) {
+            public CountingSink(@Nonnull Sink delegate) {
                 super(delegate);
             }
 
             @Override
-            public void write(Buffer source, long byteCount) throws IOException {
+            public void write(@Nonnull Buffer source, long byteCount) throws IOException {
                 super.write(source, byteCount);
 
                 bytesWritten += byteCount;

--- a/core/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
+++ b/core/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import okio.*;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * {@link HttpRequestor} implementation that uses <a href="http://square.github.io/okhttp/">OkHttp

--- a/core/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import okio.*;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * {@link HttpRequestor} implementation that uses <a href="http://square.github.io/okhttp/">OkHttp

--- a/core/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import okio.*;
 
 
@@ -34,7 +37,7 @@ public class OkHttpRequestor extends HttpRequestor {
     /**
      * Returns an {@code OkHttpClient} instance with the default settings for this SDK.
      */
-    public static OkHttpClient defaultOkHttpClient() {
+    public static @Nonnull OkHttpClient defaultOkHttpClient() {
         OkHttpClient client = new OkHttpClient();
         client.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         client.setReadTimeout(DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
@@ -59,7 +62,7 @@ public class OkHttpRequestor extends HttpRequestor {
      * </pre>
      *
      */
-    public OkHttpRequestor(OkHttpClient client) {
+    public OkHttpRequestor(@Nonnull OkHttpClient client) {
         if (client == null) throw new NullPointerException("client");
         OkHttpUtil.assertNotSameThreadExecutor(client.getDispatcher().getExecutorService());
         this.client = client.clone();
@@ -73,7 +76,7 @@ public class OkHttpRequestor extends HttpRequestor {
      *
      * @return clone of the underlying {@code OkHttpClient} used by this requestor.
      */
-    public OkHttpClient getClient() {
+    public @Nonnull OkHttpClient getClient() {
         return client;
     }
 
@@ -85,7 +88,7 @@ public class OkHttpRequestor extends HttpRequestor {
      *
      * @param request Builder of request to be executed
      */
-    protected void configureRequest(Request.Builder request) { }
+    protected void configureRequest(@Nonnull Request.Builder request) { }
 
     /**
      * Called before returning {@link Response} from a request.
@@ -99,12 +102,12 @@ public class OkHttpRequestor extends HttpRequestor {
      *
      * @return OkHttp response
      */
-    protected com.squareup.okhttp.Response interceptResponse(com.squareup.okhttp.Response response) {
+    protected @Nonnull com.squareup.okhttp.Response interceptResponse(@Nonnull com.squareup.okhttp.Response response) {
         return response;
     }
 
     @Override
-    public Response doGet(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Response doGet(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         Request.Builder builder = new Request.Builder().get().url(url);
         toOkHttpHeaders(headers, builder);
         configureRequest(builder);
@@ -115,29 +118,33 @@ public class OkHttpRequestor extends HttpRequestor {
     }
 
     @Override
-    public HttpRequestor.Uploader startPost(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull HttpRequestor.Uploader startPost(@Nonnull String url,
+                                                     @Nonnull Iterable<Header> headers) throws IOException {
         return startUpload(url, headers, "POST");
     }
 
     @Override
-    public HttpRequestor.Uploader startPut(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull HttpRequestor.Uploader startPut(@Nonnull String url,
+                                                    @Nonnull Iterable<Header> headers) throws IOException {
         return startUpload(url, headers, "PUT");
     }
 
-    private BufferedUploader startUpload(String url, Iterable<Header> headers, String method) {
+    private @Nonnull BufferedUploader startUpload(@Nonnull String url,
+                                                  @Nonnull Iterable<Header> headers,
+                                                  @Nonnull String method) {
         Request.Builder builder = new Request.Builder()
             .url(url);
         toOkHttpHeaders(headers, builder);
         return new BufferedUploader(method, builder);
     }
 
-    private static void toOkHttpHeaders(Iterable<Header> headers, Request.Builder builder) {
+    private static void toOkHttpHeaders(@Nonnull Iterable<Header> headers, @Nonnull Request.Builder builder) {
         for (Header header : headers) {
             builder.addHeader(header.getKey(), header.getValue());
         }
     }
 
-    private static Map<String, List<String>> fromOkHttpHeaders(Headers headers) {
+    private static @Nonnull Map<String, List<String>> fromOkHttpHeaders(@Nonnull Headers headers) {
         Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>(headers.size());
         for (String name : headers.names()) {
             responseHeaders.put(name, headers.values(name));
@@ -166,7 +173,7 @@ public class OkHttpRequestor extends HttpRequestor {
         private boolean closed;
         private boolean cancelled;
 
-        public BufferedUploader(String method, Request.Builder request) {
+        public BufferedUploader(@Nonnull String method, @Nonnull Request.Builder request) {
             this.method = method;
             this.request = request;
 
@@ -185,7 +192,7 @@ public class OkHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public OutputStream getBody() {
+        public @Nonnull OutputStream getBody() {
             // getBody() can be called multiple times to get access to the output stream. Don't
             // error if this is the case.
             if (body instanceof PipedRequestBody) {
@@ -205,7 +212,7 @@ public class OkHttpRequestor extends HttpRequestor {
             }
         }
 
-        private void setBody(RequestBody body) {
+        private void setBody(@Nonnull RequestBody body) {
             assertNoBody();
             this.body = body;
             this.request.method(method, body);
@@ -213,12 +220,12 @@ public class OkHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public void upload(File file) {
+        public void upload(@Nonnull File file) {
             setBody(RequestBody.create(null, file));
         }
 
         @Override
-        public void upload(byte [] body) {
+        public void upload(@Nonnull byte [] body) {
             setBody(RequestBody.create(null, body));
         }
 
@@ -244,7 +251,7 @@ public class OkHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public Response finish() throws IOException {
+        public @Nonnull Response finish() throws IOException {
             if (cancelled) {
                 throw new IllegalStateException("Already aborted");
             }
@@ -271,15 +278,15 @@ public class OkHttpRequestor extends HttpRequestor {
     }
 
     public static final class AsyncCallback implements Callback {
-        private IOException error;
-        private com.squareup.okhttp.Response response;
+        private @Nullable IOException error;
+        private @Nullable com.squareup.okhttp.Response response;
 
         private AsyncCallback() {
             this.error = null;
             this.response = null;
         }
 
-        public synchronized com.squareup.okhttp.Response getResponse() throws IOException {
+        public synchronized @Nonnull com.squareup.okhttp.Response getResponse() throws IOException {
             while (error == null && response == null) {
                 try {
                     wait();
@@ -295,13 +302,13 @@ public class OkHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public synchronized void onFailure(Request request, IOException ex) {
+        public synchronized void onFailure(@Nonnull Request request, @Nonnull IOException ex) {
             this.error = ex;
             notifyAll();
         }
 
         @Override
-        public synchronized void onResponse(com.squareup.okhttp.Response response) throws IOException {
+        public synchronized void onResponse(@Nonnull com.squareup.okhttp.Response response) throws IOException {
             this.response = response;
             notifyAll();
         }
@@ -310,15 +317,15 @@ public class OkHttpRequestor extends HttpRequestor {
     private static class PipedRequestBody extends RequestBody implements Closeable {
         private final OkHttpUtil.PipedStream stream;
 
-        private IOUtil.ProgressListener listener;
+        private @Nullable IOUtil.ProgressListener listener;
 
         public PipedRequestBody() {
             this.stream = new OkHttpUtil.PipedStream();
         }
 
-        public void setListener(IOUtil.ProgressListener listener) { this.listener = listener; }
+        public void setListener(@Nullable IOUtil.ProgressListener listener) { this.listener = listener; }
 
-        public OutputStream getOutputStream() {
+        public @Nonnull OutputStream getOutputStream() {
             return stream.getOutputStream();
         }
 
@@ -328,7 +335,7 @@ public class OkHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public MediaType contentType() {
+        public @Nullable MediaType contentType() {
             return null;
         }
 
@@ -338,7 +345,7 @@ public class OkHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public void writeTo(BufferedSink sink) throws IOException {
+        public void writeTo(@Nonnull BufferedSink sink) throws IOException {
             CountingSink countingSink = new CountingSink(sink);
             BufferedSink bufferedSink = Okio.buffer(countingSink);
             stream.writeTo(bufferedSink);
@@ -349,12 +356,12 @@ public class OkHttpRequestor extends HttpRequestor {
         private final class CountingSink extends ForwardingSink {
             private long bytesWritten = 0;
 
-            public CountingSink(Sink delegate) {
+            public CountingSink(@Nonnull Sink delegate) {
                 super(delegate);
             }
 
             @Override
-            public void write(Buffer source, long byteCount) throws IOException {
+            public void write(@Nonnull Buffer source, long byteCount) throws IOException {
                 super.write(source, byteCount);
 
                 bytesWritten += byteCount;

--- a/core/src/main/java/com/dropbox/core/http/OkHttpUtil.java
+++ b/core/src/main/java/com/dropbox/core/http/OkHttpUtil.java
@@ -9,20 +9,22 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nonnull;
+
 import okio.BufferedSink;
 import okio.Okio;
 
 
 final class OkHttpUtil {
 
-    public static void assertNotSameThreadExecutor(ExecutorService executor) {
+    public static void assertNotSameThreadExecutor(@Nonnull ExecutorService executor) {
         Thread current = Thread.currentThread();
 
         Thread executed;
         try {
             executed = executor.submit(new Callable<Thread>() {
                 @Override
-                public Thread call() {
+                public @Nonnull Thread call() {
                     return Thread.currentThread();
                 }
             }).get(2, TimeUnit.MINUTES);
@@ -57,7 +59,7 @@ final class OkHttpUtil {
             }
         }
 
-        public OutputStream getOutputStream() {
+        public @Nonnull OutputStream getOutputStream() {
             return out;
         }
 
@@ -75,7 +77,7 @@ final class OkHttpUtil {
             }
         }
 
-        public void writeTo(BufferedSink sink) throws IOException {
+        public void writeTo(@Nonnull BufferedSink sink) throws IOException {
             sink.writeAll(Okio.source(in));
         }
     }

--- a/core/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
@@ -9,7 +9,7 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 

--- a/core/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
@@ -9,14 +9,13 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
 import com.dropbox.core.util.IOUtil;
 import com.dropbox.core.util.ProgressOutputStream;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * {@link HttpRequestor} implementation that uses Java's standard library

--- a/core/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
+++ b/core/src/main/java/com/dropbox/core/http/StandardHttpRequestor.java
@@ -9,6 +9,7 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
@@ -34,7 +35,7 @@ public class StandardHttpRequestor extends HttpRequestor {
      * A thread-safe instance of {@code StandardHttpRequestor} that connects directly
      * (as opposed to using a proxy).
      */
-    public static final StandardHttpRequestor INSTANCE = new StandardHttpRequestor(Config.DEFAULT_INSTANCE);
+    public static final @Nonnull StandardHttpRequestor INSTANCE = new StandardHttpRequestor(Config.DEFAULT_INSTANCE);
 
     private static volatile boolean certPinningWarningLogged = false;
 
@@ -43,11 +44,11 @@ public class StandardHttpRequestor extends HttpRequestor {
     /**
      * Creates an instance that connects through the given proxy.
      */
-    public StandardHttpRequestor(Config config) {
+    public StandardHttpRequestor(@Nonnull Config config) {
         this.config = config;
     }
 
-    private Response toResponse(HttpURLConnection conn) throws IOException {
+    private @Nonnull Response toResponse(@Nonnull HttpURLConnection conn) throws IOException {
         int responseCode = conn.getResponseCode();
         InputStream bodyStream;
         if (responseCode >= 400 || responseCode == -1) {
@@ -60,7 +61,7 @@ public class StandardHttpRequestor extends HttpRequestor {
     }
 
     @Override
-    public Response doGet(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Response doGet(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         HttpURLConnection conn = prepRequest(url, headers, false);
         conn.setRequestMethod("GET");
         conn.connect();
@@ -68,14 +69,14 @@ public class StandardHttpRequestor extends HttpRequestor {
     }
 
     @Override
-    public Uploader startPost(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Uploader startPost(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         HttpURLConnection conn = prepRequest(url, headers, false);
         conn.setRequestMethod("POST");
         return new Uploader(conn);
     }
 
     @Override
-    public Uploader startPostInStreamingMode(String url, Iterable<Header> headers) throws
+    public @Nonnull Uploader startPostInStreamingMode(@Nonnull String url, @Nonnull Iterable<Header> headers) throws
         IOException {
         HttpURLConnection conn = prepRequest(url, headers, true);
         conn.setRequestMethod("POST");
@@ -83,7 +84,7 @@ public class StandardHttpRequestor extends HttpRequestor {
     }
 
     @Override
-    public Uploader startPut(String url, Iterable<Header> headers) throws IOException {
+    public @Nonnull Uploader startPut(@Nonnull String url, @Nonnull Iterable<Header> headers) throws IOException {
         HttpURLConnection conn = prepRequest(url, headers, false);
         conn.setRequestMethod("PUT");
         return new Uploader(conn);
@@ -97,7 +98,7 @@ public class StandardHttpRequestor extends HttpRequestor {
      * @deprecated use {@link #configure} instead.
      */
     @Deprecated
-    protected void configureConnection(HttpsURLConnection conn) throws IOException { }
+    protected void configureConnection(@Nonnull HttpsURLConnection conn) throws IOException { }
 
     /**
      * Can be overriden to configure the underlying {@link HttpURLConnection} used to make network
@@ -112,7 +113,7 @@ public class StandardHttpRequestor extends HttpRequestor {
      *
      * @param conn URL connection object returned after creating an https network request.
      */
-    protected void configure(HttpURLConnection conn) throws IOException { }
+    protected void configure(@Nonnull HttpURLConnection conn) throws IOException { }
 
     /**
      * Called before returning {@link Response} from a request.
@@ -126,9 +127,9 @@ public class StandardHttpRequestor extends HttpRequestor {
      *
      * @param conn HTTP URL connection
      */
-    protected void interceptResponse(HttpURLConnection conn) throws IOException { }
+    protected void interceptResponse(@Nonnull HttpURLConnection conn) throws IOException { }
 
-    private static OutputStream getOutputStream(HttpURLConnection conn) throws IOException {
+    private static @Nonnull OutputStream getOutputStream(@Nonnull HttpURLConnection conn) throws IOException {
         conn.setDoOutput(true);
         return conn.getOutputStream();
     }
@@ -137,7 +138,7 @@ public class StandardHttpRequestor extends HttpRequestor {
         private final ProgressOutputStream out;
         private HttpURLConnection conn;
 
-        public Uploader(HttpURLConnection conn) throws IOException {
+        public Uploader(@Nonnull HttpURLConnection conn) throws IOException {
             this.conn = conn;
             this.out = new ProgressOutputStream(getOutputStream(conn));
 
@@ -145,7 +146,7 @@ public class StandardHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public OutputStream getBody() {
+        public @Nonnull OutputStream getBody() {
             return out;
         }
 
@@ -178,7 +179,7 @@ public class StandardHttpRequestor extends HttpRequestor {
         }
 
         @Override
-        public Response finish() throws IOException {
+        public @Nonnull Response finish() throws IOException {
             if (conn == null) {
                 throw new IllegalStateException("Can't finish().  Uploader already closed.");
             }
@@ -190,13 +191,16 @@ public class StandardHttpRequestor extends HttpRequestor {
             }
         }
 
-        public void setProgressListener(IOUtil.ProgressListener progressListener) {
+        @Override
+        public void setProgressListener(@Nullable IOUtil.ProgressListener progressListener) {
             out.setListener(progressListener);
         }
     }
 
 
-    protected HttpURLConnection prepRequest(String url, Iterable<Header> headers, boolean streaming) throws IOException {
+    protected @Nonnull HttpURLConnection prepRequest(@Nonnull String url,
+                                                     @Nonnull Iterable<Header> headers,
+                                                     boolean streaming) throws IOException {
         URL urlObject = new URL(url);
         HttpURLConnection conn = (HttpURLConnection) urlObject.openConnection(config.getProxy());
 
@@ -261,17 +265,17 @@ public class StandardHttpRequestor extends HttpRequestor {
          * {@link Config} with all its attributes set to their default
          * values.
          */
-        public static final Config DEFAULT_INSTANCE = builder().build();
+        public static final @Nonnull Config DEFAULT_INSTANCE = builder().build();
 
         private final Proxy proxy;
         private final long connectTimeoutMillis;
         private final long readTimeoutMillis;
         private final SSLSocketFactory sslSocketFactory;
 
-        private Config(Proxy proxy,
+        private Config(@Nonnull Proxy proxy,
                        long connectTimeoutMillis,
                        long readTimeoutMillis,
-                       SSLSocketFactory sslSocketFactory) {
+                       @Nullable SSLSocketFactory sslSocketFactory) {
             this.proxy = proxy;
             this.connectTimeoutMillis = connectTimeoutMillis;
             this.readTimeoutMillis = readTimeoutMillis;
@@ -283,7 +287,7 @@ public class StandardHttpRequestor extends HttpRequestor {
          *
          * @return proxy configuration to use for network connections.
          */
-        public Proxy getProxy() {
+        public @Nonnull Proxy getProxy() {
             return proxy;
         }
 
@@ -319,8 +323,7 @@ public class StandardHttpRequestor extends HttpRequestor {
          *
          * @return SSLSocketFactory or null.
          */
-        @Nullable
-        public SSLSocketFactory getSslSocketFactory() {
+        public @Nullable SSLSocketFactory getSslSocketFactory() {
             return sslSocketFactory;
         }
 
@@ -331,7 +334,7 @@ public class StandardHttpRequestor extends HttpRequestor {
          *
          * @return builder for creating a copy of this config.
          */
-        public Builder copy() {
+        public @Nonnull Builder copy() {
             return new Builder(proxy, connectTimeoutMillis, readTimeoutMillis, sslSocketFactory);
         }
 
@@ -340,7 +343,7 @@ public class StandardHttpRequestor extends HttpRequestor {
          *
          * @return builder for creating an instance of this class
          */
-        public static Builder builder() {
+        public static @Nonnull Builder builder() {
             return new Builder();
         }
 
@@ -357,7 +360,10 @@ public class StandardHttpRequestor extends HttpRequestor {
                 this(Proxy.NO_PROXY, DEFAULT_CONNECT_TIMEOUT_MILLIS, DEFAULT_READ_TIMEOUT_MILLIS, null);
             }
 
-            private Builder(Proxy proxy, long connectTimeoutMillis, long readTimeoutMillis, SSLSocketFactory sslSocketFactory) {
+            private Builder(@Nonnull Proxy proxy,
+                            long connectTimeoutMillis,
+                            long readTimeoutMillis,
+                            @Nullable SSLSocketFactory sslSocketFactory) {
                 this.proxy = proxy;
                 this.connectTimeoutMillis = connectTimeoutMillis;
                 this.readTimeoutMillis = readTimeoutMillis;
@@ -373,7 +379,7 @@ public class StandardHttpRequestor extends HttpRequestor {
              *
              * @throws NullPointerException if {@code proxy} is {@code null}
              */
-            public Builder withProxy(Proxy proxy) {
+            public @Nonnull Builder withProxy(@Nonnull Proxy proxy) {
                 if (proxy == null) {
                     throw new NullPointerException("proxy");
                 }
@@ -387,7 +393,7 @@ public class StandardHttpRequestor extends HttpRequestor {
              *
              * @return this builder
              */
-            public Builder withNoConnectTimeout() {
+            public @Nonnull Builder withNoConnectTimeout() {
                 return withConnectTimeout(0L, TimeUnit.MILLISECONDS);
             }
 
@@ -404,7 +410,7 @@ public class StandardHttpRequestor extends HttpRequestor {
              * @throws IllegalArgumentException if {@code timeout} is negative
              * @throws NullPointerException if {@code unit} is {@code null}
              */
-            public Builder withConnectTimeout(long timeout, TimeUnit unit) {
+            public @Nonnull Builder withConnectTimeout(long timeout, @Nonnull TimeUnit unit) {
                 this.connectTimeoutMillis = checkTimeoutMillis(timeout, unit);
                 return this;
             }
@@ -414,7 +420,7 @@ public class StandardHttpRequestor extends HttpRequestor {
              *
              * @return this builder
              */
-            public Builder withNoReadTimeout() {
+            public @Nonnull Builder withNoReadTimeout() {
                 return withReadTimeout(0L, TimeUnit.MILLISECONDS);
             }
 
@@ -436,7 +442,7 @@ public class StandardHttpRequestor extends HttpRequestor {
              * @throws IllegalArgumentException if {@code timeout} is negative
              * @throws NullPointerException if {@code unit} is {@code null}
              */
-            public Builder withReadTimeout(long timeout, TimeUnit unit) {
+            public @Nonnull Builder withReadTimeout(long timeout, @Nonnull TimeUnit unit) {
                 this.readTimeoutMillis = checkTimeoutMillis(timeout, unit);
                 return this;
             }
@@ -451,7 +457,7 @@ public class StandardHttpRequestor extends HttpRequestor {
              *
              * @return this builder
              */
-            public Builder withSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+            public @Nonnull Builder withSslSocketFactory(@Nullable SSLSocketFactory sslSocketFactory) {
                 this.sslSocketFactory = sslSocketFactory;
                 return this;
             }
@@ -461,7 +467,7 @@ public class StandardHttpRequestor extends HttpRequestor {
              *
              * @return {@link Config} with this builder's values
              */
-            public Config build() {
+            public @Nonnull Config build() {
                 return new Config(
                     proxy,
                     connectTimeoutMillis,
@@ -470,7 +476,7 @@ public class StandardHttpRequestor extends HttpRequestor {
                 );
             }
 
-            private static long checkTimeoutMillis(long timeout, TimeUnit unit) {
+            private static long checkTimeoutMillis(long timeout, @Nonnull TimeUnit unit) {
                 if (unit == null) {
                     throw new NullPointerException("unit");
                 }

--- a/core/src/main/java/com/dropbox/core/json/JsonArrayReader.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonArrayReader.java
@@ -3,37 +3,38 @@ package com.dropbox.core.json;
 import com.dropbox.core.util.Collector;
 import com.fasterxml.jackson.core.*;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
 public class JsonArrayReader<T,L> extends JsonReader<L>
 {
-    public final JsonReader<? extends T> elementReader;
-    public final Collector<T,? extends L> collector;
+    public final @Nonnull JsonReader<? extends T> elementReader;
+    public final @Nonnull Collector<T,? extends L> collector;
 
-    public JsonArrayReader(JsonReader<? extends T> elementReader, Collector<T, ? extends L> collector)
+    public JsonArrayReader(@Nonnull JsonReader<? extends T> elementReader, @Nonnull Collector<T, ? extends L> collector)
     {
         this.elementReader = elementReader;
         this.collector = collector;
     }
 
-    public static <T> JsonArrayReader<T,List<T>> mk(JsonReader<? extends T> elementReader)
+    public static <T> @Nonnull JsonArrayReader<T,List<T>> mk(@Nonnull JsonReader<? extends T> elementReader)
     {
         return new JsonArrayReader<T,List<T>>(elementReader, new Collector.ArrayListCollector<T>());
     }
 
-    public static <T,L> JsonArrayReader<T,L> mk(JsonReader<? extends T> elementReader, Collector<T,? extends L> collector)
+    public static <T,L> @Nonnull JsonArrayReader<T,L> mk(@Nonnull JsonReader<? extends T> elementReader, @Nonnull Collector<T,? extends L> collector)
     {
         return new JsonArrayReader<T,L>(elementReader, collector);
     }
 
-    public L read(JsonParser parser)
+    public @Nonnull L read(@Nonnull JsonParser parser)
         throws JsonReadException, IOException
     {
         return read(elementReader, collector, parser);
     }
 
-    public static <T,L> L read(JsonReader<? extends T> elementReader, Collector<T, ? extends L> collector, JsonParser parser)
+    public static <T,L> @Nonnull L read(@Nonnull JsonReader<? extends T> elementReader, @Nonnull Collector<T, ? extends L> collector, @Nonnull JsonParser parser)
         throws JsonReadException, IOException
     {
         expectArrayStart(parser);

--- a/core/src/main/java/com/dropbox/core/json/JsonDateReader.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonDateReader.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -16,9 +17,9 @@ public class JsonDateReader
     /**
      * A parser for dates returned by the Dropbox API.
      */
-    public static final JsonReader<Date> Dropbox = new JsonReader<Date>() {
+    public static final @Nonnull JsonReader<Date> Dropbox = new JsonReader<Date>() {
         @Override
-        public Date read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull Date read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             JsonLocation l = parser.getCurrentLocation();
             try {
@@ -38,7 +39,7 @@ public class JsonDateReader
         }
     };
 
-    public static Date parseDropboxDate(char[] buffer, int offset, int length)
+    public static @Nonnull Date parseDropboxDate(@Nonnull char[] buffer, int offset, int length)
         throws java.text.ParseException
     {
         int i = offset;
@@ -147,7 +148,7 @@ public class JsonDateReader
         return c.getTime();
     }
 
-    public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    public static final @Nonnull TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     private static boolean isDigit(char c)
     {
@@ -229,9 +230,9 @@ public class JsonDateReader
      * (e.g. {@literal "2010-01-01T12:00:00Z"}
      * or {@literal "2010-01-01T12:00:00.000Z"}).
      */
-    public static final JsonReader<Date> DropboxV2 = new JsonReader<Date>() {
+    public static final @Nonnull JsonReader<Date> DropboxV2 = new JsonReader<Date>() {
         @Override
-        public Date read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull Date read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             JsonLocation l = parser.getCurrentLocation();
             try {
@@ -251,7 +252,7 @@ public class JsonDateReader
         }
     };
 
-    public static Date parseDropbox8601Date(char[] buffer, int offset, int length)
+    public static @Nonnull Date parseDropbox8601Date(@Nonnull char[] buffer, int offset, int length)
         throws java.text.ParseException
     {
         int i = offset;

--- a/core/src/main/java/com/dropbox/core/json/JsonReadException.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonReadException.java
@@ -1,11 +1,11 @@
 package com.dropbox.core.json;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.File;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 public final class JsonReadException extends java.lang.Exception
 {
@@ -13,7 +13,7 @@ public final class JsonReadException extends java.lang.Exception
 
     public final String error;
     public final JsonLocation location;
-    private /*@Nullable*/PathPart path;
+    private @Nullable PathPart path;
 
     public JsonReadException(String error, JsonLocation location)
     {
@@ -85,9 +85,9 @@ public final class JsonReadException extends java.lang.Exception
     public static final class PathPart
     {
         public final String description;
-        public final /*@Nullable*/PathPart next;
+        public final @Nullable PathPart next;
 
-        public PathPart(String description, /*@Nullable*/PathPart next)
+        public PathPart(String description, @Nullable PathPart next)
         {
             this.description = description;
             this.next = next;

--- a/core/src/main/java/com/dropbox/core/json/JsonReadException.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonReadException.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.json;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -87,7 +87,7 @@ public final class JsonReadException extends java.lang.Exception
         public final String description;
         public final @Nullable PathPart next;
 
-        public PathPart(String description, @Nullable PathPart next)
+        public PathPart(String description, PathPart next)
         {
             this.description = description;
             this.next = next;

--- a/core/src/main/java/com/dropbox/core/json/JsonReadException.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonReadException.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.json;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -11,18 +12,18 @@ public final class JsonReadException extends java.lang.Exception
 {
     public static final long serialVersionUID = 0;
 
-    public final String error;
-    public final JsonLocation location;
+    public final @Nonnull String error;
+    public final @Nonnull JsonLocation location;
     private @Nullable PathPart path;
 
-    public JsonReadException(String error, JsonLocation location)
+    public JsonReadException(@Nonnull String error, @Nonnull JsonLocation location)
     {
         this.error = error;
         this.location = location;
         this.path = null;
     }
 
-    public JsonReadException(String error, JsonLocation location, Throwable cause)
+    public JsonReadException(@Nonnull String error, @Nonnull JsonLocation location, @Nonnull Throwable cause)
     {
         super(cause);
         this.error = error;
@@ -30,19 +31,19 @@ public final class JsonReadException extends java.lang.Exception
         this.path = null;
     }
 
-    public JsonReadException addFieldContext(String fieldName)
+    public @Nonnull JsonReadException addFieldContext(@Nonnull String fieldName)
     {
         this.path = new PathPart('"' + fieldName + '"', this.path);
         return this;
     }
 
-    public JsonReadException addArrayContext(int index)
+    public @Nonnull JsonReadException addArrayContext(int index)
     {
         this.path = new PathPart(Integer.toString(index), this.path);
         return this;
     }
 
-    public String getMessage()
+    public @Nonnull String getMessage()
     {
         StringBuilder buf = new StringBuilder();
 
@@ -68,7 +69,7 @@ public final class JsonReadException extends java.lang.Exception
         return buf.toString();
     }
 
-    public static void toStringLocation(StringBuilder buf, JsonLocation location)
+    public static void toStringLocation(@Nonnull StringBuilder buf, @Nonnull JsonLocation location)
     {
         Object sourceRef = location.getSourceRef();
         if (sourceRef instanceof File) {
@@ -84,17 +85,17 @@ public final class JsonReadException extends java.lang.Exception
 
     public static final class PathPart
     {
-        public final String description;
+        public final @Nonnull String description;
         public final @Nullable PathPart next;
 
-        public PathPart(String description, PathPart next)
+        public PathPart(@Nonnull String description, @Nullable PathPart next)
         {
             this.description = description;
             this.next = next;
         }
     }
 
-    public static JsonReadException fromJackson(JsonProcessingException ex)
+    public static @Nonnull JsonReadException fromJackson(@Nonnull JsonProcessingException ex)
     {
         String message = ex.getMessage();
 

--- a/core/src/main/java/com/dropbox/core/json/JsonReader.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonReader.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.json;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.dropbox.core.util.IOUtil;
 import static com.dropbox.core.util.LangUtil.mkAssert;
 
@@ -17,7 +18,6 @@ import java.io.InputStream;
 
 import java.util.HashMap;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 public abstract class JsonReader<T>
 {
@@ -41,14 +41,14 @@ public abstract class JsonReader<T>
         // Base implementation does nothing.
     }
 
-    public final T readField(JsonParser parser, String fieldName, /*@Nullable*/Object v)
+    public final T readField(JsonParser parser, String fieldName, @Nullable Object v)
         throws IOException, JsonReadException
     {
         if (v != null) throw new JsonReadException("duplicate field \"" + fieldName + "\"", parser.getTokenLocation());
         return read(parser);
     }
 
-    public final /*@Nullable*/T readOptional(JsonParser parser)
+    public final @Nullable T readOptional(JsonParser parser)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
@@ -423,7 +423,7 @@ public abstract class JsonReader<T>
 
         public static final class Builder
         {
-            private /*@Nullable*/HashMap<String,Integer> fields = new HashMap<String,Integer>();
+            private @Nullable HashMap<String,Integer> fields = new HashMap<String,Integer>();
 
             public void add(String fieldName, int expectedIndex)
             {

--- a/core/src/main/java/com/dropbox/core/json/JsonReader.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonReader.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.json;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.dropbox.core.util.IOUtil;
 import static com.dropbox.core.util.LangUtil.mkAssert;
 
@@ -41,7 +41,7 @@ public abstract class JsonReader<T>
         // Base implementation does nothing.
     }
 
-    public final T readField(JsonParser parser, String fieldName, @Nullable Object v)
+    public final T readField(JsonParser parser, String fieldName, Object v)
         throws IOException, JsonReadException
     {
         if (v != null) throw new JsonReadException("duplicate field \"" + fieldName + "\"", parser.getTokenLocation());

--- a/core/src/main/java/com/dropbox/core/json/JsonReader.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonReader.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.json;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.dropbox.core.util.IOUtil;
 import static com.dropbox.core.util.LangUtil.mkAssert;
@@ -21,34 +22,34 @@ import java.util.HashMap;
 
 public abstract class JsonReader<T>
 {
-    public abstract T read(JsonParser parser)
+    public abstract @Nullable T read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException;
 
-    public T readFromTags(String[] tags, JsonParser parser)
+    public @Nullable T readFromTags(@Nonnull String[] tags, @Nonnull JsonParser parser)
             throws IOException, JsonReadException
     {
         return null;  // Must override for struct
     }
 
-    public T readFields(JsonParser parser)
+    public @Nullable T readFields(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
     {
         return null;  // Must override for struct
     }
 
-    public void validate(T value)
+    public void validate(@Nullable T value)
     {
         // Base implementation does nothing.
     }
 
-    public final T readField(JsonParser parser, String fieldName, Object v)
+    public final @Nullable T readField(@Nonnull JsonParser parser, @Nonnull String fieldName, @Nullable Object v)
         throws IOException, JsonReadException
     {
         if (v != null) throw new JsonReadException("duplicate field \"" + fieldName + "\"", parser.getTokenLocation());
         return read(parser);
     }
 
-    public final @Nullable T readOptional(JsonParser parser)
+    public final @Nullable T readOptional(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
@@ -65,7 +66,7 @@ public abstract class JsonReader<T>
      * Returns null if there isn't a ".tag" field; otherwise an array of strings (the tags).
      * Initially the parser must be positioned right after the opening brace.
      */
-    public static String[] readTags(JsonParser parser)
+    public static @Nullable String[] readTags(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() != JsonToken.FIELD_NAME) {
@@ -92,7 +93,7 @@ public abstract class JsonReader<T>
      * logical location information (see {@link JsonReadException#addFieldContext} and
      * {@link JsonReadException#addArrayContext}).
      */
-    public static JsonToken nextToken(JsonParser parser)
+    public static @Nullable JsonToken nextToken(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         try {
@@ -106,7 +107,7 @@ public abstract class JsonReader<T>
     // ------------------------------------------------------------------
     // Delimiter checking helpers.
 
-    public static JsonLocation expectObjectStart(JsonParser parser)
+    public static @Nonnull JsonLocation expectObjectStart(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
@@ -117,7 +118,7 @@ public abstract class JsonReader<T>
         return loc;
     }
 
-    public static void expectObjectEnd(JsonParser parser)
+    public static void expectObjectEnd(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() != JsonToken.END_OBJECT) {
@@ -126,7 +127,7 @@ public abstract class JsonReader<T>
         nextToken(parser);
     }
 
-    public static JsonLocation expectArrayStart(JsonParser parser)
+    public static @Nonnull JsonLocation expectArrayStart(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() != JsonToken.START_ARRAY) {
@@ -137,7 +138,7 @@ public abstract class JsonReader<T>
         return loc;
     }
 
-    public static JsonLocation expectArrayEnd(JsonParser parser)
+    public static @Nonnull JsonLocation expectArrayEnd(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() != JsonToken.END_ARRAY) {
@@ -148,17 +149,17 @@ public abstract class JsonReader<T>
         return loc;
     }
 
-    public static boolean isArrayEnd(JsonParser parser)
+    public static boolean isArrayEnd(@Nonnull JsonParser parser)
     {
         return (parser.getCurrentToken() == JsonToken.END_ARRAY);
     }
 
-    public static boolean isArrayStart(JsonParser parser)
+    public static boolean isArrayStart(@Nonnull JsonParser parser)
     {
         return (parser.getCurrentToken() == JsonToken.START_ARRAY);
     }
 
-    public static void skipValue(JsonParser parser)
+    public static void skipValue(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         try {
@@ -173,16 +174,16 @@ public abstract class JsonReader<T>
     // ------------------------------------------------------------------
     // Helpers for various types.
 
-    public static final JsonReader<Long> UnsignedLongReader = new JsonReader<Long>() {
+    public static final @Nonnull JsonReader<Long> UnsignedLongReader = new JsonReader<Long>() {
         @Override
-        public Long read(JsonParser parser)
+        public @Nonnull Long read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             return readUnsignedLong(parser);
         }
     };
 
-    public static long readUnsignedLong(JsonParser parser)
+    public static long readUnsignedLong(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         try {
@@ -198,16 +199,16 @@ public abstract class JsonReader<T>
         }
     }
 
-    public static long readUnsignedLongField(JsonParser parser, String fieldName, long v)
+    public static long readUnsignedLongField(@Nonnull JsonParser parser, @Nonnull String fieldName, long v)
         throws IOException, JsonReadException
     {
         if (v >= 0) throw new JsonReadException("duplicate field \"" + fieldName + "\"", parser.getCurrentLocation());
         return JsonReader.readUnsignedLong(parser);
     }
 
-    public static final JsonReader<Long> Int64Reader = new JsonReader<Long>()
+    public static final @Nonnull JsonReader<Long> Int64Reader = new JsonReader<Long>()
     {
-        public Long read(JsonParser parser)
+        public @Nonnull Long read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
         {
             long v = parser.getLongValue();
@@ -216,9 +217,9 @@ public abstract class JsonReader<T>
         }
     };
 
-    public static final JsonReader<Integer> Int32Reader = new JsonReader<Integer>()
+    public static final @Nonnull JsonReader<Integer> Int32Reader = new JsonReader<Integer>()
     {
-        public Integer read(JsonParser parser)
+        public @Nonnull Integer read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
         {
             int v = parser.getIntValue();
@@ -228,9 +229,9 @@ public abstract class JsonReader<T>
     };
 
     // NOTE: This can't read values >= 2**63.
-    public static final JsonReader<Long> UInt64Reader = new JsonReader<Long>()
+    public static final @Nonnull JsonReader<Long> UInt64Reader = new JsonReader<Long>()
     {
-        public Long read(JsonParser parser)
+        public @Nonnull Long read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
         {
             return readUnsignedLong(parser);
@@ -238,9 +239,9 @@ public abstract class JsonReader<T>
     };
 
     // NOTE: This stores the value in a Long.
-    public static final JsonReader<Long> UInt32Reader = new JsonReader<Long>()
+    public static final @Nonnull JsonReader<Long> UInt32Reader = new JsonReader<Long>()
     {
-        public Long read(JsonParser parser)
+        public @Nonnull Long read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
         {
             long v = readUnsignedLong(parser);
@@ -251,9 +252,9 @@ public abstract class JsonReader<T>
         }
     };
 
-    public static final JsonReader<Double> Float64Reader = new JsonReader<Double>()
+    public static final @Nonnull JsonReader<Double> Float64Reader = new JsonReader<Double>()
     {
-        public Double read(JsonParser parser)
+        public @Nonnull Double read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
         {
             double v = parser.getDoubleValue();
@@ -262,9 +263,9 @@ public abstract class JsonReader<T>
         }
     };
 
-    public static final JsonReader<Float> Float32Reader = new JsonReader<Float>()
+    public static final @Nonnull JsonReader<Float> Float32Reader = new JsonReader<Float>()
     {
-        public Float read(JsonParser parser)
+        public @Nonnull Float read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
         {
             float v = parser.getFloatValue();
@@ -273,9 +274,9 @@ public abstract class JsonReader<T>
         }
     };
 
-    public static final JsonReader<String> StringReader = new JsonReader<String>()
+    public static final @Nonnull JsonReader<String> StringReader = new JsonReader<String>()
     {
-        public String read(JsonParser parser)
+        public @Nonnull String read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             try {
@@ -289,9 +290,9 @@ public abstract class JsonReader<T>
         }
     };
 
-    public static final JsonReader<byte[]> BinaryReader = new JsonReader<byte[]>()
+    public static final @Nonnull JsonReader<byte[]> BinaryReader = new JsonReader<byte[]>()
     {
-        public byte[] read(JsonParser parser)
+        public @Nonnull byte[] read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             try {
@@ -307,16 +308,16 @@ public abstract class JsonReader<T>
         }
     };
 
-    public static final JsonReader<Boolean> BooleanReader = new JsonReader<Boolean>()
+    public static final @Nonnull JsonReader<Boolean> BooleanReader = new JsonReader<Boolean>()
     {
-        public Boolean read(JsonParser parser)
+        public @Nonnull Boolean read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             return readBoolean(parser);
         }
     };
 
-    public static boolean readBoolean(JsonParser parser)
+    public static boolean readBoolean(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         try {
@@ -329,7 +330,7 @@ public abstract class JsonReader<T>
         }
     }
 
-    public static double readDouble(JsonParser parser)
+    public static double readDouble(@Nonnull JsonParser parser)
         throws  IOException, JsonReadException
     {
         try {
@@ -341,9 +342,9 @@ public abstract class JsonReader<T>
         }
     }
 
-    public static final JsonReader<Object> VoidReader = new JsonReader<Object>()
+    public static final @Nonnull JsonReader<Object> VoidReader = new JsonReader<Object>()
     {
-        public Object read(JsonParser parser)
+        public @Nullable Object read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             skipValue(parser);
@@ -351,7 +352,7 @@ public abstract class JsonReader<T>
         }
     };
 
-    public static <T> T readEnum(JsonParser parser, HashMap<String,T> values, T catch_all)
+    public static <T> @Nonnull T readEnum(@Nonnull JsonParser parser, @Nonnull HashMap<String,T> values, @Nullable T catch_all)
         throws IOException, JsonReadException
     {
         if (parser.getCurrentToken() == JsonToken.START_OBJECT) {
@@ -406,15 +407,15 @@ public abstract class JsonReader<T>
         // - The get() could take (char[], offset, length) instead of String, which we can
         //   provide straight from JsonParser's internal buffer.  This makes error reporting
         //   tricky, though, because we won't have a string for addFieldContext.
-        public final HashMap<String,Integer> fields;
+        public final @Nonnull HashMap<String,Integer> fields;
 
-        private FieldMapping(HashMap<String,Integer> fields)
+        private FieldMapping(@Nonnull HashMap<String,Integer> fields)
         {
             assert fields != null;
             this.fields = fields;
         }
 
-        public int get(String fieldName)
+        public int get(@Nonnull String fieldName)
         {
             Integer i = fields.get(fieldName);
             if (i == null) return -1;
@@ -425,7 +426,7 @@ public abstract class JsonReader<T>
         {
             private @Nullable HashMap<String,Integer> fields = new HashMap<String,Integer>();
 
-            public void add(String fieldName, int expectedIndex)
+            public void add(@Nonnull String fieldName, int expectedIndex)
             {
                 if (fields == null) throw new IllegalStateException("already called build(); can't call add() anymore");
                 int i = fields.size();
@@ -438,7 +439,7 @@ public abstract class JsonReader<T>
                 }
             }
 
-            public FieldMapping build()
+            public @Nonnull FieldMapping build()
             {
                 if (fields == null) throw new IllegalStateException("already called build(); can't call build() again");
                 HashMap<String,Integer> f = fields;
@@ -450,7 +451,7 @@ public abstract class JsonReader<T>
 
     static final JsonFactory jsonFactory = new JsonFactory();
 
-    public T readFully(InputStream utf8Body)
+    public @Nullable T readFully(@Nonnull InputStream utf8Body)
         throws IOException, JsonReadException
     {
         try {
@@ -462,7 +463,7 @@ public abstract class JsonReader<T>
         }
     }
 
-    public T readFully(String body)
+    public @Nullable T readFully(@Nonnull String body)
         throws JsonReadException
     {
         try {
@@ -482,7 +483,7 @@ public abstract class JsonReader<T>
         }
     }
 
-    public T readFully(byte[] utf8Body)
+    public @Nullable T readFully(@Nonnull byte[] utf8Body)
         throws JsonReadException
     {
         try {
@@ -502,13 +503,13 @@ public abstract class JsonReader<T>
         }
     }
 
-    public T readFromFile(String filePath)
+    public @Nullable T readFromFile(@Nonnull String filePath)
         throws FileLoadException
     {
         return readFromFile(new File(filePath));
     }
 
-    public T readFromFile(File file)
+    public @Nullable T readFromFile(@Nonnull File file)
         throws FileLoadException
     {
         try {
@@ -531,7 +532,7 @@ public abstract class JsonReader<T>
     public static abstract class FileLoadException extends Exception {
         private static final long serialVersionUID = 0L;
 
-        protected FileLoadException(String message)
+        protected FileLoadException(@Nonnull String message)
         {
             super(message);
         }
@@ -539,9 +540,9 @@ public abstract class JsonReader<T>
         public static final class IOError extends FileLoadException {
             private static final long serialVersionUID = 0L;
 
-            public final IOException reason;
+            public final @Nonnull IOException reason;
 
-            public IOError(File file, IOException reason)
+            public IOError(@Nonnull File file, @Nonnull IOException reason)
             {
                 super("unable to read file \"" + file.getPath() + "\": " + reason.getMessage());
                 this.reason = reason;
@@ -551,9 +552,9 @@ public abstract class JsonReader<T>
         public static final class JsonError extends FileLoadException {
             private static final long serialVersionUID = 0L;
 
-            public final JsonReadException reason;
+            public final @Nonnull JsonReadException reason;
 
-            public JsonError(File file, JsonReadException reason)
+            public JsonError(@Nonnull File file, @Nonnull JsonReadException reason)
             {
                 super(file.getPath() + ": " + reason.getMessage());
                 this.reason = reason;
@@ -561,7 +562,7 @@ public abstract class JsonReader<T>
         }
     }
 
-    public T readFully(JsonParser parser)
+    public @Nullable T readFully(@Nonnull JsonParser parser)
         throws IOException, JsonReadException
     {
         parser.nextToken();

--- a/core/src/main/java/com/dropbox/core/json/JsonWriter.java
+++ b/core/src/main/java/com/dropbox/core/json/JsonWriter.java
@@ -13,33 +13,36 @@ import java.util.TimeZone;
 
 import com.dropbox.core.json.JsonDateReader;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public abstract class JsonWriter<T>
 {
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
-    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    private static final @Nonnull TimeZone UTC = TimeZone.getTimeZone("UTC");
+    private static final @Nonnull String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
-    public static String formatDate(Date date) {
+    public static @Nonnull String formatDate(@Nonnull Date date) {
         DateFormat df = new SimpleDateFormat(DATE_FORMAT);
         df.setTimeZone(UTC);
         return df.format(date);
     }
 
-    public abstract void write(T value, JsonGenerator g)
+    public abstract void write(@Nullable T value, @Nonnull JsonGenerator g)
         throws IOException;
 
-    public void write(T value, JsonGenerator g, int level)
+    public void write(@Nullable T value, @Nonnull JsonGenerator g, int level)
             throws IOException
     {
         write(value, g);
     }
 
-    public void writeFields(T value, JsonGenerator g)
+    public void writeFields(@Nullable T value, @Nonnull JsonGenerator g)
         throws IOException
     {
         // Default does nothing.  Override for struct fields.
     }
 
-    public final String writeToString(T value, boolean indent)
+    public final @Nonnull String writeToString(@Nullable T value, boolean indent)
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
@@ -62,12 +65,12 @@ public abstract class JsonWriter<T>
         }
     }
 
-    public final String writeToString(T value)
+    public final @Nonnull String writeToString(@Nullable T value)
     {
         return writeToString(value, true);
     }
 
-    public final void writeToStream(T value, OutputStream out, boolean indent)
+    public final void writeToStream(@Nullable T value, @Nonnull OutputStream out, boolean indent)
         throws IOException
     {
         JsonGenerator g = JsonReader.jsonFactory.createGenerator(out);
@@ -82,13 +85,13 @@ public abstract class JsonWriter<T>
         }
     }
 
-    public final void writeToStream(T value, OutputStream out)
+    public final void writeToStream(@Nullable T value, @Nonnull OutputStream out)
             throws IOException
     {
         writeToStream(value, out, true);
     }
 
-    public final void writeToFile(T value, File file, boolean indent)
+    public final void writeToFile(@Nullable T value, @Nonnull File file, boolean indent)
         throws IOException
     {
         FileOutputStream fout = new FileOutputStream(file);
@@ -100,25 +103,25 @@ public abstract class JsonWriter<T>
         }
     }
 
-    public final void writeToFile(T value, File file)
+    public final void writeToFile(@Nullable T value, @Nonnull File file)
             throws IOException
     {
         writeToFile(value, file, true);
     }
 
-    public final void writeToFile(T value, String fileName, boolean indent)
+    public final void writeToFile(@Nullable T value, @Nonnull String fileName, boolean indent)
             throws IOException
     {
         writeToFile(value, new File(fileName), indent);
     }
 
-    public final void writeToFile(T value, String fileName)
+    public final void writeToFile(@Nullable T value, @Nonnull String fileName)
         throws IOException
     {
         writeToFile(value, fileName, true);
     }
 
-    public final void writeDateIso(java.util.Date date, JsonGenerator g)
+    public final void writeDateIso(@Nonnull java.util.Date date, @Nonnull JsonGenerator g)
             throws IOException
     {
         g.writeString(formatDate(date));
@@ -127,7 +130,7 @@ public abstract class JsonWriter<T>
     static private final String weekdays[] = {null, "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
     static private final String months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", null};
 
-    public final void writeDate(java.util.Date date, JsonGenerator g)
+    public final void writeDate(@Nonnull java.util.Date date, @Nonnull JsonGenerator g)
         throws IOException
     {
         GregorianCalendar c = new GregorianCalendar(JsonDateReader.UTC);
@@ -150,7 +153,7 @@ public abstract class JsonWriter<T>
         g.writeString(buf.toString());
     }
 
-    private static String zeroPad(String v, int desiredLength)
+    private static @Nonnull String zeroPad(@Nonnull String v, int desiredLength)
     {
         while (v.length() < desiredLength) {
             v = "0" + v;

--- a/core/src/main/java/com/dropbox/core/oauth/DbxCredential.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxCredential.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.oauth;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.DbxHost;
@@ -43,18 +44,18 @@ public class DbxCredential {
      */
     public final static long EXPIRE_MARGIN = 5 * 60 * 1000; // 5 minutes
 
-    private String accessToken;
+    private @Nonnull String accessToken;
     private @Nullable Long expiresAt;
-    private final String refreshToken;
-    private final String appKey;
-    private final String appSecret;
+    private final @Nullable String refreshToken;
+    private final @Nullable String appKey;
+    private final @Nullable String appSecret;
 
     /**
      * Create a DbxCredential object that doesn't support refreshing.
      *
      * @param accessToken Short live token or legacty long live token.
      */
-    public DbxCredential(String accessToken) {
+    public DbxCredential(@Nonnull String accessToken) {
         this(accessToken, null, null, null, null);
     }
 
@@ -67,8 +68,10 @@ public class DbxCredential {
      * @param refreshToken Refresh token from OAuth flow.
      * @param appKey You app's client id.
      */
-    public DbxCredential(String accessToken, Long expiresAt, String refreshToken, String
-        appKey) {
+    public DbxCredential(@Nonnull String accessToken,
+                         @Nullable Long expiresAt,
+                         @Nullable String refreshToken,
+                         @Nullable String appKey) {
         this(accessToken, expiresAt, refreshToken, appKey, null);
     }
 
@@ -81,7 +84,11 @@ public class DbxCredential {
      * @param appKey You app's client id.
      * @param appSecret You app's client secret.
      */
-    public DbxCredential(String accessToken, Long expiresAt, String refreshToken, String appKey, String appSecret) {
+    public DbxCredential(@Nonnull String accessToken,
+                         @Nullable Long expiresAt,
+                         @Nullable String refreshToken,
+                         @Nullable String appKey,
+                         @Nullable String appSecret) {
         if (accessToken == null) {
             throw new IllegalArgumentException("Missing access token.");
         }
@@ -106,7 +113,7 @@ public class DbxCredential {
      *
      * @return OAuth access token
      */
-    public String getAccessToken() {
+    public @Nonnull String getAccessToken() {
         return this.accessToken;
     }
 
@@ -116,15 +123,15 @@ public class DbxCredential {
      *
      * @return ExpiresAt in millisecond.
      */
-    public Long getExpiresAt() {
+    public @Nullable Long getExpiresAt() {
         return this.expiresAt;
     }
 
-    public String getAppKey() {
+    public @Nullable String getAppKey() {
         return this.appKey;
     }
 
-    public String getAppSecret() {
+    public @Nullable String getAppSecret() {
         return this.appSecret;
     }
 
@@ -134,7 +141,7 @@ public class DbxCredential {
      *
      * @return Refresh Token.
      */
-    public String getRefreshToken() {
+    public @Nullable String getRefreshToken() {
         return this.refreshToken;
     }
 
@@ -161,8 +168,9 @@ public class DbxCredential {
      * refresh token is revoked.
      * @throws DbxException If refresh failed for general errors.
      */
-    public DbxRefreshResult refresh(DbxRequestConfig requestConfig, DbxHost host,
-                                    Collection<String> scope)
+    public @Nonnull DbxRefreshResult refresh(@Nonnull DbxRequestConfig requestConfig,
+                                    @Nonnull DbxHost host,
+                                    @Nullable Collection<String> scope)
         throws DbxException {
         if (this.refreshToken == null) {
             throw new DbxOAuthException(null, new DbxOAuthError(INVALID_REQUEST, "Cannot refresh becasue there is no refresh token"));
@@ -201,7 +209,7 @@ public class DbxCredential {
             headers,
             new DbxRequestUtil.ResponseHandler<DbxRefreshResult>() {
                 @Override
-                public DbxRefreshResult handle(HttpRequestor.Response response) throws DbxException {
+                public @Nonnull DbxRefreshResult handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                     if (response.getStatusCode() != 200) {
                         String requestId = DbxRequestUtil.getRequestId(response);
                         DbxOAuthError dbxOAuthError = DbxRequestUtil.readJsonFromResponse(
@@ -231,7 +239,7 @@ public class DbxCredential {
      * refresh token is invalid or revoked.
      * @throws DbxException If refresh failed for general errors.
      */
-    public DbxRefreshResult refresh(DbxRequestConfig requestConfig) throws DbxException {
+    public @Nonnull DbxRefreshResult refresh(@Nonnull DbxRequestConfig requestConfig) throws DbxException {
         return refresh(requestConfig, DbxHost.DEFAULT, null);
     }
 
@@ -248,7 +256,8 @@ public class DbxCredential {
      * refresh token is invalid or revoked.
      * @throws DbxException If refresh failed for general errors.
      */
-    public DbxRefreshResult refresh(DbxRequestConfig requestConfig, Collection<String> scope) throws
+    public @Nonnull DbxRefreshResult refresh(@Nonnull DbxRequestConfig requestConfig,
+                                             @Nullable Collection<String> scope) throws
         DbxException {
         return refresh(requestConfig, DbxHost.DEFAULT, scope);
     }
@@ -257,14 +266,14 @@ public class DbxCredential {
      * @return The json string containing all fields.
      */
     @Override
-    public String toString() {
+    public @Nonnull String toString() {
         return Writer.writeToString(this);
     }
 
-    public static final JsonReader<DbxCredential> Reader = new JsonReader<DbxCredential>()
+    public static final @Nonnull JsonReader<DbxCredential> Reader = new JsonReader<DbxCredential>()
     {
         @Override
-        public final DbxCredential read(JsonParser parser)
+        public final @Nonnull DbxCredential read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -313,10 +322,10 @@ public class DbxCredential {
         }
     };
 
-    public static final JsonWriter<DbxCredential> Writer = new JsonWriter<DbxCredential>()
+    public static final @Nonnull JsonWriter<DbxCredential> Writer = new JsonWriter<DbxCredential>()
     {
         @Override
-        public void write(DbxCredential credential, JsonGenerator g) throws IOException
+        public void write(@Nonnull DbxCredential credential, @Nonnull JsonGenerator g) throws IOException
         {
             g.writeStartObject();
             g.writeStringField("access_token", credential.accessToken);

--- a/core/src/main/java/com/dropbox/core/oauth/DbxCredential.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxCredential.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.oauth;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.DbxHost;
 import com.dropbox.core.DbxRequestConfig;
@@ -67,7 +67,7 @@ public class DbxCredential {
      * @param refreshToken Refresh token from OAuth flow.
      * @param appKey You app's client id.
      */
-    public DbxCredential(String accessToken, @Nullable Long expiresAt, String refreshToken, String
+    public DbxCredential(String accessToken, Long expiresAt, String refreshToken, String
         appKey) {
         this(accessToken, expiresAt, refreshToken, appKey, null);
     }
@@ -81,7 +81,7 @@ public class DbxCredential {
      * @param appKey You app's client id.
      * @param appSecret You app's client secret.
      */
-    public DbxCredential(String accessToken, @Nullable Long expiresAt, String refreshToken, String appKey, String appSecret) {
+    public DbxCredential(String accessToken, Long expiresAt, String refreshToken, String appKey, String appSecret) {
         if (accessToken == null) {
             throw new IllegalArgumentException("Missing access token.");
         }

--- a/core/src/main/java/com/dropbox/core/oauth/DbxCredential.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxCredential.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.oauth;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.DbxHost;
 import com.dropbox.core.DbxRequestConfig;
@@ -24,8 +25,6 @@ import java.util.Map;
 
 import static com.dropbox.core.oauth.DbxOAuthError.INVALID_REQUEST;
 
-/*>>> import checkers.nullness.quals.NonNull; */
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  *
@@ -45,7 +44,7 @@ public class DbxCredential {
     public final static long EXPIRE_MARGIN = 5 * 60 * 1000; // 5 minutes
 
     private String accessToken;
-    private /*@Nullable*/Long expiresAt;
+    private @Nullable Long expiresAt;
     private final String refreshToken;
     private final String appKey;
     private final String appSecret;
@@ -68,7 +67,7 @@ public class DbxCredential {
      * @param refreshToken Refresh token from OAuth flow.
      * @param appKey You app's client id.
      */
-    public DbxCredential(String accessToken, /*Nullable*/Long expiresAt, String refreshToken, String
+    public DbxCredential(String accessToken, @Nullable Long expiresAt, String refreshToken, String
         appKey) {
         this(accessToken, expiresAt, refreshToken, appKey, null);
     }
@@ -82,7 +81,7 @@ public class DbxCredential {
      * @param appKey You app's client id.
      * @param appSecret You app's client secret.
      */
-    public DbxCredential(String accessToken, /*@Nullable*/Long expiresAt, String refreshToken, String appKey, String appSecret) {
+    public DbxCredential(String accessToken, @Nullable Long expiresAt, String refreshToken, String appKey, String appSecret) {
         if (accessToken == null) {
             throw new IllegalArgumentException("Missing access token.");
         }

--- a/core/src/main/java/com/dropbox/core/oauth/DbxOAuthError.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxOAuthError.java
@@ -11,6 +11,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  *
  * This class provides deserialization for the error response returned from OAuth endpoint.
@@ -18,17 +21,17 @@ import java.util.Set;
  * @see <a href="https://tools.ietf.org/html/rfc6749#section-5.2">https://tools.ietf.org/html/rfc6749#section-5.2</a>
  */
 public class DbxOAuthError {
-    public final static String INVALID_REQUEST = "invalid_request";
-    public final static String INVALID_GRANT = "invalid_grant";
-    public final static String UNSUPPORTED_GRANT_TYPE = "unsupported_grant_type";
-    public final static String UNKNOWN = "unknown";
-    public final static Set<String> ERRORS = new HashSet<String>(Arrays.asList(INVALID_REQUEST,
+    public final static @Nonnull String INVALID_REQUEST = "invalid_request";
+    public final static @Nonnull String INVALID_GRANT = "invalid_grant";
+    public final static @Nonnull String UNSUPPORTED_GRANT_TYPE = "unsupported_grant_type";
+    public final static @Nonnull String UNKNOWN = "unknown";
+    public final static @Nonnull Set<String> ERRORS = new HashSet<String>(Arrays.asList(INVALID_REQUEST,
         INVALID_GRANT, UNSUPPORTED_GRANT_TYPE));
 
-    private final String error;
-    private final String errorDescription;
+    private final @Nonnull String error;
+    private final @Nullable String errorDescription;
 
-    public DbxOAuthError(String error, String errorDescription) {
+    public DbxOAuthError(@Nonnull String error, @Nullable String errorDescription) {
         if (ERRORS.contains(error)) {
             this.error = error;
         } else {
@@ -38,18 +41,18 @@ public class DbxOAuthError {
         this.errorDescription = errorDescription;
     }
 
-    public String getError() {
+    public @Nonnull String getError() {
         return this.error;
     }
 
-    public String getErrorDescription() {
+    public @Nullable String getErrorDescription() {
         return this.errorDescription;
     }
 
-    public static final JsonReader<DbxOAuthError> Reader = new JsonReader<DbxOAuthError>()
+    public static final @Nonnull JsonReader<DbxOAuthError> Reader = new JsonReader<DbxOAuthError>()
     {
         @Override
-        public final DbxOAuthError read(JsonParser parser)
+        public final @Nonnull DbxOAuthError read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);

--- a/core/src/main/java/com/dropbox/core/oauth/DbxOAuthException.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxOAuthException.java
@@ -2,15 +2,18 @@ package com.dropbox.core.oauth;
 
 import com.dropbox.core.DbxException;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  *
  * This exception means OAuth endpoint has thrown error.
  */
 public class DbxOAuthException extends DbxException {
     private static final long serialVersionUID = 0L;
-    private final DbxOAuthError dbxOAuthError;
+    private final @Nonnull DbxOAuthError dbxOAuthError;
 
-    public DbxOAuthException(String requestId, DbxOAuthError dbxOAuthError) {
+    public DbxOAuthException(@Nullable String requestId, @Nonnull DbxOAuthError dbxOAuthError) {
         super(requestId, dbxOAuthError.getErrorDescription());
         this.dbxOAuthError = dbxOAuthError;
     }
@@ -19,7 +22,7 @@ public class DbxOAuthException extends DbxException {
      * Get the wrapped {@link DbxOAuthError} to tell what error has been thrown.
      * @return {@link DbxOAuthError} contains what error has been thrown.
      */
-    public DbxOAuthError getDbxOAuthError() {
+    public @Nonnull DbxOAuthError getDbxOAuthError() {
         return dbxOAuthError;
     }
 }

--- a/core/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
@@ -1,6 +1,7 @@
 package com.dropbox.core.oauth;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import com.dropbox.core.DbxAuthFinish;
 import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.json.JsonReadException;
@@ -18,10 +19,10 @@ import java.io.IOException;
  * access token and expiration time.
  */
 public class DbxRefreshResult {
-    private final String accessToken;
+    private final @Nonnull String accessToken;
     private final long expiresIn; /* in seconds */
     private long issueTime; /* in milliseconds */
-    private String scope;
+    private @Nullable String scope;
 
     /**
      * @param accessToken OAuth access token.
@@ -37,7 +38,7 @@ public class DbxRefreshResult {
      * @param expiresIn Duration time of accessToken in second.
      * was passed
      */
-    public DbxRefreshResult(@Nonnull String accessToken, long expiresIn, String scope) {
+    public DbxRefreshResult(@Nonnull String accessToken, long expiresIn, @Nullable String scope) {
         if (accessToken == null) {
             throw new IllegalArgumentException("access token can't be null.");
         }
@@ -53,7 +54,7 @@ public class DbxRefreshResult {
      *
      * @return OAuth access token used for authorization with Dropbox servers
      */
-    public String getAccessToken() {
+    public @Nonnull String getAccessToken() {
         return accessToken;
     }
 
@@ -63,7 +64,7 @@ public class DbxRefreshResult {
      *
      * @return OAuth access token used for authorization with Dropbox servers
      */
-    public Long getExpiresAt() {
+    public @Nonnull Long getExpiresAt() {
         return issueTime + expiresIn * 1000;
     }
 
@@ -71,7 +72,7 @@ public class DbxRefreshResult {
      * @return If you specified a subset of original scope in refresh call, this value shows what
      * permissions the new short lived token has.
      */
-    public String getScope() {
+    public @Nullable String getScope() {
         return scope;
     }
 
@@ -85,8 +86,8 @@ public class DbxRefreshResult {
     /**
      * For JSON parsing.
      */
-    public static final JsonReader<DbxRefreshResult> Reader = new JsonReader<DbxRefreshResult>() {
-        public DbxRefreshResult read(JsonParser parser) throws IOException, JsonReadException {
+    public static final @Nonnull JsonReader<DbxRefreshResult> Reader = new JsonReader<DbxRefreshResult>() {
+        public @Nonnull DbxRefreshResult read(@Nonnull JsonParser parser) throws IOException, JsonReadException {
             JsonLocation top = JsonReader.expectObjectStart(parser);
 
             String tokenType = null;

--- a/core/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.oauth;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import javax.annotation.Nonnull;
 import com.dropbox.core.DbxAuthFinish;
 import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.json.JsonReadException;
@@ -28,7 +28,7 @@ public class DbxRefreshResult {
      * @param expiresIn Duration time of accessToken in second.
      * was passed
      */
-    public DbxRefreshResult(@NonNull String accessToken, long expiresIn) {
+    public DbxRefreshResult(@Nonnull String accessToken, long expiresIn) {
         this(accessToken, expiresIn, null);
     }
 
@@ -37,7 +37,7 @@ public class DbxRefreshResult {
      * @param expiresIn Duration time of accessToken in second.
      * was passed
      */
-    public DbxRefreshResult(@NonNull String accessToken, long expiresIn, String scope) {
+    public DbxRefreshResult(@Nonnull String accessToken, long expiresIn, String scope) {
         if (accessToken == null) {
             throw new IllegalArgumentException("access token can't be null.");
         }

--- a/core/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
+++ b/core/src/main/java/com/dropbox/core/oauth/DbxRefreshResult.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.oauth;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import com.dropbox.core.DbxAuthFinish;
 import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.json.JsonReadException;
@@ -10,7 +11,6 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import java.io.IOException;
 
-/*>>> import checkers.nullness.quals.NonNull; */
 
 /**
 
@@ -28,7 +28,7 @@ public class DbxRefreshResult {
      * @param expiresIn Duration time of accessToken in second.
      * was passed
      */
-    public DbxRefreshResult(/*@NotNull*/String accessToken, long expiresIn) {
+    public DbxRefreshResult(@NonNull String accessToken, long expiresIn) {
         this(accessToken, expiresIn, null);
     }
 
@@ -37,7 +37,7 @@ public class DbxRefreshResult {
      * @param expiresIn Duration time of accessToken in second.
      * was passed
      */
-    public DbxRefreshResult(/*@NotNull*/String accessToken, long expiresIn, String scope) {
+    public DbxRefreshResult(@NonNull String accessToken, long expiresIn, String scope) {
         if (accessToken == null) {
             throw new IllegalArgumentException("access token can't be null.");
         }

--- a/core/src/main/java/com/dropbox/core/stone/CompositeSerializer.java
+++ b/core/src/main/java/com/dropbox/core/stone/CompositeSerializer.java
@@ -8,14 +8,17 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
-public abstract class CompositeSerializer<T> extends StoneSerializer<T> {
-    protected static final String TAG_FIELD = ".tag";
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-    protected static boolean hasTag(JsonParser p) throws IOException, JsonParseException {
+public abstract class CompositeSerializer<T> extends StoneSerializer<T> {
+    protected static final @Nonnull String TAG_FIELD = ".tag";
+
+    protected static boolean hasTag(@Nonnull JsonParser p) throws IOException, JsonParseException {
         return p.getCurrentToken() == JsonToken.FIELD_NAME && TAG_FIELD.equals(p.getCurrentName());
     }
 
-    protected static String readTag(JsonParser p) throws IOException, JsonParseException {
+    protected static @Nullable String readTag(@Nonnull JsonParser p) throws IOException, JsonParseException {
         if (!hasTag(p)) {
             return null;
         }
@@ -26,10 +29,9 @@ public abstract class CompositeSerializer<T> extends StoneSerializer<T> {
         return tag;
     }
 
-    protected void writeTag(String tag, JsonGenerator g) throws IOException, JsonGenerationException {
+    protected void writeTag(@Nullable String tag, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
         if (tag != null) {
             g.writeStringField(TAG_FIELD, tag);
         }
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/stone/StoneDeserializerLogger.java
+++ b/core/src/main/java/com/dropbox/core/stone/StoneDeserializerLogger.java
@@ -3,24 +3,30 @@ package com.dropbox.core.stone;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class StoneDeserializerLogger {
-    public static Map<Class<?>, LoggerCallback> LOGGER_MAP =
+    public static @Nonnull Map<Class<?>, LoggerCallback> LOGGER_MAP =
             new HashMap<Class<?>, LoggerCallback>();
 
-    public static <T> void registerCallback(Class<T> c, LoggerCallback callback) {
+    public static <T> void registerCallback(@Nonnull Class<T> c, @Nonnull LoggerCallback callback) {
         LOGGER_MAP.put(c, callback);
     }
 
-    public static void log(Object value, String multiLineLog) {
+    public static void log(@Nonnull Object value, @Nonnull String multiLineLog) {
         Class<?> c = value.getClass();
 
         if (LOGGER_MAP.containsKey(c)) {
-            LoggerCallback callback = LOGGER_MAP.get(c);
+            @Nullable LoggerCallback callback = LOGGER_MAP.get(c);
+            if (callback == null) {
+                return;
+            }
             callback.invoke(value, multiLineLog);
         }
     }
 
     public interface LoggerCallback {
-        public void invoke(Object value, String multiLineLog);
+        public void invoke(@Nonnull Object value, @Nonnull String multiLineLog);
     }
 }

--- a/core/src/main/java/com/dropbox/core/stone/StoneSerializer.java
+++ b/core/src/main/java/com/dropbox/core/stone/StoneSerializer.java
@@ -12,14 +12,17 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
-public abstract class StoneSerializer<T> {
-    private static final Charset UTF8 = Charset.forName("UTF-8");
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-    public String serialize(T value) {
+public abstract class StoneSerializer<T> {
+    private static final @Nonnull Charset UTF8 = Charset.forName("UTF-8");
+
+    public @Nonnull String serialize(@Nullable T value) {
         return serialize(value, false);
     }
 
-    public String serialize(T value, boolean pretty) {
+    public @Nonnull String serialize(@Nullable T value, boolean pretty) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
             serialize(value, out, pretty);
@@ -31,11 +34,11 @@ public abstract class StoneSerializer<T> {
         return new String(out.toByteArray(), UTF8);
     }
 
-    public void serialize(T value, OutputStream out) throws IOException {
+    public void serialize(@Nullable T value, @Nonnull OutputStream out) throws IOException {
         serialize(value, out, false);
     }
 
-    public void serialize(T value, OutputStream out, boolean pretty) throws IOException {
+    public void serialize(@Nullable T value, @Nonnull OutputStream out, boolean pretty) throws IOException {
         JsonGenerator g = Util.JSON.createGenerator(out);
         if (pretty) {
             g.useDefaultPrettyPrinter();
@@ -48,7 +51,7 @@ public abstract class StoneSerializer<T> {
         g.flush();
     }
 
-    public T deserialize(String json) throws JsonParseException {
+    public @Nullable T deserialize(@Nonnull String json) throws JsonParseException {
         try {
             JsonParser p = Util.JSON.createParser(json);
             p.nextToken();
@@ -60,23 +63,23 @@ public abstract class StoneSerializer<T> {
         }
     }
 
-    public T deserialize(InputStream json) throws IOException, JsonParseException {
+    public @Nullable T deserialize(@Nonnull InputStream json) throws IOException, JsonParseException {
         JsonParser p = Util.JSON.createParser(json);
         p.nextToken();
         return deserialize(p);
     }
 
-    public abstract void serialize(T value, JsonGenerator g) throws IOException, JsonGenerationException;
-    public abstract T deserialize(JsonParser p) throws IOException, JsonParseException;
+    public abstract void serialize(@Nullable T value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException;
+    public abstract @Nullable T deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException;
 
-    protected static String getStringValue(JsonParser p) throws IOException, JsonParseException {
+    protected static @Nonnull String getStringValue(@Nonnull JsonParser p) throws IOException, JsonParseException {
         if (p.getCurrentToken() != JsonToken.VALUE_STRING) {
             throw new JsonParseException(p, "expected string value, but was " + p.getCurrentToken());
         }
         return p.getText();
     }
 
-    protected static void expectField(String name, JsonParser p) throws IOException, JsonParseException {
+    protected static void expectField(@Nonnull String name, @Nonnull JsonParser p) throws IOException, JsonParseException {
         if (p.getCurrentToken() != JsonToken.FIELD_NAME) {
             throw new JsonParseException(p, "expected field name, but was: " + p.getCurrentToken());
         }
@@ -86,35 +89,35 @@ public abstract class StoneSerializer<T> {
         p.nextToken();
     }
 
-    protected static void expectStartObject(JsonParser p) throws IOException, JsonParseException {
+    protected static void expectStartObject(@Nonnull JsonParser p) throws IOException, JsonParseException {
         if (p.getCurrentToken() != JsonToken.START_OBJECT) {
             throw new JsonParseException(p, "expected object value.");
         }
         p.nextToken();
     }
 
-    protected static void expectEndObject(JsonParser p) throws IOException, JsonParseException {
+    protected static void expectEndObject(@Nonnull JsonParser p) throws IOException, JsonParseException {
         if (p.getCurrentToken() != JsonToken.END_OBJECT) {
             throw new JsonParseException(p, "expected end of object value.");
         }
         p.nextToken();
     }
 
-    protected static void expectStartArray(JsonParser p) throws IOException, JsonParseException {
+    protected static void expectStartArray(@Nonnull JsonParser p) throws IOException, JsonParseException {
         if (p.getCurrentToken() != JsonToken.START_ARRAY) {
             throw new JsonParseException(p, "expected array value.");
         }
         p.nextToken();
     }
 
-    protected static void expectEndArray(JsonParser p) throws IOException, JsonParseException {
+    protected static void expectEndArray(@Nonnull JsonParser p) throws IOException, JsonParseException {
         if (p.getCurrentToken() != JsonToken.END_ARRAY) {
             throw new JsonParseException(p, "expected end of array value.");
         }
         p.nextToken();
     }
 
-    protected static void skipValue(JsonParser p) throws IOException, JsonParseException {
+    protected static void skipValue(@Nonnull JsonParser p) throws IOException, JsonParseException {
         if (p.getCurrentToken().isStructStart()) {
             p.skipChildren(); // will leave parser at end token (e.g. '}' or ']')
             p.nextToken();
@@ -125,7 +128,7 @@ public abstract class StoneSerializer<T> {
         }
     }
 
-    protected static void skipFields(JsonParser p) throws IOException, JsonParseException {
+    protected static void skipFields(@Nonnull JsonParser p) throws IOException, JsonParseException {
         while (p.getCurrentToken() != null && !p.getCurrentToken().isStructEnd()) {
             if (p.getCurrentToken().isStructStart()) {
                 p.skipChildren();

--- a/core/src/main/java/com/dropbox/core/stone/StoneSerializers.java
+++ b/core/src/main/java/com/dropbox/core/stone/StoneSerializers.java
@@ -14,78 +14,81 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public final class StoneSerializers {
 
-    public static StoneSerializer<Long> uInt64() {
+    public static @Nonnull StoneSerializer<Long> uInt64() {
         return LongSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Long> int64() {
+    public static @Nonnull StoneSerializer<Long> int64() {
         return LongSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Long> uInt32() {
+    public static @Nonnull StoneSerializer<Long> uInt32() {
         return LongSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Integer> int32() {
+    public static @Nonnull StoneSerializer<Integer> int32() {
         return IntSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Double> float64() {
+    public static @Nonnull StoneSerializer<Double> float64() {
         return DoubleSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Float> float32() {
+    public static @Nonnull StoneSerializer<Float> float32() {
         return FloatSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Boolean> boolean_() {
+    public static @Nonnull StoneSerializer<Boolean> boolean_() {
         return BooleanSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<byte []> bytes() {
+    public static @Nonnull StoneSerializer<byte []> bytes() {
         return ByteArraySerializer.INSTANCE;
     }
 
-    public static StoneSerializer<String> string() {
+    public static @Nonnull StoneSerializer<String> string() {
         return StringSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Date> timestamp() {
+    public static @Nonnull StoneSerializer<Date> timestamp() {
         return DateSerializer.INSTANCE;
     }
 
-    public static StoneSerializer<Void> void_() {
+    public static @Nonnull StoneSerializer<Void> void_() {
         return VoidSerializer.INSTANCE;
     }
 
-    public static <T> StoneSerializer<T> nullable(StoneSerializer<T> underlying) {
+    public static <T> @Nonnull StoneSerializer<T> nullable(@Nonnull StoneSerializer<T> underlying) {
         return new NullableSerializer<T>(underlying);
     }
 
-    public static <T> StructSerializer<T> nullableStruct(StructSerializer<T> underlying) {
+    public static <T> @Nonnull StructSerializer<T> nullableStruct(@Nonnull StructSerializer<T> underlying) {
         return new NullableStructSerializer<T>(underlying);
     }
 
-    public static <T> StoneSerializer<List<T>> list(StoneSerializer<T> underlying) {
+    public static <T> @Nonnull StoneSerializer<List<T>> list(@Nonnull StoneSerializer<T> underlying) {
         return new ListSerializer<T>(underlying);
     }
 
-    public static <T> StoneSerializer<Map<String, T>> map(StoneSerializer<T> underlying) {
+    public static <T> @Nonnull StoneSerializer<Map<String, T>> map(@Nonnull StoneSerializer<T> underlying) {
         return new MapSerializer<T>(underlying);
     }
 
     private static final class LongSerializer extends StoneSerializer<Long> {
-        public static final LongSerializer INSTANCE = new LongSerializer();
+        public static final @Nonnull LongSerializer INSTANCE = new LongSerializer();
 
         @Override
-        public void serialize(Long value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Long value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeNumber(value);
         }
 
         @Override
-        public Long deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull Long deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             Long value = p.getLongValue();
             p.nextToken();
             return value;
@@ -93,15 +96,15 @@ public final class StoneSerializers {
     }
 
     private static final class IntSerializer extends StoneSerializer<Integer> {
-        public static final IntSerializer INSTANCE = new IntSerializer();
+        public static final @Nonnull IntSerializer INSTANCE = new IntSerializer();
 
         @Override
-        public void serialize(Integer value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Integer value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeNumber(value);
         }
 
         @Override
-        public Integer deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull Integer deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             Integer value = p.getIntValue();
             p.nextToken();
             return value;
@@ -109,15 +112,15 @@ public final class StoneSerializers {
     }
 
     private static final class DoubleSerializer extends StoneSerializer<Double> {
-        public static final DoubleSerializer INSTANCE = new DoubleSerializer();
+        public static final @Nonnull DoubleSerializer INSTANCE = new DoubleSerializer();
 
         @Override
-        public void serialize(Double value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Double value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeNumber(value);
         }
 
         @Override
-        public Double deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull Double deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             Double value = p.getDoubleValue();
             p.nextToken();
             return value;
@@ -125,15 +128,15 @@ public final class StoneSerializers {
     }
 
     private static final class FloatSerializer extends StoneSerializer<Float> {
-        public static final FloatSerializer INSTANCE = new FloatSerializer();
+        public static final @Nonnull FloatSerializer INSTANCE = new FloatSerializer();
 
         @Override
-        public void serialize(Float value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Float value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeNumber(value);
         }
 
         @Override
-        public Float deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull Float deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             Float value = p.getFloatValue();
             p.nextToken();
             return value;
@@ -141,15 +144,15 @@ public final class StoneSerializers {
     }
 
     private static final class BooleanSerializer extends StoneSerializer<Boolean> {
-        public static final BooleanSerializer INSTANCE = new BooleanSerializer();
+        public static final @Nonnull BooleanSerializer INSTANCE = new BooleanSerializer();
 
         @Override
-        public void serialize(Boolean value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Boolean value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeBoolean(value);
         }
 
         @Override
-        public Boolean deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull Boolean deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             Boolean value = p.getBooleanValue();
             p.nextToken();
             return value;
@@ -157,15 +160,15 @@ public final class StoneSerializers {
     }
 
     private static final class ByteArraySerializer extends StoneSerializer<byte []> {
-        public static final ByteArraySerializer INSTANCE = new ByteArraySerializer();
+        public static final @Nonnull ByteArraySerializer INSTANCE = new ByteArraySerializer();
 
         @Override
-        public void serialize(byte [] value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable byte [] value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeBinary(value);
         }
 
         @Override
-        public byte [] deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull byte [] deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             byte [] value = p.getBinaryValue();
             p.nextToken();
             return value;
@@ -173,15 +176,15 @@ public final class StoneSerializers {
     }
 
     private static final class StringSerializer extends StoneSerializer<String> {
-        public static final StringSerializer INSTANCE = new StringSerializer();
+        public static final @Nonnull StringSerializer INSTANCE = new StringSerializer();
 
         @Override
-        public void serialize(String value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable String value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeString(value);
         }
 
         @Override
-        public String deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull String deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             String value = getStringValue(p);
             p.nextToken();
             return value;
@@ -189,15 +192,15 @@ public final class StoneSerializers {
     }
 
     private static final class DateSerializer extends StoneSerializer<Date> {
-        public static final DateSerializer INSTANCE = new DateSerializer();
+        public static final @Nonnull DateSerializer INSTANCE = new DateSerializer();
 
         @Override
-        public void serialize(Date value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Date value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeString(Util.formatTimestamp(value));
         }
 
         @Override
-        public Date deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull Date deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             String text = getStringValue(p);
             p.nextToken();
             try {
@@ -209,29 +212,29 @@ public final class StoneSerializers {
     }
 
     private static final class VoidSerializer extends StoneSerializer<Void> {
-        public static final VoidSerializer INSTANCE = new VoidSerializer();
+        public static final @Nonnull VoidSerializer INSTANCE = new VoidSerializer();
 
         @Override
-        public void serialize(Void value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Void value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeNull();
         }
 
         @Override
-        public Void deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nullable Void deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             skipValue(p);
             return null;
         }
     }
 
     private static final class NullableSerializer<T> extends StoneSerializer<T> {
-        private final StoneSerializer<T> underlying;
+        private final @Nonnull StoneSerializer<T> underlying;
 
-        public NullableSerializer(StoneSerializer<T> underlying) {
+        public NullableSerializer(@Nonnull StoneSerializer<T> underlying) {
             this.underlying = underlying;
         }
 
         @Override
-        public void serialize(T value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable T value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             if (value == null) {
                 g.writeNull();
             } else {
@@ -240,7 +243,7 @@ public final class StoneSerializers {
         }
 
         @Override
-        public T deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nullable T deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             if (p.getCurrentToken() == JsonToken.VALUE_NULL) {
                 p.nextToken();
                 return null;
@@ -251,14 +254,14 @@ public final class StoneSerializers {
     }
 
     private static final class NullableStructSerializer<T> extends StructSerializer<T> {
-        private final StructSerializer<T> underlying;
+        private final @Nonnull StructSerializer<T> underlying;
 
-        public NullableStructSerializer(StructSerializer<T> underlying) {
+        public NullableStructSerializer(@Nonnull StructSerializer<T> underlying) {
             this.underlying = underlying;
         }
 
         @Override
-        public void serialize(T value, JsonGenerator g) throws IOException {
+        public void serialize(@Nullable T value, @Nonnull JsonGenerator g) throws IOException {
             if (value == null) {
                 g.writeNull();
             } else {
@@ -267,7 +270,7 @@ public final class StoneSerializers {
         }
 
         @Override
-        public void serialize(T value, JsonGenerator g, boolean collapsed) throws IOException {
+        public void serialize(@Nullable T value, @Nonnull JsonGenerator g, boolean collapsed) throws IOException {
             if (value == null) {
                 g.writeNull();
             } else {
@@ -276,7 +279,7 @@ public final class StoneSerializers {
         }
 
         @Override
-        public T deserialize(JsonParser p) throws IOException {
+        public @Nullable T deserialize(@Nonnull JsonParser p) throws IOException {
             if (p.getCurrentToken() == JsonToken.VALUE_NULL) {
                 p.nextToken();
                 return null;
@@ -286,7 +289,7 @@ public final class StoneSerializers {
         }
 
         @Override
-        public T deserialize(JsonParser p, boolean collapsed) throws IOException {
+        public @Nullable T deserialize(@Nonnull JsonParser p, boolean collapsed) throws IOException {
             if (p.getCurrentToken() == JsonToken.VALUE_NULL) {
                 p.nextToken();
                 return null;
@@ -297,14 +300,14 @@ public final class StoneSerializers {
     }
 
     private static final class ListSerializer<T> extends StoneSerializer<List<T>> {
-        private final StoneSerializer<T> underlying;
+        private final @Nonnull StoneSerializer<T> underlying;
 
-        public ListSerializer(StoneSerializer<T> underlying) {
+        public ListSerializer(@Nonnull StoneSerializer<T> underlying) {
             this.underlying = underlying;
         }
 
         @Override
-        public void serialize(List<T> value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable List<T> value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeStartArray(value.size());
             for (T elem : value) {
                 underlying.serialize(elem, g);
@@ -313,7 +316,7 @@ public final class StoneSerializers {
         }
 
         @Override
-        public List<T> deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull List<T> deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             expectStartArray(p);
             List<T> list = new ArrayList<T>();
             while (p.getCurrentToken() != JsonToken.END_ARRAY) {
@@ -326,14 +329,14 @@ public final class StoneSerializers {
     }
 
     private static final class MapSerializer<T> extends StoneSerializer<Map<String, T>> {
-        private final StoneSerializer<T> underlying;
+        private final @Nonnull StoneSerializer<T> underlying;
 
-        public MapSerializer(StoneSerializer<T> underlying) {
+        public MapSerializer(@Nonnull StoneSerializer<T> underlying) {
             this.underlying = underlying;
         }
 
         @Override
-        public void serialize(Map<String, T> value, JsonGenerator g) throws IOException, JsonGenerationException {
+        public void serialize(@Nullable Map<String, T> value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
             g.writeStartObject();
             for (Map.Entry<String, T> e : value.entrySet()) {
                 g.writeFieldName(e.getKey());
@@ -343,7 +346,7 @@ public final class StoneSerializers {
         }
 
         @Override
-        public Map<String, T> deserialize(JsonParser p) throws IOException, JsonParseException {
+        public @Nonnull Map<String, T> deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
             Map<String, T> map = new HashMap<String, T>();
 
             expectStartObject(p);

--- a/core/src/main/java/com/dropbox/core/stone/StructSerializer.java
+++ b/core/src/main/java/com/dropbox/core/stone/StructSerializer.java
@@ -7,19 +7,22 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public abstract class StructSerializer<T> extends CompositeSerializer<T> {
 
     @Override
-    public void serialize(T value, JsonGenerator g) throws IOException, JsonGenerationException {
+    public void serialize(@Nullable T value, @Nonnull JsonGenerator g) throws IOException, JsonGenerationException {
         serialize(value, g, false);
     }
 
-    public abstract void serialize(T value, JsonGenerator g, boolean collapse) throws IOException, JsonGenerationException;
+    public abstract void serialize(@Nullable T value, @Nonnull JsonGenerator g, boolean collapse) throws IOException, JsonGenerationException;
 
     @Override
-    public T deserialize(JsonParser p) throws IOException, JsonParseException {
+    public @Nullable T deserialize(@Nonnull JsonParser p) throws IOException, JsonParseException {
         return deserialize(p, false);
     }
 
-    public abstract T deserialize(JsonParser p, boolean collapsed) throws IOException, JsonParseException;
+    public abstract @Nullable T deserialize(@Nonnull JsonParser p, boolean collapsed) throws IOException, JsonParseException;
 }

--- a/core/src/main/java/com/dropbox/core/stone/Util.java
+++ b/core/src/main/java/com/dropbox/core/stone/Util.java
@@ -10,22 +10,24 @@ import java.util.TimeZone;
 
 import com.fasterxml.jackson.core.JsonFactory;
 
-final class Util {
-    public static final JsonFactory JSON = new JsonFactory();
+import javax.annotation.Nonnull;
 
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
-    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-    private static final String DATE_FORMAT = "yyyy-MM-dd";
+final class Util {
+    public static final @Nonnull JsonFactory JSON = new JsonFactory();
+
+    private static final @Nonnull TimeZone UTC = TimeZone.getTimeZone("UTC");
+    private static final @Nonnull String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    private static final @Nonnull String DATE_FORMAT = "yyyy-MM-dd";
     private static final int LONG_FORMAT_LENGTH = DATE_TIME_FORMAT.replace("'", "").length();
     private static final int SHORT_FORMAT_LENGTH = DATE_FORMAT.replace("'", "").length();
 
-    public static String formatTimestamp(Date timestamp) {
+    public static @Nonnull String formatTimestamp(@Nonnull Date timestamp) {
         DateFormat format = new SimpleDateFormat(DATE_TIME_FORMAT, Locale.ENGLISH);
         format.setCalendar(new GregorianCalendar(UTC));
         return format.format(timestamp);
     }
 
-    public static Date parseTimestamp(String timestamp) throws ParseException {
+    public static @Nonnull Date parseTimestamp(@Nonnull String timestamp) throws ParseException {
         int length = timestamp.length();
 
         DateFormat format = null;

--- a/core/src/main/java/com/dropbox/core/util/Collector.java
+++ b/core/src/main/java/com/dropbox/core/util/Collector.java
@@ -1,25 +1,26 @@
 package com.dropbox.core.util;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 
 
 public abstract class Collector<E,L>
 {
-    public abstract void add(E element);
-    public abstract L finish();
+    public abstract void add(@Nullable E element);
+    public abstract @Nonnull L finish();
 
     public static final class ArrayListCollector<E> extends Collector<E,ArrayList<E>>
     {
         private @Nullable ArrayList<E> list = new ArrayList<E>();
 
-        public void add(E element)
+        public void add(@Nullable E element)
         {
             if (list == null) throw new IllegalStateException("already called finish()");
             this.list.add(element);
         }
 
-        public ArrayList<E> finish()
+        public @Nonnull ArrayList<E> finish()
         {
             ArrayList<E> list = this.list;
             if (list == null) throw new IllegalStateException("already called finish()");
@@ -30,14 +31,14 @@ public abstract class Collector<E,L>
 
     public static final class NullSkipper<E,L> extends Collector<E,L>
     {
-        private final Collector<E,L> underlying;
+        private final @Nonnull Collector<E,L> underlying;
 
-        public NullSkipper(Collector<E,L> underlying)
+        public NullSkipper(@Nonnull Collector<E,L> underlying)
         {
             this.underlying = underlying;
         }
 
-        public static <E,L> Collector<E,L> mk(Collector<E,L> underlying)
+        public static <E,L> @Nonnull Collector<E,L> mk(@Nonnull Collector<E,L> underlying)
         {
             return new NullSkipper<E,L>(underlying);
         }
@@ -49,7 +50,7 @@ public abstract class Collector<E,L>
             }
         }
 
-        public L finish()
+        public @Nonnull L finish()
         {
             return underlying.finish();
         }

--- a/core/src/main/java/com/dropbox/core/util/Collector.java
+++ b/core/src/main/java/com/dropbox/core/util/Collector.java
@@ -1,8 +1,8 @@
 package com.dropbox.core.util;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.ArrayList;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 public abstract class Collector<E,L>
 {
@@ -11,7 +11,7 @@ public abstract class Collector<E,L>
 
     public static final class ArrayListCollector<E> extends Collector<E,ArrayList<E>>
     {
-        private /*@Nullable*/ArrayList<E> list = new ArrayList<E>();
+        private @Nullable ArrayList<E> list = new ArrayList<E>();
 
         public void add(E element)
         {
@@ -28,7 +28,7 @@ public abstract class Collector<E,L>
         }
     }
 
-    public static final class NullSkipper<E,L> extends Collector</*@Nullable*/E,L>
+    public static final class NullSkipper<E,L> extends Collector<@Nullable E,L>
     {
         private final Collector<E,L> underlying;
 
@@ -37,12 +37,12 @@ public abstract class Collector<E,L>
             this.underlying = underlying;
         }
 
-        public static <E,L> Collector</*@Nullable*/E,L> mk(Collector<E,L> underlying)
+        public static <E,L> Collector<@Nullable E,L> mk(Collector<E,L> underlying)
         {
             return new NullSkipper<E,L>(underlying);
         }
 
-        public void add(/*@Nullable*/E element)
+        public void add(@Nullable E element)
         {
             if (element != null) {
                 underlying.add(element);

--- a/core/src/main/java/com/dropbox/core/util/Collector.java
+++ b/core/src/main/java/com/dropbox/core/util/Collector.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.util;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 
 
@@ -28,7 +28,7 @@ public abstract class Collector<E,L>
         }
     }
 
-    public static final class NullSkipper<E,L> extends Collector<@Nullable E,L>
+    public static final class NullSkipper<E,L> extends Collector<E,L>
     {
         private final Collector<E,L> underlying;
 
@@ -37,7 +37,7 @@ public abstract class Collector<E,L>
             this.underlying = underlying;
         }
 
-        public static <E,L> Collector<@Nullable E,L> mk(Collector<E,L> underlying)
+        public static <E,L> Collector<E,L> mk(Collector<E,L> underlying)
         {
             return new NullSkipper<E,L>(underlying);
         }

--- a/core/src/main/java/com/dropbox/core/util/CountingOutputStream.java
+++ b/core/src/main/java/com/dropbox/core/util/CountingOutputStream.java
@@ -3,12 +3,14 @@ package com.dropbox.core.util;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+
 public class CountingOutputStream extends OutputStream
 {
-    private final OutputStream out;
+    private final @Nonnull OutputStream out;
     private long bytesWritten = 0;
 
-    public CountingOutputStream(OutputStream out)
+    public CountingOutputStream(@Nonnull OutputStream out)
     {
         this.out = out;
     }
@@ -26,14 +28,14 @@ public class CountingOutputStream extends OutputStream
     }
 
     @Override
-    public void write(byte[] b) throws IOException
+    public void write(@Nonnull byte[] b) throws IOException
     {
         bytesWritten += b.length;
         out.write(b);
     }
 
     @Override
-    public void write(byte[] b, int off, int len) throws IOException
+    public void write(@Nonnull byte[] b, int off, int len) throws IOException
     {
         bytesWritten += len;
         out.write(b, off, len);

--- a/core/src/main/java/com/dropbox/core/util/DumpWriter.java
+++ b/core/src/main/java/com/dropbox/core/util/DumpWriter.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.util;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonDateReader;
 
@@ -10,12 +11,12 @@ import java.util.GregorianCalendar;
 
 public abstract class DumpWriter
 {
-    public abstract DumpWriter recordStart(@Nullable String name);
-    public abstract DumpWriter recordEnd();
-    public abstract DumpWriter f(String name);  // Write a field name.  You should write a value after.
-    public abstract DumpWriter listStart();
-    public abstract DumpWriter listEnd();
-    public abstract DumpWriter verbatim(String s);
+    public abstract @Nonnull DumpWriter recordStart(@Nullable String name);
+    public abstract @Nonnull DumpWriter recordEnd();
+    public abstract @Nonnull DumpWriter f(@Nonnull String name);  // Write a field name.  You should write a value after.
+    public abstract @Nonnull DumpWriter listStart();
+    public abstract @Nonnull DumpWriter listEnd();
+    public abstract @Nonnull DumpWriter verbatim(@Nonnull String s);
 
     public static final class Multiline extends DumpWriter
     {
@@ -23,7 +24,7 @@ public abstract class DumpWriter
         private final int indentAmount;
         private int currentIndent;
 
-        public Multiline(StringBuilder buf, int indentAmount, int currentIndent, boolean nl)
+        public Multiline(@Nonnull StringBuilder buf, int indentAmount, int currentIndent, boolean nl)
         {
             if (buf == null) throw new IllegalArgumentException("'buf' must not be null");
             if (indentAmount < 0) throw new IllegalArgumentException("'indentAmount' must be non-negative");
@@ -34,7 +35,7 @@ public abstract class DumpWriter
             this.nl = nl;
         }
 
-        public Multiline(StringBuilder buf, int indentAmount, boolean nl)
+        public Multiline(@Nonnull StringBuilder buf, int indentAmount, boolean nl)
         {
             this(buf, indentAmount, 0, nl);
         }
@@ -63,7 +64,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter recordStart(@Nullable String name)
+        public @Nonnull DumpWriter recordStart(@Nullable String name)
         {
             prefix();
             if (name != null) {
@@ -76,7 +77,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter recordEnd()
+        public @Nonnull DumpWriter recordEnd()
         {
             if (!nl) throw new AssertionError("called recordEnd() in a bad state");
             indentLess();
@@ -87,7 +88,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter f(String name)
+        public @Nonnull DumpWriter f(@Nonnull String name)
         {
             if (!nl) throw new AssertionError("called fieldStart() in a bad state");
             prefix();
@@ -97,7 +98,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter listStart()
+        public @Nonnull DumpWriter listStart()
         {
             prefix();
             buf.append("[\n");
@@ -107,7 +108,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter listEnd()
+        public @Nonnull DumpWriter listEnd()
         {
             if (!nl) throw new AssertionError("called listEnd() in a bad state");
             indentLess();
@@ -118,7 +119,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter verbatim(String s)
+        public @Nonnull DumpWriter verbatim(@Nonnull String s)
         {
             prefix();
             buf.append(s);
@@ -132,7 +133,7 @@ public abstract class DumpWriter
     {
         private StringBuilder buf;
 
-        public Plain(StringBuilder buf)
+        public Plain(@Nonnull StringBuilder buf)
         {
             this.buf = buf;
         }
@@ -149,7 +150,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter recordStart(@Nullable String name)
+        public @Nonnull DumpWriter recordStart(@Nullable String name)
         {
             if (name != null) {
                 buf.append(name);
@@ -160,7 +161,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter recordEnd()
+        public @Nonnull DumpWriter recordEnd()
         {
             buf.append(")");
             needSep = true;
@@ -168,7 +169,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter f(String name)
+        public @Nonnull DumpWriter f(@Nonnull String name)
         {
             sep();
             buf.append(name).append('=');
@@ -177,7 +178,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter listStart()
+        public @Nonnull DumpWriter listStart()
         {
             sep();
             buf.append("[");
@@ -186,7 +187,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter listEnd()
+        public @Nonnull DumpWriter listEnd()
         {
             buf.append("]");
             needSep = true;
@@ -194,7 +195,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter verbatim(String s)
+        public @Nonnull DumpWriter verbatim(@Nonnull String s)
         {
             sep();
             buf.append(s);
@@ -202,12 +203,12 @@ public abstract class DumpWriter
         }
     }
 
-    public DumpWriter fieldVerbatim(String name, String s)
+    public @Nonnull DumpWriter fieldVerbatim(@Nonnull String name, @Nonnull String s)
     {
         return f(name).verbatim(s);
     }
 
-    public DumpWriter v(@Nullable Iterable<? extends Dumpable> list)
+    public @Nonnull DumpWriter v(@Nullable Iterable<? extends Dumpable> list)
     {
         if (list == null) {
             verbatim("null");
@@ -221,7 +222,7 @@ public abstract class DumpWriter
         return this;
     }
 
-    public DumpWriter v(@Nullable String v)
+    public @Nonnull DumpWriter v(@Nullable String v)
     {
         if (v == null) {
             verbatim("null");
@@ -231,15 +232,15 @@ public abstract class DumpWriter
         return this;
     }
 
-    public DumpWriter v(int v) { return verbatim(Integer.toString(v)); }
-    public DumpWriter v(long v) { return verbatim(Long.toString(v)); }
-    public DumpWriter v(boolean v) { return verbatim(Boolean.toString(v)); }
-    public DumpWriter v(float v) { return verbatim(Float.toString(v)); }
-    public DumpWriter v(double v) { return verbatim(Double.toString(v)); }
-    public DumpWriter v(@Nullable Date v) { return verbatim(toStringDate(v)); }
-    public DumpWriter v(@Nullable Long v) { return verbatim(v == null ? "null" : Long.toString(v)); }
+    public @Nonnull DumpWriter v(int v) { return verbatim(Integer.toString(v)); }
+    public @Nonnull DumpWriter v(long v) { return verbatim(Long.toString(v)); }
+    public @Nonnull DumpWriter v(boolean v) { return verbatim(Boolean.toString(v)); }
+    public @Nonnull DumpWriter v(float v) { return verbatim(Float.toString(v)); }
+    public @Nonnull DumpWriter v(double v) { return verbatim(Double.toString(v)); }
+    public @Nonnull DumpWriter v(@Nullable Date v) { return verbatim(toStringDate(v)); }
+    public @Nonnull DumpWriter v(@Nullable Long v) { return verbatim(v == null ? "null" : Long.toString(v)); }
 
-    public DumpWriter v(@Nullable Dumpable v)
+    public @Nonnull DumpWriter v(@Nullable Dumpable v)
     {
         if (v == null) {
             verbatim("null");
@@ -252,7 +253,7 @@ public abstract class DumpWriter
         return this;
     }
 
-    public static String toStringDate(@Nullable Date date)
+    public static @Nonnull String toStringDate(@Nullable Date date)
     {
         if (date == null) {
             return "null";

--- a/core/src/main/java/com/dropbox/core/util/DumpWriter.java
+++ b/core/src/main/java/com/dropbox/core/util/DumpWriter.java
@@ -1,16 +1,16 @@
 package com.dropbox.core.util;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.dropbox.core.json.JsonDateReader;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 public abstract class DumpWriter
 {
-    public abstract DumpWriter recordStart(/*@Nullable*/String name);
+    public abstract DumpWriter recordStart(@Nullable String name);
     public abstract DumpWriter recordEnd();
     public abstract DumpWriter f(String name);  // Write a field name.  You should write a value after.
     public abstract DumpWriter listStart();
@@ -63,7 +63,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter recordStart(/*@Nullable*/String name)
+        public DumpWriter recordStart(@Nullable String name)
         {
             prefix();
             if (name != null) {
@@ -149,7 +149,7 @@ public abstract class DumpWriter
         }
 
         @Override
-        public DumpWriter recordStart(/*@Nullable*/String name)
+        public DumpWriter recordStart(@Nullable String name)
         {
             if (name != null) {
                 buf.append(name);
@@ -207,7 +207,7 @@ public abstract class DumpWriter
         return f(name).verbatim(s);
     }
 
-    public DumpWriter v(/*@Nullable*/Iterable<? extends Dumpable> list)
+    public DumpWriter v(@Nullable Iterable<? extends Dumpable> list)
     {
         if (list == null) {
             verbatim("null");
@@ -221,7 +221,7 @@ public abstract class DumpWriter
         return this;
     }
 
-    public DumpWriter v(/*@Nullable*/String v)
+    public DumpWriter v(@Nullable String v)
     {
         if (v == null) {
             verbatim("null");
@@ -236,10 +236,10 @@ public abstract class DumpWriter
     public DumpWriter v(boolean v) { return verbatim(Boolean.toString(v)); }
     public DumpWriter v(float v) { return verbatim(Float.toString(v)); }
     public DumpWriter v(double v) { return verbatim(Double.toString(v)); }
-    public DumpWriter v(/*@Nullable*/Date v) { return verbatim(toStringDate(v)); }
-    public DumpWriter v(/*@Nullable*/Long v) { return verbatim(v == null ? "null" : Long.toString(v)); }
+    public DumpWriter v(@Nullable Date v) { return verbatim(toStringDate(v)); }
+    public DumpWriter v(@Nullable Long v) { return verbatim(v == null ? "null" : Long.toString(v)); }
 
-    public DumpWriter v(/*@Nullable*/Dumpable v)
+    public DumpWriter v(@Nullable Dumpable v)
     {
         if (v == null) {
             verbatim("null");
@@ -252,7 +252,7 @@ public abstract class DumpWriter
         return this;
     }
 
-    public static String toStringDate(/*@Nullable*/Date date)
+    public static String toStringDate(@Nullable Date date)
     {
         if (date == null) {
             return "null";

--- a/core/src/main/java/com/dropbox/core/util/DumpWriter.java
+++ b/core/src/main/java/com/dropbox/core/util/DumpWriter.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.util;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonDateReader;
 
 import java.util.Calendar;

--- a/core/src/main/java/com/dropbox/core/util/Dumpable.java
+++ b/core/src/main/java/com/dropbox/core/util/Dumpable.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.util;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 
 /**
  * A common superclass for pure-data classes.  Contains a function to dump

--- a/core/src/main/java/com/dropbox/core/util/Dumpable.java
+++ b/core/src/main/java/com/dropbox/core/util/Dumpable.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.util;
 
-/*>>> import checkers.nullness.quals.Nullable; */
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A common superclass for pure-data classes.  Contains a function to dump
@@ -57,6 +57,6 @@ public abstract class Dumpable
         new DumpWriter.Multiline(buf, 2, currentIndent, nl).v(this);
     }
 
-    protected /*@Nullable*/String getTypeName() { return null; }
+    protected @Nullable String getTypeName() { return null; }
     protected abstract void dumpFields(DumpWriter out);
 }

--- a/core/src/main/java/com/dropbox/core/util/Dumpable.java
+++ b/core/src/main/java/com/dropbox/core/util/Dumpable.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.util;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -8,14 +9,14 @@ import javax.annotation.Nullable;
  */
 public abstract class Dumpable
 {
-    public final String toString()
+    public final @Nonnull String toString()
     {
         StringBuilder buf = new StringBuilder();
         toString(buf);
         return buf.toString();
     }
 
-    public final void toString(StringBuilder buf)
+    public final void toString(@Nonnull StringBuilder buf)
     {
         new DumpWriter.Plain(buf).v(this);
     }
@@ -29,7 +30,7 @@ public abstract class Dumpable
      * may change the format.
      * </p>
      */
-    public final String toStringMultiline()
+    public final @Nonnull String toStringMultiline()
     {
         StringBuilder buf = new StringBuilder();
         toStringMultiline(buf, 0, true);
@@ -52,11 +53,11 @@ public abstract class Dumpable
      *    Whether you will start displaying this value on its own line (and will need indentation
      *    on the first line) or not.
      */
-    public final void toStringMultiline(StringBuilder buf, int currentIndent, boolean nl)
+    public final void toStringMultiline(@Nonnull StringBuilder buf, int currentIndent, boolean nl)
     {
         new DumpWriter.Multiline(buf, 2, currentIndent, nl).v(this);
     }
 
     protected @Nullable String getTypeName() { return null; }
-    protected abstract void dumpFields(DumpWriter out);
+    protected abstract void dumpFields(@Nonnull DumpWriter out);
 }

--- a/core/src/main/java/com/dropbox/core/util/IOUtil.java
+++ b/core/src/main/java/com/dropbox/core/util/IOUtil.java
@@ -16,20 +16,23 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.CharacterCodingException;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class IOUtil {
     public static final int DEFAULT_COPY_BUFFER_SIZE = 16 << 10; // 16 KiB
 
-    public static Reader utf8Reader(InputStream in) {
+    public static @Nonnull Reader utf8Reader(@Nonnull InputStream in) {
         // NOTE: Just passing StringUtil.UTF8 instead of StringUtil.UTF8.newDecoder() would be wrong.
         // The former will cause the InputStreamReader to ignore UTF-8 errors in the input.
         return new InputStreamReader(in, StringUtil.UTF8.newDecoder());
     }
 
-    public static Writer utf8Writer(OutputStream out) {
+    public static @Nonnull Writer utf8Writer(@Nonnull OutputStream out) {
         return new OutputStreamWriter(out, StringUtil.UTF8.newEncoder());
     }
 
-    public static String toUtf8String(InputStream in) throws ReadException, CharacterCodingException {
+    public static @Nonnull String toUtf8String(@Nonnull InputStream in) throws ReadException, CharacterCodingException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
             copyStreamToStream(in, out);
@@ -39,11 +42,11 @@ public class IOUtil {
         return StringUtil.utf8ToString(out.toByteArray());
     }
 
-    public static void copyStreamToStream(InputStream in, OutputStream out) throws ReadException, WriteException {
+    public static void copyStreamToStream(@Nonnull InputStream in, @Nonnull OutputStream out) throws ReadException, WriteException {
         copyStreamToStream(in, out, DEFAULT_COPY_BUFFER_SIZE);
     }
 
-    public static void copyStreamToStream(InputStream in, OutputStream out, byte[] copyBuffer)
+    public static void copyStreamToStream(@Nonnull InputStream in, @Nonnull OutputStream out, @Nonnull byte[] copyBuffer)
         throws ReadException, WriteException {
         while (true) {
             int count;
@@ -63,16 +66,16 @@ public class IOUtil {
         }
     }
 
-    public static void copyStreamToStream(InputStream in, OutputStream out, int copyBufferSize)
+    public static void copyStreamToStream(@Nonnull InputStream in, @Nonnull OutputStream out, int copyBufferSize)
         throws ReadException, WriteException {
         copyStreamToStream(in, out, new byte[copyBufferSize]);
     }
 
-    public static byte[] slurp(InputStream in, int byteLimit) throws IOException {
+    public static @Nonnull byte[] slurp(@Nonnull InputStream in, int byteLimit) throws IOException {
         return slurp(in, byteLimit, new byte[DEFAULT_COPY_BUFFER_SIZE]);
     }
 
-    public static byte[] slurp(InputStream in, int byteLimit, byte[] slurpBuffer) throws IOException {
+    public static @Nonnull byte[] slurp(@Nonnull InputStream in, int byteLimit, @Nonnull byte[] slurpBuffer) throws IOException {
         if (byteLimit < 0) throw new RuntimeException("'byteLimit' must be non-negative: " + byteLimit);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -80,11 +83,11 @@ public class IOUtil {
         return baos.toByteArray();
     }
 
-    public void copyFileToStream(File fin, OutputStream out) throws ReadException, WriteException {
+    public void copyFileToStream(@Nonnull File fin, @Nonnull OutputStream out) throws ReadException, WriteException {
         copyFileToStream(fin, out, DEFAULT_COPY_BUFFER_SIZE);
     }
 
-    public void copyFileToStream(File fin, OutputStream out, int copyBufferSize) throws ReadException, WriteException {
+    public void copyFileToStream(@Nonnull File fin, @Nonnull OutputStream out, int copyBufferSize) throws ReadException, WriteException {
         FileInputStream in;
         try {
             in = new FileInputStream(fin);
@@ -99,11 +102,11 @@ public class IOUtil {
         }
     }
 
-    public void copyStreamToFile(InputStream in, File fout) throws ReadException, WriteException {
+    public void copyStreamToFile(@Nonnull InputStream in, @Nonnull File fout) throws ReadException, WriteException {
         copyStreamToFile(in, fout, DEFAULT_COPY_BUFFER_SIZE);
     }
 
-    public void copyStreamToFile(InputStream in, File fout, int copyBufferSize) throws ReadException, WriteException {
+    public void copyStreamToFile(@Nonnull InputStream in, @Nonnull File fout, int copyBufferSize) throws ReadException, WriteException {
         FileOutputStream out;
         try {
             out = new FileOutputStream(fout);
@@ -124,7 +127,7 @@ public class IOUtil {
     /**
      * Closes the given input stream and ignores the IOException.
      */
-    public static void closeInput(InputStream in) {
+    public static void closeInput(@Nullable InputStream in) {
         try {
             if (in != null) {
                 in.close();
@@ -137,7 +140,7 @@ public class IOUtil {
     /**
      * Closes the given Reader and ignores the IOException.
      */
-    public static void closeInput(Reader in) {
+    public static void closeInput(@Nullable Reader in) {
         try {
             if (in != null) {
                 in.close();
@@ -147,7 +150,7 @@ public class IOUtil {
         }
     }
 
-    public static void closeQuietly(Closeable obj) {
+    public static void closeQuietly(@Nullable Closeable obj) {
         if (obj != null) {
             try {
                 obj.close();
@@ -157,28 +160,28 @@ public class IOUtil {
         }
     }
 
-    public static InputStream limit(InputStream in, long limit) {
+    public static @Nonnull InputStream limit(@Nonnull InputStream in, long limit) {
         return new LimitInputStream(in, limit);
     }
 
     public static abstract class WrappedException extends IOException {
         private static final long serialVersionUID = 0;
 
-        public WrappedException(String message, IOException underlying) {
+        public WrappedException(@Nullable String message, @Nonnull IOException underlying) {
             super(message + ": " + underlying.getMessage(), underlying);
         }
 
-        public WrappedException(IOException underlying) {
+        public WrappedException(@Nonnull IOException underlying) {
             super(underlying);
         }
 
         @Override
-        public IOException getCause() {
+        public @Nonnull IOException getCause() {
             return (IOException) super.getCause();
         }
 
         @Override
-        public String getMessage() {
+        public @Nonnull String getMessage() {
             String m = super.getCause().getMessage();
             if (m == null) return "";
             else return m;
@@ -188,11 +191,11 @@ public class IOUtil {
     public static final class ReadException extends WrappedException {
         private static final long serialVersionUID = 0;
 
-        public ReadException(String message, IOException underlying) {
+        public ReadException(@Nullable String message, @Nonnull IOException underlying) {
             super(message, underlying);
         }
 
-        public ReadException(IOException underlying) {
+        public ReadException(@Nonnull IOException underlying) {
             super(underlying);
         }
     }
@@ -200,25 +203,25 @@ public class IOUtil {
     public static final class WriteException extends WrappedException {
         private static final long serialVersionUID = 0;
 
-        public WriteException(String message, IOException underlying) {
+        public WriteException(@Nullable String message, @Nonnull IOException underlying) {
             super(message, underlying);
         }
 
-        public WriteException(IOException underlying) {
+        public WriteException(@Nonnull IOException underlying) {
             super(underlying);
         }
     }
 
-    public static final InputStream EmptyInputStream = new InputStream() {
+    public static final @Nonnull InputStream EmptyInputStream = new InputStream() {
         public int read() { return -1; }
-        public int read(byte[] data) { return -1; }
-        public int read(byte[] data, int off, int len) { return -1; }
+        public int read(@Nonnull byte[] data) { return -1; }
+        public int read(@Nonnull byte[] data, int off, int len) { return -1; }
     };
 
-    public static final OutputStream BlackHoleOutputStream = new OutputStream() {
+    public static final @Nonnull OutputStream BlackHoleOutputStream = new OutputStream() {
         public void write(int b) {}
-        public void write(byte[] data) {}
-        public void write(byte[] data, int off, int len) {}
+        public void write(@Nonnull byte[] data) {}
+        public void write(@Nonnull byte[] data, int off, int len) {}
     };
 
     /**
@@ -228,7 +231,7 @@ public class IOUtil {
     private static final class LimitInputStream extends FilterInputStream {
         private long left;
 
-        public LimitInputStream(InputStream in, long limit) {
+        public LimitInputStream(@Nonnull InputStream in, long limit) {
             super(in);
 
             if (in == null) {

--- a/core/src/main/java/com/dropbox/core/util/LangUtil.java
+++ b/core/src/main/java/com/dropbox/core/util/LangUtil.java
@@ -1,12 +1,11 @@
 package com.dropbox.core.util;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-/*>>> import checkers.nullness.quals.Nullable; */
-/*>>> import checkers.nullness.quals.NonNull; */
 
 public class LangUtil
 {
@@ -35,26 +34,26 @@ public class LangUtil
     {
         if (a == null) throw new IllegalArgumentException("'a' can't be null");
         if (b == null) throw new IllegalArgumentException("'b' can't be null");
-        /*@Nullable*/T[] rn = Arrays.copyOf(a, a.length + b.length);
+        @Nullable T[] rn = Arrays.copyOf(a, a.length + b.length);
         System.arraycopy(b, 0, rn, a.length, b.length);
         @SuppressWarnings("nullness") T[] r = rn;
         return r;
     }
 
-    public static <T> boolean nullableEquals(/*@Nullable*/T a, /*@Nullable*/T b)
+    public static <T> boolean nullableEquals(@Nullable T a, @Nullable T b)
     {
         if (a == null) return (b == null);
         if (b == null) return false;
         return a.equals(b);
     }
 
-    public static int nullableHashCode(/*@Nullable*/Object o)
+    public static int nullableHashCode(@Nullable Object o)
     {
         if (o == null) return 0;
         return o.hashCode() + 1;
     }
 
-    public static Date truncateMillis(/*@Nullable*/Date date) {
+    public static Date truncateMillis(@Nullable Date date) {
         if (date != null) {
             long time = date.getTime();
             return new Date(time - (time % 1000L));
@@ -63,7 +62,7 @@ public class LangUtil
         }
     }
 
-    public static List<Date> truncateMillis(/*@Nullable*/List<Date> dates) {
+    public static List<Date> truncateMillis(@Nullable List<Date> dates) {
         if (dates != null) {
             List<Date> truncated = new ArrayList<Date>(dates.size());
             for (Date date : dates) {

--- a/core/src/main/java/com/dropbox/core/util/LangUtil.java
+++ b/core/src/main/java/com/dropbox/core/util/LangUtil.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.util;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,7 +10,7 @@ import java.util.List;
 
 public class LangUtil
 {
-    public static RuntimeException mkAssert(String messagePrefix, Throwable cause)
+    public static @Nonnull RuntimeException mkAssert(@Nonnull String messagePrefix, @Nonnull Throwable cause)
     {
         RuntimeException ae = new RuntimeException(messagePrefix + ": " + cause.getMessage());
         ae.initCause(cause);
@@ -19,7 +20,7 @@ public class LangUtil
         // RuntimeException worked.
     }
 
-    public static AssertionError badType(Object a)
+    public static @Nonnull AssertionError badType(@Nullable Object a)
     {
         String msg;
         if (a == null) {
@@ -30,7 +31,7 @@ public class LangUtil
         return new AssertionError(msg);
     }
 
-    public static <T> T[] arrayConcat(T[] a, T[] b)
+    public static <T> @Nonnull T[] arrayConcat(@Nonnull T[] a, @Nonnull T[] b)
     {
         if (a == null) throw new IllegalArgumentException("'a' can't be null");
         if (b == null) throw new IllegalArgumentException("'b' can't be null");
@@ -53,7 +54,7 @@ public class LangUtil
         return o.hashCode() + 1;
     }
 
-    public static Date truncateMillis(@Nullable Date date) {
+    public static @Nullable Date truncateMillis(@Nullable Date date) {
         if (date != null) {
             long time = date.getTime();
             return new Date(time - (time % 1000L));
@@ -62,7 +63,7 @@ public class LangUtil
         }
     }
 
-    public static List<Date> truncateMillis(@Nullable List<Date> dates) {
+    public static @Nullable List<Date> truncateMillis(@Nullable List<Date> dates) {
         if (dates != null) {
             List<Date> truncated = new ArrayList<Date>(dates.size());
             for (Date date : dates) {

--- a/core/src/main/java/com/dropbox/core/util/LangUtil.java
+++ b/core/src/main/java/com/dropbox/core/util/LangUtil.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.util;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;

--- a/core/src/main/java/com/dropbox/core/util/Maybe.java
+++ b/core/src/main/java/com/dropbox/core/util/Maybe.java
@@ -1,39 +1,42 @@
 package com.dropbox.core.util;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public abstract class Maybe<T>
 {
     private Maybe() {}
 
     public abstract boolean isNothing();
     public abstract boolean isJust();
-    public abstract T getJust();
-    public abstract T get(T def);
-    public abstract String toString();
+    public abstract @Nullable T getJust();
+    public abstract @Nullable T get(@Nullable T def);
+    public abstract @Nonnull String toString();
     public abstract int hashCode();
-    public abstract boolean equals(Maybe<T> other);
+    public abstract boolean equals(@Nullable Maybe<T> other);
 
-    public static <T> Maybe<T> Just(T value)
+    public static <T> @Nonnull Maybe<T> Just(@Nullable T value)
     {
         return new Just<T>(value);
     }
 
     private static final class Just<T> extends Maybe<T>
     {
-        private final T value;
-        private Just(T value)
+        private final @Nullable T value;
+        private Just(@Nullable T value)
         {
             this.value = value;
         }
 
         public boolean isNothing() { return false; }
         public boolean isJust() { return true; }
-        public T getJust() { return value; }
-        public T get(T def) { return value; }
-        public String toString() { return "Just(" + value + ")"; }
+        public @Nullable T getJust() { return value; }
+        public @Nullable T get(@Nullable T def) { return value; }
+        public @Nonnull String toString() { return "Just(" + value + ")"; }
         public int hashCode() { return 1 + LangUtil.nullableHashCode(value); }
 
         @Override
-        public boolean equals(Maybe<T> other)
+        public boolean equals(@Nullable Maybe<T> other)
         {
             if (other instanceof Just) {
                 Just<T> j = (Just<T>) other;
@@ -49,25 +52,25 @@ public abstract class Maybe<T>
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> Maybe<T> Nothing()
+    public static <T> @Nonnull Maybe<T> Nothing()
     {
         return (Maybe<T>) Nothing;
     }
 
-    private static final Maybe<Object> Nothing = new Nothing<Object>();
+    private static final @Nonnull Maybe<Object> Nothing = new Nothing<Object>();
     private static final class Nothing<T> extends Maybe<T>
     {
         private Nothing() {}
 
         public boolean isNothing() { return true; }
         public boolean isJust() { return false; }
-        public T getJust() { throw new IllegalStateException("can't call getJust() on a Nothing"); }
-        public T get(T def) { return def; }
-        public String toString() { return "Nothing"; }
+        public @Nullable T getJust() { throw new IllegalStateException("can't call getJust() on a Nothing"); }
+        public @Nullable T get(@Nullable T def) { return def; }
+        public @Nonnull String toString() { return "Nothing"; }
         public int hashCode() { return 0; }
 
         @Override
-        public boolean equals(Maybe<T> other)
+        public boolean equals(@Nullable Maybe<T> other)
         {
             return other == this;  // There's only a single Nothing instance.
         }

--- a/core/src/main/java/com/dropbox/core/util/ProgressOutputStream.java
+++ b/core/src/main/java/com/dropbox/core/util/ProgressOutputStream.java
@@ -3,33 +3,36 @@ package com.dropbox.core.util;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class ProgressOutputStream extends OutputStream {
     private long completed;
-    private OutputStream underlying;
-    private IOUtil.ProgressListener listener;
+    private @Nonnull OutputStream underlying;
+    private @Nullable IOUtil.ProgressListener listener;
 
-    public ProgressOutputStream(OutputStream underlying) {
+    public ProgressOutputStream(@Nonnull OutputStream underlying) {
         this.underlying = underlying;
         this.completed = 0;
     }
 
-    public ProgressOutputStream(OutputStream underlying, IOUtil.ProgressListener listener) {
+    public ProgressOutputStream(@Nonnull OutputStream underlying, @Nullable IOUtil.ProgressListener listener) {
         this(underlying);
         this.listener = listener;
     }
 
-    public void setListener(IOUtil.ProgressListener listener) {
+    public void setListener(@Nullable IOUtil.ProgressListener listener) {
         this.listener = listener;
     }
 
     @Override
-    public void write(byte[] data, int off, int len) throws IOException {
+    public void write(@Nonnull byte[] data, int off, int len) throws IOException {
         this.underlying.write(data, off, len);
         track(len);
     }
 
     @Override
-    public void write(byte[] data) throws IOException {
+    public void write(@Nonnull byte[] data) throws IOException {
         this.underlying.write(data);
         track(data.length);
     }

--- a/core/src/main/java/com/dropbox/core/util/StringUtil.java
+++ b/core/src/main/java/com/dropbox/core/util/StringUtil.java
@@ -11,20 +11,22 @@ import java.nio.charset.CharsetDecoder;
 import java.util.Arrays;
 import java.util.Collection;
 
+import javax.annotation.Nonnull;
+
 public class StringUtil
 {
-    public static final Charset UTF8 = Charset.forName("UTF-8");
+    public static final @Nonnull Charset UTF8 = Charset.forName("UTF-8");
 
-    private static final char[] HexDigits = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f',};
+    private static final @Nonnull char[] HexDigits = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f',};
     public static char hexDigit(int i) { return HexDigits[i]; }
 
-    public static String utf8ToString(byte[] utf8Data)
+    public static @Nonnull String utf8ToString(@Nonnull byte[] utf8Data)
         throws CharacterCodingException
     {
         return utf8ToString(utf8Data, 0, utf8Data.length);
     }
 
-    public static String utf8ToString(byte[] utf8Data, int offset, int length)
+    public static @Nonnull String utf8ToString(@Nonnull byte[] utf8Data, int offset, int length)
         throws CharacterCodingException
     {
         // NOTE: Using the String(..., UTF8) constructor would be wrong.  That method will
@@ -34,7 +36,7 @@ public class StringUtil
         return result.toString();
     }
 
-    public static byte[] stringToUtf8(String s)
+    public static @Nonnull byte[] stringToUtf8(@Nonnull String s)
     {
         try {
             // Java 1.5 doesn't have the version of getBytes that takes a Charset object, so we
@@ -50,7 +52,7 @@ public class StringUtil
      * Given a string, returns the representation of that string
      * as a Java string literal.
      */
-    public static String javaQuotedLiteral(String value)
+    public static @Nonnull String javaQuotedLiteral(@Nonnull String value)
     {
         StringBuilder b = new StringBuilder(value.length() * 2);
         b.append('"');
@@ -84,11 +86,11 @@ public class StringUtil
         return b.toString();
     }
 
-    public static String javaQuotedLiterals(String[] value) {
+    public static @Nonnull String javaQuotedLiterals(@Nonnull String[] value) {
         return javaQuotedLiterals(Arrays.asList(value));
     }
 
-    public static String javaQuotedLiterals(Iterable<String> value) {
+    public static @Nonnull String javaQuotedLiterals(@Nonnull Iterable<String> value) {
         StringBuilder b = new StringBuilder();
         String sep = "";
         for (String element : value) {
@@ -100,13 +102,13 @@ public class StringUtil
     }
 
     /** Shorthand for {@link #javaQuotedLiteral}. */
-    public static String jq(String value) { return javaQuotedLiteral(value); }
+    public static @Nonnull String jq(@Nonnull String value) { return javaQuotedLiteral(value); }
     /** Shorthand for {@link #javaQuotedLiterals}. */
-    public static String jq(String[] value) { return javaQuotedLiterals(value); }
+    public static @Nonnull String jq(@Nonnull String[] value) { return javaQuotedLiterals(value); }
     /** Shorthand for {@link #javaQuotedLiterals}. */
-    public static String jq(Iterable<String> value) { return javaQuotedLiterals(value); }
+    public static @Nonnull String jq(@Nonnull Iterable<String> value) { return javaQuotedLiterals(value); }
 
-    public static String binaryToHex(byte[] data)
+    public static @Nonnull String binaryToHex(@Nonnull byte[] data)
     {
         return binaryToHex(data, 0, data.length);
     }
@@ -116,7 +118,7 @@ public class StringUtil
      * The resulting String will have two characters for every byte in the
      * input.
      */
-    public static String binaryToHex(byte[] data, int offset, int length)
+    public static @Nonnull String binaryToHex(@Nonnull byte[] data, int offset, int length)
     {
         assert offset < data.length && offset >= 0 : offset + ", " + data.length;
         int end = offset + length;
@@ -139,7 +141,7 @@ public class StringUtil
      * this function to check for equality.  Using regular {@code String.equals} is not
      * secure.
      */
-    public static boolean secureStringEquals(String a, String b)
+    public static boolean secureStringEquals(@Nonnull String a, @Nonnull String b)
     {
         if (a.length() != b.length()) return false;
 
@@ -154,24 +156,24 @@ public class StringUtil
         return result == 0;
     }
 
-    public static final String Base64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    public static final String UrlSafeBase64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    public static final @Nonnull String Base64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    public static final @Nonnull String UrlSafeBase64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
     static {
         assert Base64Digits.length() == 64 : Base64Digits.length();
         assert UrlSafeBase64Digits.length() == 64 : UrlSafeBase64Digits.length();
     }
 
-    public static String base64Encode(byte[] data)
+    public static @Nonnull String base64Encode(@Nonnull byte[] data)
     {
         return base64EncodeGeneric(Base64Digits, data);
     }
 
-    public static String urlSafeBase64Encode(byte[] data)
+    public static @Nonnull String urlSafeBase64Encode(@Nonnull byte[] data)
     {
         return base64EncodeGeneric(UrlSafeBase64Digits, data);
     }
 
-    public static String base64EncodeGeneric(String digits, byte[] data)
+    public static @Nonnull String base64EncodeGeneric(@Nonnull String digits, @Nonnull byte[] data)
     {
         if (data == null) throw new IllegalArgumentException("'data' can't be null");
         if (digits == null) throw new IllegalArgumentException("'digits' can't be null");
@@ -234,7 +236,7 @@ public class StringUtil
         return buf.toString();
     }
 
-    public static String join(Collection<String> strings, String delimiter) {
+    public static @Nonnull String join(@Nonnull Collection<String> strings, @Nonnull String delimiter) {
         StringBuilder sb = new StringBuilder();
         int i = 0;
         for (String s: strings) {

--- a/core/src/main/java/com/dropbox/core/v1/DbxAccountInfo.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxAccountInfo.java
@@ -11,20 +11,23 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import java.io.IOException;
 
+import javax.annotation.Nonnull;
+
 public class DbxAccountInfo extends Dumpable
 {
     public final long userId;
-    public final String displayName;
-    public final String country;
-    public final String referralLink;
-    public final Quota quota;
-    public final String email;
-    public final NameDetails nameDetails;
+    public final @Nonnull String displayName;
+    public final @Nonnull String country;
+    public final @Nonnull String referralLink;
+    public final @Nonnull Quota quota;
+    public final @Nonnull String email;
+    public final @Nonnull NameDetails nameDetails;
     public final boolean emailVerified;
 
 
-    public DbxAccountInfo(long userId, String displayName, String country, String referralLink, Quota quota, String email,
-                          NameDetails nameDetails, boolean emailVerified)
+    public DbxAccountInfo(long userId, @Nonnull String displayName, @Nonnull String country,
+                          @Nonnull String referralLink, @Nonnull Quota quota, @Nonnull String email,
+                          @Nonnull NameDetails nameDetails, boolean emailVerified)
     {
         this.userId = userId;
         this.displayName = displayName;
@@ -37,7 +40,7 @@ public class DbxAccountInfo extends Dumpable
     }
 
     @Override
-    protected void dumpFields(DumpWriter out)
+    protected void dumpFields(@Nonnull DumpWriter out)
     {
         out.f("userId").v(userId);
         out.f("displayName").v(displayName);
@@ -63,7 +66,7 @@ public class DbxAccountInfo extends Dumpable
         }
 
         @Override
-        protected void dumpFields(DumpWriter out)
+        protected void dumpFields(@Nonnull DumpWriter out)
         {
             out.f("total").v(total);
             out.f("normal").v(normal);
@@ -73,9 +76,9 @@ public class DbxAccountInfo extends Dumpable
         // ------------------------------------------------------
         // JSON parsing
 
-        public static final JsonReader<Quota> Reader = new JsonReader<Quota>()
+        public static final @Nonnull JsonReader<Quota> Reader = new JsonReader<Quota>()
         {
-            public final Quota read(JsonParser parser)
+            public final @Nonnull Quota read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -131,11 +134,11 @@ public class DbxAccountInfo extends Dumpable
 
     public static final class NameDetails extends Dumpable
     {
-        public final String familiarName;
-        public final String givenName;
-        public final String surname;
+        public final @Nonnull String familiarName;
+        public final @Nonnull String givenName;
+        public final @Nonnull String surname;
 
-        public NameDetails(String familiarName, String givenName, String surname)
+        public NameDetails(@Nonnull String familiarName, @Nonnull String givenName, @Nonnull String surname)
         {
             this.familiarName = familiarName;
             this.givenName = givenName;
@@ -143,7 +146,7 @@ public class DbxAccountInfo extends Dumpable
         }
 
         @Override
-        protected void dumpFields(DumpWriter out)
+        protected void dumpFields(@Nonnull DumpWriter out)
         {
             out.f("familiarName").v(familiarName);
             out.f("givenName").v(givenName);
@@ -153,9 +156,9 @@ public class DbxAccountInfo extends Dumpable
         // ------------------------------------------------------
         // JSON parsing
 
-        public static final JsonReader<NameDetails> Reader = new JsonReader<NameDetails>()
+        public static final @Nonnull JsonReader<NameDetails> Reader = new JsonReader<NameDetails>()
         {
-            public final NameDetails read(JsonParser parser)
+            public final @Nonnull NameDetails read(@Nonnull JsonParser parser)
                     throws IOException, JsonReadException
             {
                 JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -212,9 +215,9 @@ public class DbxAccountInfo extends Dumpable
     // ------------------------------------------------------
     // JSON parsing
 
-    public static final JsonReader<DbxAccountInfo> Reader = new JsonReader<DbxAccountInfo>()
+    public static final @Nonnull JsonReader<DbxAccountInfo> Reader = new JsonReader<DbxAccountInfo>()
     {
-        public final DbxAccountInfo read(JsonParser parser)
+        public final @Nonnull DbxAccountInfo read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);

--- a/core/src/main/java/com/dropbox/core/v1/DbxClientV1.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxClientV1.java
@@ -1,9 +1,7 @@
 package com.dropbox.core.v1;
 
-import org.checkerframework.checker.initialization.qual.Initialized;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -124,7 +122,7 @@ public final class DbxClientV1
             "include_media_info", includeMediaInfo ? "true" : null,
         };
 
-        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>() {
+        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>() {
             @Override
             public @Nullable DbxEntry handle(HttpRequestor.Response response) throws DbxException
             {
@@ -171,7 +169,7 @@ public final class DbxClientV1
      *    Otherwise, return the metadata for that path and the metadata for all its immediate
      *    children (if it's a folder).
      */
-    public DbxEntry.@Nullable WithChildren getMetadataWithChildren(String path, boolean includeMediaInfo)
+    public @Nullable DbxEntry.WithChildren getMetadataWithChildren(String path, boolean includeMediaInfo)
         throws DbxException
     {
         return getMetadataWithChildrenBase(path, includeMediaInfo, DbxEntry.WithChildren.ReaderMaybeDeleted);
@@ -181,7 +179,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildren(String, boolean)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public DbxEntry.@Nullable WithChildren getMetadataWithChildren(String path)
+    public @Nullable DbxEntry.WithChildren getMetadataWithChildren(String path)
         throws DbxException
     {
         return getMetadataWithChildren(path, false);
@@ -201,7 +199,7 @@ public final class DbxClientV1
      * the entire call succeeds.
      * </p>
      */
-    public <C> DbxEntry.@Nullable WithChildrenC<C> getMetadataWithChildrenC(String path, boolean includeMediaInfo, final Collector<DbxEntry, ? extends C> collector)
+    public <C> @Nullable DbxEntry.WithChildrenC<C> getMetadataWithChildrenC(String path, boolean includeMediaInfo, final Collector<DbxEntry, ? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenBase(path, includeMediaInfo, new DbxEntry.WithChildrenC.ReaderMaybeDeleted<C>(collector));
@@ -211,7 +209,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenC(String, boolean, Collector)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public <C> DbxEntry.@Nullable WithChildrenC<C> getMetadataWithChildrenC(String path, final Collector<DbxEntry, ? extends C> collector)
+    public <C> @Nullable DbxEntry.WithChildrenC<C> getMetadataWithChildrenC(String path, final Collector<DbxEntry, ? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenC(path, false, collector);
@@ -231,7 +229,7 @@ public final class DbxClientV1
             "include_media_info", includeMediaInfo ? "true" : null,
         };
 
-        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<@Nullable T>() {
+        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<T>() {
             @Override
             public @Nullable T handle(HttpRequestor.Response response) throws DbxException
             {
@@ -261,7 +259,7 @@ public final class DbxClientV1
      *    {@code Maybe.Just(null)} if there's nothing there or {@code Maybe.Just} with the
      *    metadata.
      */
-    public Maybe<DbxEntry.@Nullable WithChildren> getMetadataWithChildrenIfChanged(String path, boolean includeMediaInfo, @Nullable String previousFolderHash)
+    public Maybe<DbxEntry.WithChildren> getMetadataWithChildrenIfChanged(String path, boolean includeMediaInfo, String previousFolderHash)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedBase(path, includeMediaInfo, previousFolderHash, DbxEntry.WithChildren.ReaderMaybeDeleted);
@@ -271,7 +269,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenIfChanged(String, boolean, String)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public Maybe<DbxEntry.@Nullable WithChildren> getMetadataWithChildrenIfChanged(String path, @Nullable String previousFolderHash)
+    public Maybe<DbxEntry.WithChildren> getMetadataWithChildrenIfChanged(String path, String previousFolderHash)
         throws DbxException
     {
         return getMetadataWithChildrenIfChanged(path, false, previousFolderHash);
@@ -291,7 +289,7 @@ public final class DbxClientV1
      * the entire call succeeds.
      * </p>
      */
-    public <C> Maybe<DbxEntry.@Nullable WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
+    public <C> Maybe<DbxEntry.WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
             String path, boolean includeMediaInfo, @Nullable String previousFolderHash, Collector<DbxEntry,? extends C> collector)
         throws DbxException
     {
@@ -302,14 +300,14 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenIfChangedC(String, boolean, String, Collector)} with
      * {@code includeMediaInfo} set to {@code false}.
      */
-    public <C> Maybe<DbxEntry.@Nullable WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
+    public <C> Maybe<DbxEntry.WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
             String path, @Nullable String previousFolderHash, Collector<DbxEntry,? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedC(path, false, previousFolderHash, collector);
     }
 
-    private <T> Maybe<@Nullable T> getMetadataWithChildrenIfChangedBase(
+    private <T> Maybe<T> getMetadataWithChildrenIfChangedBase(
             String path, boolean includeMediaInfo, @Nullable String previousFolderHash, final JsonReader<T> reader)
         throws DbxException
     {
@@ -327,15 +325,15 @@ public final class DbxClientV1
             "include_media_info", includeMediaInfo ? "true" : null,
         };
 
-        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<Maybe<@Nullable T>>() {
+        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<Maybe<T>>() {
             @Override
-            public Maybe<@Nullable T> handle(HttpRequestor.Response response) throws DbxException
+            public Maybe<T> handle(HttpRequestor.Response response) throws DbxException
             {
-                if (response.getStatusCode() == 404) return Maybe.<@Nullable T>Just(null);
-                if (response.getStatusCode() == 304) return Maybe.<@Nullable T>Nothing();
+                if (response.getStatusCode() == 404) return Maybe.<T>Just(null);
+                if (response.getStatusCode() == 304) return Maybe.<T>Nothing();
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
 
-                return Maybe.<@Nullable T>Just(DbxRequestUtil.readJsonFromResponse(reader, response));
+                return Maybe.<T>Just(DbxRequestUtil.readJsonFromResponse(reader, response));
             }
         });
     }
@@ -377,7 +375,7 @@ public final class DbxClientV1
         String host = this.host.getApi();
         String apiPath = "1/disable_access_token";
 
-        doPost(host, apiPath, null, null, new DbxRequestUtil.ResponseHandler<@Nullable Void>() {
+        doPost(host, apiPath, null, null, new DbxRequestUtil.ResponseHandler<Void>() {
             @Override
             public @Nullable Void handle(HttpRequestor.Response response) throws DbxException
             {
@@ -419,7 +417,7 @@ public final class DbxClientV1
      * @throws IOException
      *    If there's an error writing to {@code target}.
      */
-    public DbxEntry.@Nullable File getFile(String path, @Nullable String rev, OutputStream target)
+    public @Nullable DbxEntry.File getFile(String path, @Nullable String rev, OutputStream target)
         throws DbxException, IOException
     {
         Downloader downloader = startGetFile(path, rev);
@@ -760,7 +758,7 @@ public final class DbxClientV1
 
     private static final class SingleUploader extends Uploader
     {
-        private HttpRequestor.@Nullable Uploader httpUploader;
+        private @Nullable HttpRequestor.Uploader httpUploader;
         private final long claimedBytes;
         private final CountingOutputStream body;
 
@@ -843,7 +841,7 @@ public final class DbxClientV1
             }
 
             @SuppressWarnings("nullness")  // Workaround for bug in Checker Framework: https://code.google.com/p/checker-framework/issues/detail?id=293
-            final HttpRequestor.@Initialized @NonNull Response nonNullResponse = response;
+            final HttpRequestor.Response nonNullResponse = response;
 
             return DbxRequestUtil.finishResponse(nonNullResponse, new DbxRequestUtil.ResponseHandler<DbxEntry.File>() {
                 @Override
@@ -1333,7 +1331,7 @@ public final class DbxClientV1
     {
         private final byte[] chunk;
         private int chunkPos = 0;
-        private @MonotonicNonNull String uploadId;
+        private @Nullable String uploadId;
         private long uploadOffset;
 
         private ChunkedUploadOutputStream(int chunkSize)
@@ -1547,8 +1545,7 @@ public final class DbxClientV1
      * A more generic version of {@link #getDeltaWithPathPrefix}.  You provide a <em>collector</em>,
      * which lets you process the delta entries as they arrive over the network.
      */
-    public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector,
-                                                    @Nullable String cursor, String pathPrefix,
+    public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, String pathPrefix,
                                                     boolean includeMediaInfo)
         throws DbxException
     {
@@ -1560,8 +1557,7 @@ public final class DbxClientV1
      * Same as {@link #getDeltaCWithPathPrefix(Collector, String, String, boolean)} with {@code includeMediaInfo}
      * set to {@code false}.
      */
-    public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector,
-                                                    @Nullable String cursor, String pathPrefix)
+    public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, String pathPrefix)
         throws DbxException
     {
         return getDeltaCWithPathPrefix(collector, cursor, pathPrefix, false);
@@ -1588,8 +1584,7 @@ public final class DbxClientV1
         });
     }
 
-    private <C> DbxDeltaC<C> _getDeltaC(final Collector<DbxDeltaC.Entry<DbxEntry>, C> collector,
-                                        @Nullable String cursor, @Nullable String pathPrefix,
+    private <C> DbxDeltaC<C> _getDeltaC(final Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, @Nullable String pathPrefix,
                                         boolean includeMediaInfo)
         throws DbxException
     {
@@ -1765,7 +1760,7 @@ public final class DbxClientV1
      *    The metadata for the original file (not the thumbnail) or {@code null} if there
      *    is no file at that path.
      */
-    public DbxEntry.@Nullable File getThumbnail(
+    public @Nullable DbxEntry.File getThumbnail(
             DbxThumbnailSize sizeBound, DbxThumbnailFormat format,
             String path, @Nullable String rev, OutputStream target)
             throws DbxException, IOException
@@ -1823,7 +1818,7 @@ public final class DbxClientV1
                 throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
-                Collector<DbxEntry.@Nullable File,ArrayList<DbxEntry.File>> collector =
+                Collector<DbxEntry.File,ArrayList<DbxEntry.File>> collector =
                     Collector.NullSkipper.<DbxEntry.File,ArrayList<DbxEntry.File>>mk(new Collector.ArrayListCollector<DbxEntry.File>());
                 return DbxRequestUtil.readJsonFromResponse(JsonArrayReader.mk(DbxEntry.File.ReaderMaybeDeleted, collector), response);
             }
@@ -1845,7 +1840,7 @@ public final class DbxClientV1
      *     If the specified {@code path}/{@code rev} couldn't be found, return {@code null}.
      *     Otherwise, return metadata for the newly-created latest revision of the file.
      */
-    public DbxEntry.@Nullable File restoreFile(String path, String rev)
+    public @Nullable DbxEntry.File restoreFile(String path, String rev)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1857,8 +1852,8 @@ public final class DbxClientV1
             "rev", rev,
         };
 
-        return doGet(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.@Nullable File>() {
-            public DbxEntry.@Nullable File handle(HttpRequestor.Response response)
+        return doGet(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.File>() {
+            public @Nullable DbxEntry.File handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -1921,7 +1916,7 @@ public final class DbxClientV1
         String apiPath = "1/shares/auto" + path;
         String[] params = {"short_url", "false"};
 
-        return doPost(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<@Nullable String>() {
+        return doPost(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<String>() {
             @Override
             public @Nullable String handle(HttpRequestor.Response response)
                 throws DbxException
@@ -1952,7 +1947,7 @@ public final class DbxClientV1
 
         String apiPath = "1/media/auto" + path;
 
-        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxUrlWithExpiration>() {
+        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<DbxUrlWithExpiration>() {
             @Override
             public @Nullable DbxUrlWithExpiration handle(HttpRequestor.Response response)
                 throws DbxException
@@ -1992,7 +1987,7 @@ public final class DbxClientV1
 
         String apiPath = "1/copy_ref/auto" + path;
 
-        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<@Nullable String>()
+        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<String>()
         {
             @Override
             public @Nullable String handle(HttpRequestor.Response response)
@@ -2076,7 +2071,7 @@ public final class DbxClientV1
             "to_path", toPath,
         };
 
-        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>() {
+        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>() {
             @Override
             public @Nullable DbxEntry handle(HttpRequestor.Response response)
                 throws DbxException
@@ -2107,7 +2102,7 @@ public final class DbxClientV1
             "to_path", toPath,
         };
 
-        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>()
+        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>()
         {
             @Override
             public @Nullable DbxEntry handle(HttpRequestor.Response response)
@@ -2128,7 +2123,7 @@ public final class DbxClientV1
      *    If successful, returns the metadata for the newly created folder, otherwise
      *    returns {@code null}.
      */
-    public DbxEntry.@Nullable Folder createFolder(String path)
+    public @Nullable DbxEntry.Folder createFolder(String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -2138,9 +2133,9 @@ public final class DbxClientV1
             "path", path,
         };
 
-        return doPost(host.getApi(), "1/fileops/create_folder", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.@Nullable Folder>() {
+        return doPost(host.getApi(), "1/fileops/create_folder", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.Folder>() {
             @Override
-            public DbxEntry.@Nullable Folder handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry.Folder handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 403) return null;
@@ -2193,7 +2188,7 @@ public final class DbxClientV1
             "to_path", toPath,
         };
 
-        return doPost(host.getApi(), "1/fileops/move", params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>()
+        return doPost(host.getApi(), "1/fileops/move", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>()
         {
             @Override
             public @Nullable DbxEntry handle(HttpRequestor.Response response)
@@ -2211,7 +2206,7 @@ public final class DbxClientV1
     // --------------------------------------------------------
 
     // Convenience function that calls RequestUtil.doGet with the first two parameters filled in.
-    private <T> T doGet(String host, String path, @Nullable String @Nullable [] params,
+    private <T> T doGet(String host, String path, @Nullable String[] params,
                         @Nullable ArrayList<HttpRequestor.Header> headers,
                         DbxRequestUtil.ResponseHandler<T> handler)
         throws DbxException
@@ -2221,7 +2216,7 @@ public final class DbxClientV1
 
     // Convenience function that calls RequestUtil.doPost with the first two parameters filled in.
     public <T> T doPost(String host, String path,
-                        @Nullable String @Nullable [] params,
+                        @Nullable String[] params,
                         @Nullable ArrayList<HttpRequestor.Header> headers,
                         DbxRequestUtil.ResponseHandler<T> handler)
         throws DbxException

--- a/core/src/main/java/com/dropbox/core/v1/DbxClientV1.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxClientV1.java
@@ -34,11 +34,11 @@ import static com.dropbox.core.util.StringUtil.jq;
  */
 public final class DbxClientV1
 {
-    public static final String USER_AGENT_ID = "Dropbox-Java-SDK";
+    public static final @Nonnull String USER_AGENT_ID = "Dropbox-Java-SDK";
 
-    private final DbxRequestConfig requestConfig;
-    private final String accessToken;
-    private final DbxHost host;
+    private final @Nonnull DbxRequestConfig requestConfig;
+    private final @Nonnull String accessToken;
+    private final @Nonnull DbxHost host;
 
     /**
      * @param accessToken
@@ -47,7 +47,7 @@ public final class DbxClientV1
      *     to get one of these is to use {@link DbxWebAuth} to send your user through Dropbox's
      *     OAuth 2 authorization flow.
      */
-    public DbxClientV1(DbxRequestConfig requestConfig, String accessToken)
+    public DbxClientV1(@Nonnull DbxRequestConfig requestConfig, @Nonnull String accessToken)
     {
         this(requestConfig, accessToken, DbxHost.DEFAULT);
     }
@@ -57,7 +57,7 @@ public final class DbxClientV1
      * hostnames of the Dropbox API servers.  This is used in testing.  You don't normally need
      * to call this.
      */
-    public DbxClientV1(DbxRequestConfig requestConfig, String accessToken, DbxHost host)
+    public DbxClientV1(@Nonnull DbxRequestConfig requestConfig, @Nonnull String accessToken, @Nonnull DbxHost host)
     {
         if (requestConfig == null) throw new IllegalArgumentException("'requestConfig' is null");
         if (accessToken == null) throw new IllegalArgumentException("'accessToken' is null");
@@ -71,17 +71,17 @@ public final class DbxClientV1
     /**
      * Returns the {@code DbxRequestConfig} that was passed in to the constructor.
      */
-    public DbxRequestConfig getRequestConfig() { return requestConfig; }
+    public @Nonnull DbxRequestConfig getRequestConfig() { return requestConfig; }
 
     /**
      * Returns the {@code DbxAccessToken} that was passed in to the constructor.
      */
-    public String getAccessToken() { return accessToken; }
+    public @Nonnull String getAccessToken() { return accessToken; }
 
     /**
      * Returns the {@code DbxHost} that was passed in to the constructor.
      */
-    public DbxHost getHost() { return host; }
+    public @Nonnull DbxHost getHost() { return host; }
 
     // -----------------------------------------------------------------
     // /metadata
@@ -110,7 +110,7 @@ public final class DbxClientV1
      *    metadata for that path.  If there is no file or folder there,
      *    return {@code null}.
      */
-    public @Nullable DbxEntry getMetadata(final String path, boolean includeMediaInfo)
+    public @Nullable DbxEntry getMetadata(final @Nonnull String path, boolean includeMediaInfo)
         throws DbxException
     {
         DbxPathV1.checkArg("path", path);
@@ -124,7 +124,7 @@ public final class DbxClientV1
 
         return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>() {
             @Override
-            public @Nullable DbxEntry handle(HttpRequestor.Response response) throws DbxException
+            public @Nullable DbxEntry handle(@Nonnull HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -138,7 +138,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadata(String, boolean)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public @Nullable DbxEntry getMetadata(final String path)
+    public @Nullable DbxEntry getMetadata(final @Nonnull String path)
         throws DbxException
     {
         return getMetadata(path, false);
@@ -169,7 +169,7 @@ public final class DbxClientV1
      *    Otherwise, return the metadata for that path and the metadata for all its immediate
      *    children (if it's a folder).
      */
-    public @Nullable DbxEntry.WithChildren getMetadataWithChildren(String path, boolean includeMediaInfo)
+    public @Nullable DbxEntry.WithChildren getMetadataWithChildren(@Nonnull String path, boolean includeMediaInfo)
         throws DbxException
     {
         return getMetadataWithChildrenBase(path, includeMediaInfo, DbxEntry.WithChildren.ReaderMaybeDeleted);
@@ -179,7 +179,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildren(String, boolean)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public @Nullable DbxEntry.WithChildren getMetadataWithChildren(String path)
+    public @Nullable DbxEntry.WithChildren getMetadataWithChildren(@Nonnull String path)
         throws DbxException
     {
         return getMetadataWithChildren(path, false);
@@ -199,7 +199,7 @@ public final class DbxClientV1
      * the entire call succeeds.
      * </p>
      */
-    public <C> @Nullable DbxEntry.WithChildrenC<C> getMetadataWithChildrenC(String path, boolean includeMediaInfo, final Collector<DbxEntry, ? extends C> collector)
+    public <C> @Nullable DbxEntry.WithChildrenC<C> getMetadataWithChildrenC(@Nonnull String path, boolean includeMediaInfo, final @Nonnull Collector<DbxEntry, ? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenBase(path, includeMediaInfo, new DbxEntry.WithChildrenC.ReaderMaybeDeleted<C>(collector));
@@ -209,7 +209,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenC(String, boolean, Collector)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public <C> @Nullable DbxEntry.WithChildrenC<C> getMetadataWithChildrenC(String path, final Collector<DbxEntry, ? extends C> collector)
+    public <C> @Nullable DbxEntry.WithChildrenC<C> getMetadataWithChildrenC(@Nonnull String path, final @Nonnull Collector<DbxEntry, ? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenC(path, false, collector);
@@ -231,7 +231,7 @@ public final class DbxClientV1
 
         return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<T>() {
             @Override
-            public @Nullable T handle(HttpRequestor.Response response) throws DbxException
+            public @Nullable T handle(@Nonnull HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -259,7 +259,7 @@ public final class DbxClientV1
      *    {@code Maybe.Just(null)} if there's nothing there or {@code Maybe.Just} with the
      *    metadata.
      */
-    public Maybe<DbxEntry.WithChildren> getMetadataWithChildrenIfChanged(String path, boolean includeMediaInfo, String previousFolderHash)
+    public @Nonnull Maybe<DbxEntry.WithChildren> getMetadataWithChildrenIfChanged(@Nonnull String path, boolean includeMediaInfo, @Nonnull String previousFolderHash)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedBase(path, includeMediaInfo, previousFolderHash, DbxEntry.WithChildren.ReaderMaybeDeleted);
@@ -269,7 +269,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenIfChanged(String, boolean, String)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public Maybe<DbxEntry.WithChildren> getMetadataWithChildrenIfChanged(String path, String previousFolderHash)
+    public @Nonnull Maybe<DbxEntry.WithChildren> getMetadataWithChildrenIfChanged(@Nonnull String path, @Nonnull String previousFolderHash)
         throws DbxException
     {
         return getMetadataWithChildrenIfChanged(path, false, previousFolderHash);
@@ -290,7 +290,7 @@ public final class DbxClientV1
      * </p>
      */
     public <C> Maybe<DbxEntry.WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
-            String path, boolean includeMediaInfo, @Nullable String previousFolderHash, Collector<DbxEntry,? extends C> collector)
+            @Nonnull String path, boolean includeMediaInfo, @Nonnull String previousFolderHash, @Nonnull Collector<DbxEntry,? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedBase(path, includeMediaInfo, previousFolderHash, new DbxEntry.WithChildrenC.ReaderMaybeDeleted<C>(collector));
@@ -301,7 +301,7 @@ public final class DbxClientV1
      * {@code includeMediaInfo} set to {@code false}.
      */
     public <C> Maybe<DbxEntry.WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
-            String path, @Nullable String previousFolderHash, Collector<DbxEntry,? extends C> collector)
+            @Nonnull String path, @Nonnull String previousFolderHash, @Nonnull Collector<DbxEntry,? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedC(path, false, previousFolderHash, collector);
@@ -327,7 +327,7 @@ public final class DbxClientV1
 
         return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<Maybe<T>>() {
             @Override
-            public Maybe<T> handle(HttpRequestor.Response response) throws DbxException
+            public @Nonnull Maybe<T> handle(@Nonnull HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() == 404) return Maybe.<T>Just(null);
                 if (response.getStatusCode() == 304) return Maybe.<T>Nothing();
@@ -344,7 +344,7 @@ public final class DbxClientV1
     /**
      * Retrieve the user's account information.
      */
-    public DbxAccountInfo getAccountInfo()
+    public @Nonnull DbxAccountInfo getAccountInfo()
         throws DbxException
     {
         String host = this.host.getApi();
@@ -352,7 +352,7 @@ public final class DbxClientV1
 
         return doGet(host, apiPath, null, null, new DbxRequestUtil.ResponseHandler<DbxAccountInfo>() {
             @Override
-            public DbxAccountInfo handle(HttpRequestor.Response response) throws DbxException
+            public @Nonnull DbxAccountInfo handle(@Nonnull HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
 
@@ -377,7 +377,7 @@ public final class DbxClientV1
 
         doPost(host, apiPath, null, null, new DbxRequestUtil.ResponseHandler<Void>() {
             @Override
-            public @Nullable Void handle(HttpRequestor.Response response) throws DbxException
+            public @Nullable Void handle(@Nonnull HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() != 200) {
                     String requestId = DbxRequestUtil.getRequestId(response);
@@ -417,7 +417,7 @@ public final class DbxClientV1
      * @throws IOException
      *    If there's an error writing to {@code target}.
      */
-    public @Nullable DbxEntry.File getFile(String path, @Nullable String rev, OutputStream target)
+    public @Nullable DbxEntry.File getFile(@Nonnull String path, @Nullable String rev, @Nonnull OutputStream target)
         throws DbxException, IOException
     {
         Downloader downloader = startGetFile(path, rev);
@@ -452,7 +452,7 @@ public final class DbxClientV1
      *     An object that can be used to download the file contents, or
      *     {@code null} if there is no file at the requested path.
      */
-    public @Nullable Downloader startGetFile(final String path, @Nullable String rev)
+    public @Nullable Downloader startGetFile(final @Nonnull String path, @Nullable String rev)
             throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -477,7 +477,7 @@ public final class DbxClientV1
         return DbxRequestUtil.runAndRetry(requestConfig.getMaxRetries(),
                                           new DbxRequestUtil.RequestMaker<Downloader, DbxException>() {
             @Override
-            public Downloader run() throws DbxException {
+            public @Nullable Downloader run() throws DbxException {
                 HttpRequestor.Response response = DbxRequestUtil.startGet(requestConfig, accessToken, USER_AGENT_ID, host, apiPath, params, null);
 
                 boolean passedOwnershipOfStream = false;
@@ -523,10 +523,10 @@ public final class DbxClientV1
      */
     public static final class Downloader
     {
-        public final DbxEntry.File metadata;
-        public final InputStream body;
+        public final @Nonnull DbxEntry.File metadata;
+        public final @Nonnull InputStream body;
 
-        public Downloader(DbxEntry.File metadata, InputStream body)
+        public Downloader(@Nonnull DbxEntry.File metadata, @Nonnull InputStream body)
         {
             this.metadata = metadata;
             this.body = body;
@@ -536,7 +536,7 @@ public final class DbxClientV1
          * Copies all of {@code #body} to the given output stream.  As a convenience, also
          * returns {@code #metadata}.
          */
-        DbxEntry.File copyBodyAndClose(OutputStream target)
+        @Nonnull DbxEntry.File copyBodyAndClose(@Nonnull OutputStream target)
             throws DbxException, IOException
         {
             try {
@@ -595,7 +595,7 @@ public final class DbxClientV1
      * @throws IOException
      *     If there's an error reading from {@code in}.
      */
-    public DbxEntry.File uploadFile(String targetPath, DbxWriteMode writeMode, long numBytes, InputStream contents)
+    public @Nonnull DbxEntry.File uploadFile(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes, @Nonnull InputStream contents)
         throws DbxException, IOException
     {
         return uploadFile(targetPath, writeMode, numBytes, new DbxStreamWriter.InputStreamCopier(contents));
@@ -642,7 +642,7 @@ public final class DbxClientV1
      * @throws E
      *     If {@code writer.write()} throws an exception, it will propagate out of this function.
      */
-    public <E extends Throwable> DbxEntry.File uploadFile(String targetPath, DbxWriteMode writeMode, long numBytes, DbxStreamWriter<E> writer)
+    public <E extends Throwable> @Nonnull DbxEntry.File uploadFile(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         Uploader uploader = startUploadFile(targetPath, writeMode, numBytes);
@@ -687,7 +687,7 @@ public final class DbxClientV1
      *     The number of bytes you're going to upload via the returned {@link DbxClientV1.Uploader}.
      *     Use {@code -1} if you don't know ahead of time.
      */
-    public Uploader startUploadFile(String targetPath, DbxWriteMode writeMode, long numBytes)
+    public @Nonnull Uploader startUploadFile(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes)
         throws DbxException
     {
         if (numBytes < 0) {
@@ -707,7 +707,7 @@ public final class DbxClientV1
         }
     }
 
-    public <E extends Throwable> DbxEntry.File finishUploadFile(Uploader uploader, DbxStreamWriter<E> writer)
+    public <E extends Throwable> @Nonnull DbxEntry.File finishUploadFile(@Nonnull Uploader uploader, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         NoThrowOutputStream streamWrapper = new NoThrowOutputStream(uploader.getBody());
@@ -731,7 +731,7 @@ public final class DbxClientV1
      * Similar to {@link #uploadFile}, except always uses the /files_put API call.
      * One difference is that {@code numBytes} must not be negative.
      */
-    public Uploader startUploadFileSingle(String targetPath, DbxWriteMode writeMode, long numBytes)
+    public @Nonnull Uploader startUploadFileSingle(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes)
         throws DbxException
     {
         DbxPathV1.checkArg("targetPath", targetPath);
@@ -749,7 +749,7 @@ public final class DbxClientV1
         return new SingleUploader(uploader, numBytes);
     }
 
-    public <E extends Throwable> DbxEntry.File uploadFileSingle(String targetPath, DbxWriteMode writeMode, long numBytes, DbxStreamWriter<E> writer)
+    public <E extends Throwable> @Nonnull DbxEntry.File uploadFileSingle(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         Uploader uploader = startUploadFileSingle(targetPath, writeMode, numBytes);
@@ -762,7 +762,7 @@ public final class DbxClientV1
         private final long claimedBytes;
         private final CountingOutputStream body;
 
-        public SingleUploader(HttpRequestor.Uploader httpUploader, long claimedBytes)
+        public SingleUploader(@Nonnull HttpRequestor.Uploader httpUploader, long claimedBytes)
         {
             if (claimedBytes < 0) {
                 throw new IllegalArgumentException("'numBytes' must be greater than or equal to 0");
@@ -773,7 +773,7 @@ public final class DbxClientV1
             this.body = new CountingOutputStream(httpUploader.getBody());
         }
 
-        public OutputStream getBody()
+        public @Nonnull OutputStream getBody()
         {
             return this.body;
         }
@@ -810,7 +810,7 @@ public final class DbxClientV1
          * to indicate that you're done.  This will actually finish the underlying HTTP
          * request and return the uploaded file's {@link DbxEntry}.
          */
-        public DbxEntry.File finish()
+        public @Nonnull DbxEntry.File finish()
             throws DbxException
         {
             if (httpUploader == null) {
@@ -845,7 +845,7 @@ public final class DbxClientV1
 
             return DbxRequestUtil.finishResponse(nonNullResponse, new DbxRequestUtil.ResponseHandler<DbxEntry.File>() {
                 @Override
-                public DbxEntry.File handle(HttpRequestor.Response response) throws DbxException
+                public @Nonnull DbxEntry.File handle(@Nonnull HttpRequestor.Response response) throws DbxException
                 {
                     if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
                     DbxEntry.File f = DbxRequestUtil.readJsonFromResponse(DbxEntry.File.Reader, response);
@@ -865,10 +865,10 @@ public final class DbxClientV1
 
     private static final class ChunkedUploadState extends Dumpable
     {
-        public final String uploadId;
+        public final @Nonnull String uploadId;
         public final long offset;
 
-        public ChunkedUploadState(String uploadId, long offset)
+        public ChunkedUploadState(@Nonnull String uploadId, long offset)
         {
             if (uploadId == null) throw new IllegalArgumentException("'uploadId' can't be null");
             if (uploadId.length() == 0) throw new IllegalArgumentException("'uploadId' can't be empty");
@@ -877,16 +877,16 @@ public final class DbxClientV1
             this.offset = offset;
         }
 
-        protected void dumpFields(DumpWriter w)
+        protected void dumpFields(@Nonnull DumpWriter w)
         {
             w.f("uploadId").v(uploadId);
             w.f("offset").v(offset);
         }
 
-        public static final JsonReader<ChunkedUploadState> Reader = new JsonReader<ChunkedUploadState>()
+        public static final @Nonnull JsonReader<ChunkedUploadState> Reader = new JsonReader<ChunkedUploadState>()
         {
             @Override
-            public ChunkedUploadState read(JsonParser parser) throws IOException, JsonReadException
+            public @Nonnull ChunkedUploadState read(@Nonnull JsonParser parser) throws IOException, JsonReadException
             {
                 JsonLocation top = JsonReader.expectObjectStart(parser);
 
@@ -925,7 +925,7 @@ public final class DbxClientV1
     /**
      * Internal function called by both chunkedUploadFirst and chunkedUploadAppend.
      */
-    private <E extends Throwable> HttpRequestor.Response chunkedUploadCommon(String[] params, long chunkSize, DbxStreamWriter<E> writer)
+    private <E extends Throwable> @Nonnull HttpRequestor.Response chunkedUploadCommon(@Nonnull String[] params, long chunkSize, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         String apiPath = "1/chunked_upload";
@@ -965,7 +965,7 @@ public final class DbxClientV1
         }
     }
 
-    private @Nullable ChunkedUploadState chunkedUploadCheckForOffsetCorrection(HttpRequestor.Response response)
+    private @Nullable ChunkedUploadState chunkedUploadCheckForOffsetCorrection(@Nonnull HttpRequestor.Response response)
         throws DbxException
     {
         if (response.getStatusCode() != 400) return null;
@@ -982,7 +982,7 @@ public final class DbxClientV1
         }
     }
 
-    private ChunkedUploadState chunkedUploadParse200(HttpRequestor.Response response)
+    private @Nonnull ChunkedUploadState chunkedUploadParse200(@Nonnull HttpRequestor.Response response)
         throws BadResponseException, NetworkIOException
     {
         assert response.getStatusCode() == 200 : response.getStatusCode();
@@ -993,7 +993,7 @@ public final class DbxClientV1
      * Equivalent to {@link #chunkedUploadFirst(byte[], int, int)
      * chunkedUploadFirst(data, 0, data.length)}.
      */
-    public String chunkedUploadFirst(byte[] data)
+    public @Nonnull String chunkedUploadFirst(@Nonnull byte[] data)
         throws DbxException
     {
         return chunkedUploadFirst(data, 0, data.length);
@@ -1012,7 +1012,7 @@ public final class DbxClientV1
      * @return
      *    The ID designated by the Dropbox server to identify the chunked upload.
      */
-    public String chunkedUploadFirst(byte[] data, int dataOffset, int dataLength)
+    public @Nonnull String chunkedUploadFirst(@Nonnull byte[] data, int dataOffset, int dataLength)
         throws DbxException
     {
         return chunkedUploadFirst(dataLength, new DbxStreamWriter.ByteArrayCopier(data, dataOffset, dataLength));
@@ -1031,7 +1031,7 @@ public final class DbxClientV1
      * @return
      *    The ID designated by the Dropbox server to identify the chunked upload.
      */
-    public <E extends Throwable> String chunkedUploadFirst(int chunkSize, DbxStreamWriter<E> writer)
+    public <E extends Throwable> @Nonnull String chunkedUploadFirst(int chunkSize, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         HttpRequestor.Response response = chunkedUploadCommon(new String[0], chunkSize, writer);
@@ -1066,7 +1066,7 @@ public final class DbxClientV1
      * Equivalent to {@link #chunkedUploadAppend(String, long, byte[], int, int)
      * chunkedUploadAppend(uploadId, uploadOffset, data, 0, data.length)}.
      */
-    public long chunkedUploadAppend(String uploadId, long uploadOffset, byte[] data)
+    public long chunkedUploadAppend(@Nonnull String uploadId, long uploadOffset, @Nonnull byte[] data)
         throws DbxException
     {
         return chunkedUploadAppend(uploadId, uploadOffset, data, 0, data.length);
@@ -1098,7 +1098,7 @@ public final class DbxClientV1
      *    match the actual number of bytes in the chunked upload session, returns the correct
      *    number of bytes.
      */
-    public long chunkedUploadAppend(String uploadId, long uploadOffset, byte[] data, int dataOffset, int dataLength)
+    public long chunkedUploadAppend(@Nonnull String uploadId, long uploadOffset, @Nonnull byte[] data, int dataOffset, int dataLength)
         throws DbxException
     {
         return chunkedUploadAppend(uploadId, uploadOffset, dataLength, new DbxStreamWriter.ByteArrayCopier(data, dataOffset, dataLength));
@@ -1128,7 +1128,7 @@ public final class DbxClientV1
      *    match the actual number of bytes in the chunked upload session, returns the correct
      *    number of bytes.
      */
-    public <E extends Throwable> long chunkedUploadAppend(String uploadId, long uploadOffset, long chunkSize, DbxStreamWriter<E> writer)
+    public <E extends Throwable> long chunkedUploadAppend(@Nonnull String uploadId, long uploadOffset, long chunkSize, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         if (uploadId == null) throw new IllegalArgumentException("'uploadId' can't be null");
@@ -1200,7 +1200,7 @@ public final class DbxClientV1
      * @param uploadId
      *     The identifier returned by {@link #chunkedUploadFirst} to identify the uploaded data.
      */
-    public DbxEntry.File chunkedUploadFinish(String targetPath, DbxWriteMode writeMode, String uploadId)
+    public @Nonnull DbxEntry.File chunkedUploadFinish(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, @Nonnull String uploadId)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("targetPath", targetPath);
@@ -1214,7 +1214,7 @@ public final class DbxClientV1
 
         return doPost(host.getContent(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.File>() {
             @Override
-            public DbxEntry.File handle(HttpRequestor.Response response) throws DbxException
+            public @Nonnull DbxEntry.File handle(@Nonnull HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
                 return DbxRequestUtil.readJsonFromResponse(DbxEntry.File.Reader, response);
@@ -1225,7 +1225,7 @@ public final class DbxClientV1
     /**
      * Similar to {@link #startUploadFile}, except always uses the chunked upload API.
      */
-    public Uploader startUploadFileChunked(String targetPath, DbxWriteMode writeMode, long numBytes)
+    public @Nonnull Uploader startUploadFileChunked(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes)
     {
         return startUploadFileChunked(ChunkedUploadChunkSize, targetPath, writeMode, numBytes);
     }
@@ -1233,7 +1233,7 @@ public final class DbxClientV1
     /**
      * Similar to {@link #startUploadFile}, except always uses the chunked upload API.
      */
-    public Uploader startUploadFileChunked(int chunkSize, String targetPath, DbxWriteMode writeMode, long numBytes)
+    public @Nonnull Uploader startUploadFileChunked(int chunkSize, @Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes)
     {
         DbxPathV1.checkArg("targetPath", targetPath);
         if (writeMode == null) throw new IllegalArgumentException("'writeMode' can't be null");
@@ -1244,7 +1244,7 @@ public final class DbxClientV1
     /**
      * Similar to {@link #uploadFile}, except always uses the chunked upload API.
      */
-    public <E extends Throwable> DbxEntry.File uploadFileChunked(String targetPath, DbxWriteMode writeMode, long numBytes, DbxStreamWriter<E> writer)
+    public <E extends Throwable> @Nonnull DbxEntry.File uploadFileChunked(@Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         Uploader uploader = startUploadFileChunked(targetPath, writeMode, numBytes);
@@ -1254,7 +1254,7 @@ public final class DbxClientV1
     /**
      * Similar to {@link #uploadFile}, except always uses the chunked upload API.
      */
-    public <E extends Throwable> DbxEntry.File uploadFileChunked(int chunkSize, String targetPath, DbxWriteMode writeMode, long numBytes, DbxStreamWriter<E> writer)
+    public <E extends Throwable> @Nonnull DbxEntry.File uploadFileChunked(int chunkSize, @Nonnull String targetPath, @Nonnull DbxWriteMode writeMode, long numBytes, @Nonnull DbxStreamWriter<E> writer)
         throws DbxException, E
     {
         Uploader uploader = startUploadFileChunked(chunkSize, targetPath, writeMode, numBytes);
@@ -1277,7 +1277,7 @@ public final class DbxClientV1
         }
 
         @Override
-        public OutputStream getBody()
+        public @Nonnull OutputStream getBody()
         {
             return body;
         }
@@ -1289,7 +1289,7 @@ public final class DbxClientV1
         }
 
         @Override
-        public DbxEntry.File finish()
+        public @Nonnull DbxEntry.File finish()
             throws DbxException
         {
             if (body.uploadId == null) {
@@ -1313,7 +1313,7 @@ public final class DbxClientV1
                 // to uploads, according to documentation, and (2) auto-retry is off by default,
                 // which would break backwards compatibility here.
                 return DbxRequestUtil.runAndRetry(3, new DbxRequestUtil.RequestMaker<DbxEntry.File, RuntimeException>() {
-                    public DbxEntry.File run() throws DbxException {
+                    public @Nonnull DbxEntry.File run() throws DbxException {
                         return chunkedUploadFinish(targetPath, writeMode, uploadId);
                     }
                 });
@@ -1372,7 +1372,7 @@ public final class DbxClientV1
                 // to uploads, according to documentation, and (2) auto-retry is off by default,
                 // which would break backwards compatibility here.
                 uploadId = DbxRequestUtil.runAndRetry(3, new DbxRequestUtil.RequestMaker<String, RuntimeException>() {
-                    public String run() throws DbxException {
+                    public @Nonnull String run() throws DbxException {
                         return chunkedUploadFirst(chunk, 0, chunkPos);
                     }
                 });
@@ -1384,7 +1384,7 @@ public final class DbxClientV1
                     final int arrayOffsetFinal = arrayOffset;
                     // don't use requestConfig.getMaxRetries() (see comment above)
                     long correctedOffset = DbxRequestUtil.runAndRetry(3, new DbxRequestUtil.RequestMaker<Long, RuntimeException>() {
-                        public Long run() throws DbxException {
+                        public @Nonnull Long run() throws DbxException {
                             return chunkedUploadAppend(uploadId, uploadOffset, chunk, arrayOffsetFinal, chunkPos-arrayOffsetFinal);
                         }
                     });
@@ -1440,9 +1440,9 @@ public final class DbxClientV1
     public static final class IODbxException extends IOException {
         private static final long serialVersionUID = 0L;
 
-        public final DbxException underlying;
+        public final @Nonnull DbxException underlying;
 
-        public IODbxException(DbxException underlying)
+        public IODbxException(@Nonnull DbxException underlying)
         {
             super(underlying);
             this.underlying = underlying;
@@ -1474,7 +1474,7 @@ public final class DbxClientV1
      * for the App Folder's contents.
      * </p>
      */
-    public DbxDelta<DbxEntry> getDelta(@Nullable String cursor, boolean includeMediaInfo)
+    public @Nonnull DbxDelta<DbxEntry> getDelta(@Nullable String cursor, boolean includeMediaInfo)
         throws DbxException
     {
         return _getDelta(cursor, null, includeMediaInfo);
@@ -1483,7 +1483,7 @@ public final class DbxClientV1
     /**
      * Same as {@link #getDelta(String, boolean)} with {@code includeMediaInfo} set to {@code false}.
      */
-    public DbxDelta<DbxEntry> getDelta(@Nullable String cursor)
+    public @Nonnull DbxDelta<DbxEntry> getDelta(@Nullable String cursor)
         throws DbxException
     {
         return getDelta(cursor, false);
@@ -1493,7 +1493,7 @@ public final class DbxClientV1
      * A more generic version of {@link #getDelta}.  You provide a <em>collector</em>,
      * which lets you process the delta entries as they arrive over the network.
      */
-    public <C> DbxDeltaC<C> getDeltaC(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor,
+    public <C> @Nonnull DbxDeltaC<C> getDeltaC(@Nonnull Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor,
                                       boolean includeMediaInfo)
         throws DbxException
     {
@@ -1503,7 +1503,7 @@ public final class DbxClientV1
     /**
      * Same as {@link #getDeltaC(Collector, String, boolean)} with {@code includeMediaInfo} set to {@code false}.
      */
-    public <C> DbxDeltaC<C> getDeltaC(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor)
+    public <C> @Nonnull DbxDeltaC<C> getDeltaC(@Nonnull Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor)
         throws DbxException
     {
         return getDeltaC(collector, cursor, false);
@@ -1522,7 +1522,7 @@ public final class DbxClientV1
      * @param pathPrefix
      *    A path on Dropbox to limit results to.
      */
-    public DbxDelta<DbxEntry> getDeltaWithPathPrefix(@Nullable String cursor, String pathPrefix,
+    public @Nonnull DbxDelta<DbxEntry> getDeltaWithPathPrefix(@Nullable String cursor, @Nonnull String pathPrefix,
                                                      boolean includeMediaInfo)
         throws DbxException
     {
@@ -1534,7 +1534,7 @@ public final class DbxClientV1
      * Same as {@link #getDeltaWithPathPrefix(String, String, boolean)} with {@code includeMediaInfo}
      * set to {@code false}.
      */
-    public DbxDelta<DbxEntry> getDeltaWithPathPrefix(@Nullable String cursor, String pathPrefix)
+    public @Nonnull DbxDelta<DbxEntry> getDeltaWithPathPrefix(@Nullable String cursor, @Nonnull String pathPrefix)
         throws DbxException
     {
         DbxPathV1.checkArg("path", pathPrefix);
@@ -1545,7 +1545,7 @@ public final class DbxClientV1
      * A more generic version of {@link #getDeltaWithPathPrefix}.  You provide a <em>collector</em>,
      * which lets you process the delta entries as they arrive over the network.
      */
-    public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, String pathPrefix,
+    public <C> @Nonnull DbxDeltaC<C> getDeltaCWithPathPrefix(@Nonnull Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, @Nonnull String pathPrefix,
                                                     boolean includeMediaInfo)
         throws DbxException
     {
@@ -1557,13 +1557,13 @@ public final class DbxClientV1
      * Same as {@link #getDeltaCWithPathPrefix(Collector, String, String, boolean)} with {@code includeMediaInfo}
      * set to {@code false}.
      */
-    public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, String pathPrefix)
+    public <C> @Nonnull DbxDeltaC<C> getDeltaCWithPathPrefix(@Nonnull Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, @Nonnull String pathPrefix)
         throws DbxException
     {
         return getDeltaCWithPathPrefix(collector, cursor, pathPrefix, false);
     }
 
-    private DbxDelta<DbxEntry> _getDelta(@Nullable String cursor, @Nullable String pathPrefix, boolean includeMediaInfo)
+    private @Nonnull DbxDelta<DbxEntry> _getDelta(@Nullable String cursor, @Nullable String pathPrefix, boolean includeMediaInfo)
         throws DbxException
     {
         String host = this.host.getApi();
@@ -1577,14 +1577,14 @@ public final class DbxClientV1
 
         return doPost(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxDelta<DbxEntry>>() {
             @Override
-            public DbxDelta<DbxEntry> handle(HttpRequestor.Response response) throws DbxException {
+            public @Nonnull DbxDelta<DbxEntry> handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
                 return DbxRequestUtil.readJsonFromResponse(new DbxDelta.Reader<DbxEntry>(DbxEntry.Reader), response);
             }
         });
     }
 
-    private <C> DbxDeltaC<C> _getDeltaC(final Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, @Nullable String pathPrefix,
+    private <C> @Nonnull DbxDeltaC<C> _getDeltaC(final @Nonnull Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor, @Nullable String pathPrefix,
                                         boolean includeMediaInfo)
         throws DbxException
     {
@@ -1599,7 +1599,7 @@ public final class DbxClientV1
 
         return doPost(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxDeltaC<C>>() {
             @Override
-            public DbxDeltaC<C> handle(HttpRequestor.Response response) throws DbxException {
+            public @Nonnull DbxDeltaC<C> handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
                 return DbxRequestUtil.readJsonFromResponse(new DbxDeltaC.Reader<C, DbxEntry>(DbxEntry.Reader, collector), response);
             }
@@ -1610,7 +1610,7 @@ public final class DbxClientV1
      * Get a cursor for the current state of a user's Dropbox folder. Can be passed to {@link #getDelta}
      * to retrieve changes since this method was called.
      */
-    public String getDeltaLatestCursor(boolean includeMediaInfo) throws DbxException
+    public @Nonnull String getDeltaLatestCursor(boolean includeMediaInfo) throws DbxException
     {
         return _getDeltaLatestCursor(null, includeMediaInfo);
     }
@@ -1619,7 +1619,7 @@ public final class DbxClientV1
      * Same as {@link #getDeltaLatestCursor(boolean)} with {@code includeMediaInfo}
      * set to {@code false}.
      */
-    public String getDeltaLatestCursor() throws DbxException
+    public @Nonnull String getDeltaLatestCursor() throws DbxException
     {
         return _getDeltaLatestCursor(null, false);
     }
@@ -1631,7 +1631,7 @@ public final class DbxClientV1
      * @param pathPrefix
      *    A path on Dropbox to limit the cursor to.
      */
-    public String getDeltaLatestCursorWithPathPrefix(String pathPrefix, boolean includeMediaInfo) throws DbxException
+    public @Nonnull String getDeltaLatestCursorWithPathPrefix(@Nonnull String pathPrefix, boolean includeMediaInfo) throws DbxException
     {
         DbxPathV1.checkArg("path", pathPrefix);
         return _getDeltaLatestCursor(pathPrefix, includeMediaInfo);
@@ -1641,12 +1641,12 @@ public final class DbxClientV1
      * Same as {@link #getDeltaLatestCursorWithPathPrefix(String, boolean)} with {@code includeMediaInfo}
      * set to {@code false}.
      */
-    public String getDeltaLatestCursorWithPathPrefix(String pathPrefix) throws DbxException
+    public @Nonnull String getDeltaLatestCursorWithPathPrefix(@Nonnull String pathPrefix) throws DbxException
     {
         return getDeltaLatestCursorWithPathPrefix(pathPrefix, false);
     }
 
-    private String _getDeltaLatestCursor(@Nullable String pathPrefix, boolean includeMediaInfo) throws DbxException
+    private @Nonnull String _getDeltaLatestCursor(@Nullable String pathPrefix, boolean includeMediaInfo) throws DbxException
     {
         String host = this.host.getApi();
         String apiPath = "1/delta/latest_cursor";
@@ -1658,16 +1658,16 @@ public final class DbxClientV1
 
         return doPost(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<String>() {
             @Override
-            public String handle(HttpRequestor.Response response) throws DbxException {
+            public @Nonnull String handle(@Nonnull HttpRequestor.Response response) throws DbxException {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
                 return DbxRequestUtil.readJsonFromResponse(LatestCursorReader, response);
             }
         });
     }
 
-    private static JsonReader<String> LatestCursorReader = new JsonReader<String>() {
+    private static @Nonnull JsonReader<String> LatestCursorReader = new JsonReader<String>() {
         @Override
-        public String read(JsonParser parser) throws IOException, JsonReadException {
+        public @Nonnull String read(@Nonnull JsonParser parser) throws IOException, JsonReadException {
             JsonLocation top = JsonReader.expectObjectStart(parser);
 
             String cursorId = null;
@@ -1704,7 +1704,7 @@ public final class DbxClientV1
      * @param timeout
      *          How long poll should run before timing out, in seconds.
      */
-    public DbxLongpollDeltaResult getLongpollDelta(String cursor, int timeout)
+    public @Nonnull DbxLongpollDeltaResult getLongpollDelta(@Nonnull String cursor, int timeout)
         throws DbxException
     {
         if (cursor == null) throw new IllegalArgumentException("'cursor' can't be null");
@@ -1724,7 +1724,7 @@ public final class DbxClientV1
             null,
             new DbxRequestUtil.ResponseHandler<DbxLongpollDeltaResult>() {
                 @Override
-                public DbxLongpollDeltaResult handle(HttpRequestor.Response response)
+                public @Nonnull DbxLongpollDeltaResult handle(@Nonnull HttpRequestor.Response response)
                     throws DbxException
                 {
                     if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -1761,8 +1761,8 @@ public final class DbxClientV1
      *    is no file at that path.
      */
     public @Nullable DbxEntry.File getThumbnail(
-            DbxThumbnailSize sizeBound, DbxThumbnailFormat format,
-            String path, @Nullable String rev, OutputStream target)
+            @Nonnull DbxThumbnailSize sizeBound, @Nonnull DbxThumbnailFormat format,
+            @Nonnull String path, @Nullable String rev, @Nonnull OutputStream target)
             throws DbxException, IOException
     {
         if (target == null) throw new IllegalArgumentException("'target' can't be null");
@@ -1777,7 +1777,7 @@ public final class DbxClientV1
      * a {@link Downloader}.
      */
     public @Nullable Downloader startGetThumbnail(
-            DbxThumbnailSize sizeBound, DbxThumbnailFormat format, String path, @Nullable String rev)
+            @Nonnull DbxThumbnailSize sizeBound, @Nonnull DbxThumbnailFormat format, @Nonnull String path, @Nullable String rev)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1806,7 +1806,7 @@ public final class DbxClientV1
      * @return
      *     A list of metadata objects, one for each file revision.
      */
-    public List<DbxEntry.File> getRevisions(String path)
+    public @Nonnull List<DbxEntry.File> getRevisions(@Nonnull String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1814,7 +1814,7 @@ public final class DbxClientV1
         String apiPath = "1/revisions/auto" + path;
 
         return doGet(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<List<DbxEntry.File>>() {
-            public List<DbxEntry.File> handle(HttpRequestor.Response response)
+            public @Nonnull List<DbxEntry.File> handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -1840,7 +1840,7 @@ public final class DbxClientV1
      *     If the specified {@code path}/{@code rev} couldn't be found, return {@code null}.
      *     Otherwise, return metadata for the newly-created latest revision of the file.
      */
-    public @Nullable DbxEntry.File restoreFile(String path, String rev)
+    public @Nullable DbxEntry.File restoreFile(@Nonnull String path, @Nonnull String rev)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1853,7 +1853,7 @@ public final class DbxClientV1
         };
 
         return doGet(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.File>() {
-            public @Nullable DbxEntry.File handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry.File handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -1874,7 +1874,7 @@ public final class DbxClientV1
      * @return
      *    The list of metadata entries that match the search query.
      */
-    public List<DbxEntry> searchFileAndFolderNames(String basePath, String query)
+    public @Nonnull List<DbxEntry> searchFileAndFolderNames(@Nonnull String basePath, @Nonnull String query)
         throws DbxException
     {
         DbxPathV1.checkArg("basePath", basePath);
@@ -1887,7 +1887,7 @@ public final class DbxClientV1
         return doPost(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<List<DbxEntry>>()
         {
             @Override
-            public List<DbxEntry> handle(HttpRequestor.Response response)
+            public @Nonnull List<DbxEntry> handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -1908,7 +1908,7 @@ public final class DbxClientV1
      *     If there is no file or folder at that path, return {@code null}.  Otherwise return
      *     a shareable URL.
      */
-    public @Nullable String createShareableUrl(String path)
+    public @Nullable String createShareableUrl(@Nonnull String path)
         throws DbxException
     {
         DbxPathV1.checkArg("path", path);
@@ -1918,7 +1918,7 @@ public final class DbxClientV1
 
         return doPost(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<String>() {
             @Override
-            public @Nullable String handle(HttpRequestor.Response response)
+            public @Nullable String handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -1940,7 +1940,7 @@ public final class DbxClientV1
      *     If there is no file at that path, return {@code null}.  Otherwise return
      *     a shareable URL along with the expiration time.
      */
-    public @Nullable DbxUrlWithExpiration createTemporaryDirectUrl(String path)
+    public @Nullable DbxUrlWithExpiration createTemporaryDirectUrl(@Nonnull String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1949,7 +1949,7 @@ public final class DbxClientV1
 
         return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<DbxUrlWithExpiration>() {
             @Override
-            public @Nullable DbxUrlWithExpiration handle(HttpRequestor.Response response)
+            public @Nullable DbxUrlWithExpiration handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -1980,7 +1980,7 @@ public final class DbxClientV1
      *     The copy ref's identifier, suitable for passing in to {@link #copyFromCopyRef},
      *     or {@code null} if the specified path does not exist.
      */
-    public @Nullable String createCopyRef(String path)
+    public @Nullable String createCopyRef(@Nonnull String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1990,7 +1990,7 @@ public final class DbxClientV1
         return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<String>()
         {
             @Override
-            public @Nullable String handle(HttpRequestor.Response response)
+            public @Nullable String handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -2003,18 +2003,18 @@ public final class DbxClientV1
 
     private static final class CopyRef
     {
-        public final String id;
-        public final Date expires;
+        public final @Nonnull String id;
+        public final @Nonnull Date expires;
 
-        private CopyRef(String id, Date expires)
+        private CopyRef(@Nonnull String id, @Nonnull Date expires)
         {
             this.id = id;
             this.expires = expires;
         }
 
-        public static final JsonReader<CopyRef> Reader = new JsonReader<CopyRef>() {
+        public static final @Nonnull JsonReader<CopyRef> Reader = new JsonReader<CopyRef>() {
             @Override
-            public CopyRef read(JsonParser parser)
+            public @Nonnull CopyRef read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -2059,7 +2059,7 @@ public final class DbxClientV1
      *    If successful, returns the metadata for new copy of the file or folder,
      *    otherwise returns {@code null}.
      */
-    public @Nullable DbxEntry copy(String fromPath, String toPath)
+    public @Nullable DbxEntry copy(@Nonnull String fromPath, @Nonnull String toPath)
         throws DbxException
     {
         DbxPathV1.checkArg("fromPath", fromPath);
@@ -2073,7 +2073,7 @@ public final class DbxClientV1
 
         return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>() {
             @Override
-            public @Nullable DbxEntry handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 403) return null;
@@ -2089,7 +2089,7 @@ public final class DbxClientV1
      * Create a file or folder at {@code toPath} based on the given copy ref (created with
      * {@link #createCopyRef}).
      */
-    public @Nullable DbxEntry copyFromCopyRef(String copyRef, String toPath)
+    public @Nullable DbxEntry copyFromCopyRef(@Nonnull String copyRef, @Nonnull String toPath)
         throws DbxException
     {
         if (copyRef == null) throw new IllegalArgumentException("'copyRef' can't be null");
@@ -2105,7 +2105,7 @@ public final class DbxClientV1
         return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>()
         {
             @Override
-            public @Nullable DbxEntry handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -2123,7 +2123,7 @@ public final class DbxClientV1
      *    If successful, returns the metadata for the newly created folder, otherwise
      *    returns {@code null}.
      */
-    public @Nullable DbxEntry.Folder createFolder(String path)
+    public @Nullable DbxEntry.Folder createFolder(@Nonnull String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -2135,7 +2135,7 @@ public final class DbxClientV1
 
         return doPost(host.getApi(), "1/fileops/create_folder", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.Folder>() {
             @Override
-            public @Nullable DbxEntry.Folder handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry.Folder handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 403) return null;
@@ -2148,7 +2148,7 @@ public final class DbxClientV1
     /**
      * Delete a file or folder from Dropbox.
      */
-    public void delete(String path)
+    public void delete(@Nonnull String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -2160,7 +2160,7 @@ public final class DbxClientV1
 
         doPost(host.getApi(), "1/fileops/delete", params, null, new DbxRequestUtil.ResponseHandler<Void>() {
             @Override
-            public Void handle(HttpRequestor.Response response)
+            public @Nullable Void handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -2176,7 +2176,7 @@ public final class DbxClientV1
      *    If successful, returns the metadata for the file or folder at its new location,
      *    otherwise returns {@code null}.
      */
-    public @Nullable DbxEntry move(String fromPath, String toPath)
+    public @Nullable DbxEntry move(@Nonnull String fromPath, @Nonnull String toPath)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("fromPath", fromPath);
@@ -2191,7 +2191,7 @@ public final class DbxClientV1
         return doPost(host.getApi(), "1/fileops/move", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry>()
         {
             @Override
-            public @Nullable DbxEntry handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry handle(@Nonnull HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 403) return null;
@@ -2215,10 +2215,10 @@ public final class DbxClientV1
     }
 
     // Convenience function that calls RequestUtil.doPost with the first two parameters filled in.
-    public <T> T doPost(String host, String path,
+    public <T> @Nullable T doPost(@Nonnull String host, @Nonnull String path,
                         @Nullable String[] params,
                         @Nullable ArrayList<HttpRequestor.Header> headers,
-                        DbxRequestUtil.ResponseHandler<T> handler)
+                        @Nonnull DbxRequestUtil.ResponseHandler<T> handler)
         throws DbxException
     {
         return DbxRequestUtil.doPost(requestConfig, accessToken, USER_AGENT_ID, host, path, params, headers, handler);
@@ -2247,7 +2247,7 @@ public final class DbxClientV1
      */
     public static abstract class Uploader
     {
-        public abstract OutputStream getBody();
+        public abstract @Nonnull OutputStream getBody();
 
         /**
          * Cancel the upload.
@@ -2266,6 +2266,6 @@ public final class DbxClientV1
          * to indicate that you're done.  This will actually finish the underlying HTTP
          * request and return the uploaded file's {@link DbxEntry}.
          */
-        public abstract DbxEntry.File finish() throws DbxException;
+        public abstract @Nonnull DbxEntry.File finish() throws DbxException;
     }
 }

--- a/core/src/main/java/com/dropbox/core/v1/DbxClientV1.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxClientV1.java
@@ -1,5 +1,9 @@
 package com.dropbox.core.v1;
 
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -20,10 +24,6 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import static com.dropbox.core.util.StringUtil.jq;
 
-/*>>> import checkers.nullness.quals.NonNull; */
-/*>>> import checkers.nullness.quals.Nullable; */
-/*>>> import checkers.nullness.quals.MonotonicNonNull; */
-/*>>> import checkers.initialization.quals.Initialized; */
 
 /**
  * Use this class to make remote calls to the Dropbox API.  You'll need an access token first,
@@ -112,21 +112,21 @@ public final class DbxClientV1
      *    metadata for that path.  If there is no file or folder there,
      *    return {@code null}.
      */
-    public /*@Nullable*/DbxEntry getMetadata(final String path, boolean includeMediaInfo)
+    public @Nullable DbxEntry getMetadata(final String path, boolean includeMediaInfo)
         throws DbxException
     {
         DbxPathV1.checkArg("path", path);
 
         String host = this.host.getApi();
         String apiPath = "1/metadata/auto" + path;
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "list", "false",
             "include_media_info", includeMediaInfo ? "true" : null,
         };
 
-        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/DbxEntry>() {
+        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>() {
             @Override
-            public /*@Nullable*/DbxEntry handle(HttpRequestor.Response response) throws DbxException
+            public @Nullable DbxEntry handle(HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -140,7 +140,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadata(String, boolean)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public /*@Nullable*/DbxEntry getMetadata(final String path)
+    public @Nullable DbxEntry getMetadata(final String path)
         throws DbxException
     {
         return getMetadata(path, false);
@@ -171,7 +171,7 @@ public final class DbxClientV1
      *    Otherwise, return the metadata for that path and the metadata for all its immediate
      *    children (if it's a folder).
      */
-    public DbxEntry./*@Nullable*/WithChildren getMetadataWithChildren(String path, boolean includeMediaInfo)
+    public DbxEntry.@Nullable WithChildren getMetadataWithChildren(String path, boolean includeMediaInfo)
         throws DbxException
     {
         return getMetadataWithChildrenBase(path, includeMediaInfo, DbxEntry.WithChildren.ReaderMaybeDeleted);
@@ -181,7 +181,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildren(String, boolean)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public DbxEntry./*@Nullable*/WithChildren getMetadataWithChildren(String path)
+    public DbxEntry.@Nullable WithChildren getMetadataWithChildren(String path)
         throws DbxException
     {
         return getMetadataWithChildren(path, false);
@@ -201,7 +201,7 @@ public final class DbxClientV1
      * the entire call succeeds.
      * </p>
      */
-    public <C> DbxEntry./*@Nullable*/WithChildrenC<C> getMetadataWithChildrenC(String path, boolean includeMediaInfo, final Collector<DbxEntry, ? extends C> collector)
+    public <C> DbxEntry.@Nullable WithChildrenC<C> getMetadataWithChildrenC(String path, boolean includeMediaInfo, final Collector<DbxEntry, ? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenBase(path, includeMediaInfo, new DbxEntry.WithChildrenC.ReaderMaybeDeleted<C>(collector));
@@ -211,13 +211,13 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenC(String, boolean, Collector)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public <C> DbxEntry./*@Nullable*/WithChildrenC<C> getMetadataWithChildrenC(String path, final Collector<DbxEntry, ? extends C> collector)
+    public <C> DbxEntry.@Nullable WithChildrenC<C> getMetadataWithChildrenC(String path, final Collector<DbxEntry, ? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenC(path, false, collector);
     }
 
-    private <T> /*@Nullable*/T getMetadataWithChildrenBase(String path, boolean includeMediaInfo, final JsonReader<? extends T> reader)
+    private <T> @Nullable T getMetadataWithChildrenBase(String path, boolean includeMediaInfo, final JsonReader<? extends T> reader)
         throws DbxException
     {
         DbxPathV1.checkArg("path", path);
@@ -225,15 +225,15 @@ public final class DbxClientV1
         String host = this.host.getApi();
         String apiPath = "1/metadata/auto" + path;
 
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "list", "true",
             "file_limit", "25000",
             "include_media_info", includeMediaInfo ? "true" : null,
         };
 
-        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/T>() {
+        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<@Nullable T>() {
             @Override
-            public /*@Nullable*/T handle(HttpRequestor.Response response) throws DbxException
+            public @Nullable T handle(HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -261,7 +261,7 @@ public final class DbxClientV1
      *    {@code Maybe.Just(null)} if there's nothing there or {@code Maybe.Just} with the
      *    metadata.
      */
-    public Maybe<DbxEntry./*@Nullable*/WithChildren> getMetadataWithChildrenIfChanged(String path, boolean includeMediaInfo, /*@Nullable*/String previousFolderHash)
+    public Maybe<DbxEntry.@Nullable WithChildren> getMetadataWithChildrenIfChanged(String path, boolean includeMediaInfo, @Nullable String previousFolderHash)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedBase(path, includeMediaInfo, previousFolderHash, DbxEntry.WithChildren.ReaderMaybeDeleted);
@@ -271,7 +271,7 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenIfChanged(String, boolean, String)} with {@code includeMediaInfo} set
      * to {@code false}.
      */
-    public Maybe<DbxEntry./*@Nullable*/WithChildren> getMetadataWithChildrenIfChanged(String path, /*@Nullable*/String previousFolderHash)
+    public Maybe<DbxEntry.@Nullable WithChildren> getMetadataWithChildrenIfChanged(String path, @Nullable String previousFolderHash)
         throws DbxException
     {
         return getMetadataWithChildrenIfChanged(path, false, previousFolderHash);
@@ -291,8 +291,8 @@ public final class DbxClientV1
      * the entire call succeeds.
      * </p>
      */
-    public <C> Maybe<DbxEntry./*@Nullable*/WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
-            String path, boolean includeMediaInfo, /*@Nullable*/String previousFolderHash, Collector<DbxEntry,? extends C> collector)
+    public <C> Maybe<DbxEntry.@Nullable WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
+            String path, boolean includeMediaInfo, @Nullable String previousFolderHash, Collector<DbxEntry,? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedBase(path, includeMediaInfo, previousFolderHash, new DbxEntry.WithChildrenC.ReaderMaybeDeleted<C>(collector));
@@ -302,15 +302,15 @@ public final class DbxClientV1
      * Same as {@link #getMetadataWithChildrenIfChangedC(String, boolean, String, Collector)} with
      * {@code includeMediaInfo} set to {@code false}.
      */
-    public <C> Maybe<DbxEntry./*@Nullable*/WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
-            String path, /*@Nullable*/String previousFolderHash, Collector<DbxEntry,? extends C> collector)
+    public <C> Maybe<DbxEntry.@Nullable WithChildrenC<C>> getMetadataWithChildrenIfChangedC(
+            String path, @Nullable String previousFolderHash, Collector<DbxEntry,? extends C> collector)
         throws DbxException
     {
         return getMetadataWithChildrenIfChangedC(path, false, previousFolderHash, collector);
     }
 
-    private <T> Maybe</*@Nullable*/T> getMetadataWithChildrenIfChangedBase(
-            String path, boolean includeMediaInfo, /*@Nullable*/String previousFolderHash, final JsonReader<T> reader)
+    private <T> Maybe<@Nullable T> getMetadataWithChildrenIfChangedBase(
+            String path, boolean includeMediaInfo, @Nullable String previousFolderHash, final JsonReader<T> reader)
         throws DbxException
     {
         if (previousFolderHash == null) throw new IllegalArgumentException("'previousFolderHash' must not be null");
@@ -320,22 +320,22 @@ public final class DbxClientV1
         String host = this.host.getApi();
         String apiPath = "1/metadata/auto" + path;
 
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "list", "true",
             "file_limit", "25000",
             "hash", previousFolderHash,
             "include_media_info", includeMediaInfo ? "true" : null,
         };
 
-        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<Maybe</*@Nullable*/T>>() {
+        return doGet(host, apiPath, params, null, new DbxRequestUtil.ResponseHandler<Maybe<@Nullable T>>() {
             @Override
-            public Maybe</*@Nullable*/T> handle(HttpRequestor.Response response) throws DbxException
+            public Maybe<@Nullable T> handle(HttpRequestor.Response response) throws DbxException
             {
-                if (response.getStatusCode() == 404) return Maybe.</*@Nullable*/T>Just(null);
-                if (response.getStatusCode() == 304) return Maybe.</*@Nullable*/T>Nothing();
+                if (response.getStatusCode() == 404) return Maybe.<@Nullable T>Just(null);
+                if (response.getStatusCode() == 304) return Maybe.<@Nullable T>Nothing();
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
 
-                return Maybe.</*@Nullable*/T>Just(DbxRequestUtil.readJsonFromResponse(reader, response));
+                return Maybe.<@Nullable T>Just(DbxRequestUtil.readJsonFromResponse(reader, response));
             }
         });
     }
@@ -377,9 +377,9 @@ public final class DbxClientV1
         String host = this.host.getApi();
         String apiPath = "1/disable_access_token";
 
-        doPost(host, apiPath, null, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/Void>() {
+        doPost(host, apiPath, null, null, new DbxRequestUtil.ResponseHandler<@Nullable Void>() {
             @Override
-            public /*@Nullable*/Void handle(HttpRequestor.Response response) throws DbxException
+            public @Nullable Void handle(HttpRequestor.Response response) throws DbxException
             {
                 if (response.getStatusCode() != 200) {
                     String requestId = DbxRequestUtil.getRequestId(response);
@@ -419,7 +419,7 @@ public final class DbxClientV1
      * @throws IOException
      *    If there's an error writing to {@code target}.
      */
-    public DbxEntry./*@Nullable*/File getFile(String path, /*@Nullable*/String rev, OutputStream target)
+    public DbxEntry.@Nullable File getFile(String path, @Nullable String rev, OutputStream target)
         throws DbxException, IOException
     {
         Downloader downloader = startGetFile(path, rev);
@@ -454,12 +454,12 @@ public final class DbxClientV1
      *     An object that can be used to download the file contents, or
      *     {@code null} if there is no file at the requested path.
      */
-    public /*@Nullable*/Downloader startGetFile(final String path, /*@Nullable*/String rev)
+    public @Nullable Downloader startGetFile(final String path, @Nullable String rev)
             throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
         String apiPath = "1/files/auto" + path;
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "rev", rev
         };
         return startGetSomething(apiPath, params);
@@ -468,8 +468,8 @@ public final class DbxClientV1
     /**
      * Generic function that downloads either files or thumbnails.
      */
-    private /*@Nullable*/Downloader startGetSomething(final String apiPath,
-                                                      final /*@Nullable*/String[] params)
+    private @Nullable Downloader startGetSomething(final String apiPath,
+                                                      final @Nullable String[] params)
         throws DbxException
     {
         final String host = this.host.getContent();
@@ -760,7 +760,7 @@ public final class DbxClientV1
 
     private static final class SingleUploader extends Uploader
     {
-        private HttpRequestor./*@Nullable*/Uploader httpUploader;
+        private HttpRequestor.@Nullable Uploader httpUploader;
         private final long claimedBytes;
         private final CountingOutputStream body;
 
@@ -843,7 +843,7 @@ public final class DbxClientV1
             }
 
             @SuppressWarnings("nullness")  // Workaround for bug in Checker Framework: https://code.google.com/p/checker-framework/issues/detail?id=293
-            final HttpRequestor./*@Initialized*//*@NonNull*/Response nonNullResponse = response;
+            final HttpRequestor.@Initialized @NonNull Response nonNullResponse = response;
 
             return DbxRequestUtil.finishResponse(nonNullResponse, new DbxRequestUtil.ResponseHandler<DbxEntry.File>() {
                 @Override
@@ -967,7 +967,7 @@ public final class DbxClientV1
         }
     }
 
-    private /*@Nullable*/ChunkedUploadState chunkedUploadCheckForOffsetCorrection(HttpRequestor.Response response)
+    private @Nullable ChunkedUploadState chunkedUploadCheckForOffsetCorrection(HttpRequestor.Response response)
         throws DbxException
     {
         if (response.getStatusCode() != 400) return null;
@@ -1333,7 +1333,7 @@ public final class DbxClientV1
     {
         private final byte[] chunk;
         private int chunkPos = 0;
-        private /*@MonotonicNonNull*/String uploadId;
+        private @MonotonicNonNull String uploadId;
         private long uploadOffset;
 
         private ChunkedUploadOutputStream(int chunkSize)
@@ -1476,7 +1476,7 @@ public final class DbxClientV1
      * for the App Folder's contents.
      * </p>
      */
-    public DbxDelta<DbxEntry> getDelta(/*@Nullable*/String cursor, boolean includeMediaInfo)
+    public DbxDelta<DbxEntry> getDelta(@Nullable String cursor, boolean includeMediaInfo)
         throws DbxException
     {
         return _getDelta(cursor, null, includeMediaInfo);
@@ -1485,7 +1485,7 @@ public final class DbxClientV1
     /**
      * Same as {@link #getDelta(String, boolean)} with {@code includeMediaInfo} set to {@code false}.
      */
-    public DbxDelta<DbxEntry> getDelta(/*@Nullable*/String cursor)
+    public DbxDelta<DbxEntry> getDelta(@Nullable String cursor)
         throws DbxException
     {
         return getDelta(cursor, false);
@@ -1495,7 +1495,7 @@ public final class DbxClientV1
      * A more generic version of {@link #getDelta}.  You provide a <em>collector</em>,
      * which lets you process the delta entries as they arrive over the network.
      */
-    public <C> DbxDeltaC<C> getDeltaC(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, /*@Nullable*/String cursor,
+    public <C> DbxDeltaC<C> getDeltaC(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor,
                                       boolean includeMediaInfo)
         throws DbxException
     {
@@ -1505,7 +1505,7 @@ public final class DbxClientV1
     /**
      * Same as {@link #getDeltaC(Collector, String, boolean)} with {@code includeMediaInfo} set to {@code false}.
      */
-    public <C> DbxDeltaC<C> getDeltaC(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, /*@Nullable*/String cursor)
+    public <C> DbxDeltaC<C> getDeltaC(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector, @Nullable String cursor)
         throws DbxException
     {
         return getDeltaC(collector, cursor, false);
@@ -1524,7 +1524,7 @@ public final class DbxClientV1
      * @param pathPrefix
      *    A path on Dropbox to limit results to.
      */
-    public DbxDelta<DbxEntry> getDeltaWithPathPrefix(/*@Nullable*/String cursor, String pathPrefix,
+    public DbxDelta<DbxEntry> getDeltaWithPathPrefix(@Nullable String cursor, String pathPrefix,
                                                      boolean includeMediaInfo)
         throws DbxException
     {
@@ -1536,7 +1536,7 @@ public final class DbxClientV1
      * Same as {@link #getDeltaWithPathPrefix(String, String, boolean)} with {@code includeMediaInfo}
      * set to {@code false}.
      */
-    public DbxDelta<DbxEntry> getDeltaWithPathPrefix(/*@Nullable*/String cursor, String pathPrefix)
+    public DbxDelta<DbxEntry> getDeltaWithPathPrefix(@Nullable String cursor, String pathPrefix)
         throws DbxException
     {
         DbxPathV1.checkArg("path", pathPrefix);
@@ -1548,7 +1548,7 @@ public final class DbxClientV1
      * which lets you process the delta entries as they arrive over the network.
      */
     public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector,
-                                                    /*@Nullable*/String cursor, String pathPrefix,
+                                                    @Nullable String cursor, String pathPrefix,
                                                     boolean includeMediaInfo)
         throws DbxException
     {
@@ -1561,19 +1561,19 @@ public final class DbxClientV1
      * set to {@code false}.
      */
     public <C> DbxDeltaC<C> getDeltaCWithPathPrefix(Collector<DbxDeltaC.Entry<DbxEntry>, C> collector,
-                                                    /*@Nullable*/String cursor, String pathPrefix)
+                                                    @Nullable String cursor, String pathPrefix)
         throws DbxException
     {
         return getDeltaCWithPathPrefix(collector, cursor, pathPrefix, false);
     }
 
-    private DbxDelta<DbxEntry> _getDelta(/*@Nullable*/String cursor, /*@Nullable*/String pathPrefix, boolean includeMediaInfo)
+    private DbxDelta<DbxEntry> _getDelta(@Nullable String cursor, @Nullable String pathPrefix, boolean includeMediaInfo)
         throws DbxException
     {
         String host = this.host.getApi();
         String apiPath = "1/delta";
 
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "cursor", cursor,
             "path_prefix", pathPrefix,
             "include_media_info", includeMediaInfo ? "true" : null,
@@ -1589,14 +1589,14 @@ public final class DbxClientV1
     }
 
     private <C> DbxDeltaC<C> _getDeltaC(final Collector<DbxDeltaC.Entry<DbxEntry>, C> collector,
-                                        /*@Nullable*/String cursor, /*@Nullable*/String pathPrefix,
+                                        @Nullable String cursor, @Nullable String pathPrefix,
                                         boolean includeMediaInfo)
         throws DbxException
     {
         String host = this.host.getApi();
         String apiPath = "1/delta";
 
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "cursor", cursor,
             "path_prefix", pathPrefix,
             "include_media_info", includeMediaInfo ? "true" : null,
@@ -1651,12 +1651,12 @@ public final class DbxClientV1
         return getDeltaLatestCursorWithPathPrefix(pathPrefix, false);
     }
 
-    private String _getDeltaLatestCursor(/*@Nullable*/String pathPrefix, boolean includeMediaInfo) throws DbxException
+    private String _getDeltaLatestCursor(@Nullable String pathPrefix, boolean includeMediaInfo) throws DbxException
     {
         String host = this.host.getApi();
         String apiPath = "1/delta/latest_cursor";
 
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "path_prefix", pathPrefix,
             "include_media_info", includeMediaInfo ? "true" : null,
         };
@@ -1765,9 +1765,9 @@ public final class DbxClientV1
      *    The metadata for the original file (not the thumbnail) or {@code null} if there
      *    is no file at that path.
      */
-    public DbxEntry./*@Nullable*/File getThumbnail(
+    public DbxEntry.@Nullable File getThumbnail(
             DbxThumbnailSize sizeBound, DbxThumbnailFormat format,
-            String path, /*@Nullable*/String rev, OutputStream target)
+            String path, @Nullable String rev, OutputStream target)
             throws DbxException, IOException
     {
         if (target == null) throw new IllegalArgumentException("'target' can't be null");
@@ -1781,8 +1781,8 @@ public final class DbxClientV1
      * Similar to {@link #getThumbnail}, except the thumbnail contents are returned via
      * a {@link Downloader}.
      */
-    public /*@Nullable*/Downloader startGetThumbnail(
-            DbxThumbnailSize sizeBound, DbxThumbnailFormat format, String path, /*@Nullable*/String rev)
+    public @Nullable Downloader startGetThumbnail(
+            DbxThumbnailSize sizeBound, DbxThumbnailFormat format, String path, @Nullable String rev)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1790,7 +1790,7 @@ public final class DbxClientV1
         if (format == null) throw new IllegalArgumentException("'format' can't be null");
 
         String apiPath = "1/thumbnails/auto" + path;
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "size", sizeBound.ident,
             "format", format.ident,
             "rev", rev,
@@ -1823,7 +1823,7 @@ public final class DbxClientV1
                 throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
-                Collector<DbxEntry./*@Nullable*/File,ArrayList<DbxEntry.File>> collector =
+                Collector<DbxEntry.@Nullable File,ArrayList<DbxEntry.File>> collector =
                     Collector.NullSkipper.<DbxEntry.File,ArrayList<DbxEntry.File>>mk(new Collector.ArrayListCollector<DbxEntry.File>());
                 return DbxRequestUtil.readJsonFromResponse(JsonArrayReader.mk(DbxEntry.File.ReaderMaybeDeleted, collector), response);
             }
@@ -1845,7 +1845,7 @@ public final class DbxClientV1
      *     If the specified {@code path}/{@code rev} couldn't be found, return {@code null}.
      *     Otherwise, return metadata for the newly-created latest revision of the file.
      */
-    public DbxEntry./*@Nullable*/File restoreFile(String path, String rev)
+    public DbxEntry.@Nullable File restoreFile(String path, String rev)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -1853,12 +1853,12 @@ public final class DbxClientV1
         if (rev.length() == 0) throw new IllegalArgumentException("'rev' can't be empty");
 
         String apiPath = "1/restore/auto" + path;
-        /*@Nullable*/String[] params = {
+        @Nullable String[] params = {
             "rev", rev,
         };
 
-        return doGet(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry./*@Nullable*/File>() {
-            public DbxEntry./*@Nullable*/File handle(HttpRequestor.Response response)
+        return doGet(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.@Nullable File>() {
+            public DbxEntry.@Nullable File handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -1913,7 +1913,7 @@ public final class DbxClientV1
      *     If there is no file or folder at that path, return {@code null}.  Otherwise return
      *     a shareable URL.
      */
-    public /*@Nullable*/String createShareableUrl(String path)
+    public @Nullable String createShareableUrl(String path)
         throws DbxException
     {
         DbxPathV1.checkArg("path", path);
@@ -1921,9 +1921,9 @@ public final class DbxClientV1
         String apiPath = "1/shares/auto" + path;
         String[] params = {"short_url", "false"};
 
-        return doPost(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/String>() {
+        return doPost(host.getApi(), apiPath, params, null, new DbxRequestUtil.ResponseHandler<@Nullable String>() {
             @Override
-            public /*@Nullable*/String handle(HttpRequestor.Response response)
+            public @Nullable String handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -1945,16 +1945,16 @@ public final class DbxClientV1
      *     If there is no file at that path, return {@code null}.  Otherwise return
      *     a shareable URL along with the expiration time.
      */
-    public /*@Nullable*/DbxUrlWithExpiration createTemporaryDirectUrl(String path)
+    public @Nullable DbxUrlWithExpiration createTemporaryDirectUrl(String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
 
         String apiPath = "1/media/auto" + path;
 
-        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/DbxUrlWithExpiration>() {
+        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxUrlWithExpiration>() {
             @Override
-            public /*@Nullable*/DbxUrlWithExpiration handle(HttpRequestor.Response response)
+            public @Nullable DbxUrlWithExpiration handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -1985,17 +1985,17 @@ public final class DbxClientV1
      *     The copy ref's identifier, suitable for passing in to {@link #copyFromCopyRef},
      *     or {@code null} if the specified path does not exist.
      */
-    public /*@Nullable*/String createCopyRef(String path)
+    public @Nullable String createCopyRef(String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
 
         String apiPath = "1/copy_ref/auto" + path;
 
-        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/String>()
+        return doPost(host.getApi(), apiPath, null, null, new DbxRequestUtil.ResponseHandler<@Nullable String>()
         {
             @Override
-            public /*@Nullable*/String handle(HttpRequestor.Response response)
+            public @Nullable String handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 404) return null;
@@ -2064,7 +2064,7 @@ public final class DbxClientV1
      *    If successful, returns the metadata for new copy of the file or folder,
      *    otherwise returns {@code null}.
      */
-    public /*@Nullable*/DbxEntry copy(String fromPath, String toPath)
+    public @Nullable DbxEntry copy(String fromPath, String toPath)
         throws DbxException
     {
         DbxPathV1.checkArg("fromPath", fromPath);
@@ -2076,9 +2076,9 @@ public final class DbxClientV1
             "to_path", toPath,
         };
 
-        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/DbxEntry>() {
+        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>() {
             @Override
-            public /*@Nullable*/DbxEntry handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 403) return null;
@@ -2094,7 +2094,7 @@ public final class DbxClientV1
      * Create a file or folder at {@code toPath} based on the given copy ref (created with
      * {@link #createCopyRef}).
      */
-    public /*@Nullable*/DbxEntry copyFromCopyRef(String copyRef, String toPath)
+    public @Nullable DbxEntry copyFromCopyRef(String copyRef, String toPath)
         throws DbxException
     {
         if (copyRef == null) throw new IllegalArgumentException("'copyRef' can't be null");
@@ -2107,10 +2107,10 @@ public final class DbxClientV1
             "to_path", toPath,
         };
 
-        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/DbxEntry>()
+        return doPost(host.getApi(), "1/fileops/copy", params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>()
         {
             @Override
-            public /*@Nullable*/DbxEntry handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() != 200) throw DbxRequestUtil.unexpectedStatus(response);
@@ -2128,7 +2128,7 @@ public final class DbxClientV1
      *    If successful, returns the metadata for the newly created folder, otherwise
      *    returns {@code null}.
      */
-    public DbxEntry./*@Nullable*/Folder createFolder(String path)
+    public DbxEntry.@Nullable Folder createFolder(String path)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("path", path);
@@ -2138,9 +2138,9 @@ public final class DbxClientV1
             "path", path,
         };
 
-        return doPost(host.getApi(), "1/fileops/create_folder", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry./*@Nullable*/Folder>() {
+        return doPost(host.getApi(), "1/fileops/create_folder", params, null, new DbxRequestUtil.ResponseHandler<DbxEntry.@Nullable Folder>() {
             @Override
-            public DbxEntry./*@Nullable*/Folder handle(HttpRequestor.Response response)
+            public DbxEntry.@Nullable Folder handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 403) return null;
@@ -2181,7 +2181,7 @@ public final class DbxClientV1
      *    If successful, returns the metadata for the file or folder at its new location,
      *    otherwise returns {@code null}.
      */
-    public /*@Nullable*/DbxEntry move(String fromPath, String toPath)
+    public @Nullable DbxEntry move(String fromPath, String toPath)
         throws DbxException
     {
         DbxPathV1.checkArgNonRoot("fromPath", fromPath);
@@ -2193,10 +2193,10 @@ public final class DbxClientV1
             "to_path", toPath,
         };
 
-        return doPost(host.getApi(), "1/fileops/move", params, null, new DbxRequestUtil.ResponseHandler</*@Nullable*/DbxEntry>()
+        return doPost(host.getApi(), "1/fileops/move", params, null, new DbxRequestUtil.ResponseHandler<@Nullable DbxEntry>()
         {
             @Override
-            public /*@Nullable*/DbxEntry handle(HttpRequestor.Response response)
+            public @Nullable DbxEntry handle(HttpRequestor.Response response)
                 throws DbxException
             {
                 if (response.getStatusCode() == 403) return null;
@@ -2211,8 +2211,8 @@ public final class DbxClientV1
     // --------------------------------------------------------
 
     // Convenience function that calls RequestUtil.doGet with the first two parameters filled in.
-    private <T> T doGet(String host, String path, /*@Nullable*/String/*@Nullable*/[] params,
-                        /*@Nullable*/ArrayList<HttpRequestor.Header> headers,
+    private <T> T doGet(String host, String path, @Nullable String @Nullable [] params,
+                        @Nullable ArrayList<HttpRequestor.Header> headers,
                         DbxRequestUtil.ResponseHandler<T> handler)
         throws DbxException
     {
@@ -2221,8 +2221,8 @@ public final class DbxClientV1
 
     // Convenience function that calls RequestUtil.doPost with the first two parameters filled in.
     public <T> T doPost(String host, String path,
-                        /*@Nullable*/String/*@Nullable*/[] params,
-                        /*@Nullable*/ArrayList<HttpRequestor.Header> headers,
+                        @Nullable String @Nullable [] params,
+                        @Nullable ArrayList<HttpRequestor.Header> headers,
                         DbxRequestUtil.ResponseHandler<T> handler)
         throws DbxException
     {

--- a/core/src/main/java/com/dropbox/core/v1/DbxDelta.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxDelta.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.v1;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonArrayReader;
 import com.dropbox.core.json.JsonReadException;
@@ -42,7 +43,7 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
     /**
      * Apply these entries to your local state to catch up with the Dropbox server's state.
      */
-    public final List<Entry<MD>> entries;
+    public final @Nonnull List<Entry<MD>> entries;
 
     /**
      * A string that is used by the server to keep track of which entries have already been
@@ -54,7 +55,7 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
      * (such as a database) so you can resume continue you left off.
      * </p>
      */
-    public final String cursor;
+    public final @Nonnull String cursor;
 
     /**
      * If {@code true}, then there are more entries available.  You can retrieve
@@ -69,7 +70,7 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
      * @param cursor {@link #cursor}
      * @param hasMore {@link #hasMore}
      */
-    public DbxDelta(boolean reset, List<Entry<MD>> entries, String cursor, boolean hasMore)
+    public DbxDelta(boolean reset, @Nonnull List<Entry<MD>> entries, @Nonnull String cursor, boolean hasMore)
     {
         this.reset = reset;
         this.entries = entries;
@@ -77,7 +78,7 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
         this.hasMore = hasMore;
     }
 
-    protected void dumpFields(DumpWriter out)
+    protected void dumpFields(@Nonnull DumpWriter out)
     {
         out.f("reset").v(reset);
         out.f("hasMore").v(hasMore);
@@ -90,19 +91,19 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
      */
     public static final class Reader<MD extends Dumpable> extends JsonReader<DbxDelta<MD>>
     {
-        public final JsonReader<MD> metadataReader;
+        public final @Nonnull JsonReader<MD> metadataReader;
 
-        public Reader(JsonReader<MD> metadataReader)
+        public Reader(@Nonnull JsonReader<MD> metadataReader)
         {
             this.metadataReader = metadataReader;
         }
 
-        public DbxDelta<MD> read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull DbxDelta<MD> read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             return read(parser, metadataReader);
         }
 
-        public static <MD extends Dumpable> DbxDelta<MD> read(JsonParser parser, JsonReader<MD> metadataReader)
+        public static <MD extends Dumpable> @Nonnull DbxDelta<MD> read(@Nonnull JsonParser parser, @Nonnull JsonReader<MD> metadataReader)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -183,7 +184,7 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
          * To get the original case-preserved path, look in the {@link #metadata} field.
          * </p>
          */
-        public final String lcPath;
+        public final @Nonnull String lcPath;
 
         /**
          * If this is {@code null}, it means that this path doesn't exist on
@@ -219,13 +220,13 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
          * @param lcPath {@link #lcPath}
          * @param metadata {@link #metadata}
          */
-        public Entry(String lcPath, @Nullable MD metadata)
+        public Entry(@Nonnull String lcPath, @Nullable MD metadata)
         {
             this.lcPath = lcPath;
             this.metadata = metadata;
         }
 
-        protected void dumpFields(DumpWriter out)
+        protected void dumpFields(@Nonnull DumpWriter out)
         {
             out.f("lcPath").v(lcPath);
             out.f("metadata").v(metadata);
@@ -236,19 +237,19 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
          */
         public static final class Reader<MD extends Dumpable> extends JsonReader<Entry<MD>>
         {
-            public final JsonReader<MD> metadataReader;
+            public final @Nonnull JsonReader<MD> metadataReader;
 
-            public Reader(JsonReader<MD> metadataReader)
+            public Reader(@Nonnull JsonReader<MD> metadataReader)
             {
                 this.metadataReader = metadataReader;
             }
 
-            public Entry<MD> read(JsonParser parser) throws IOException, JsonReadException
+            public @Nonnull Entry<MD> read(@Nonnull JsonParser parser) throws IOException, JsonReadException
             {
                 return read(parser, metadataReader);
             }
 
-            public static <MD extends Dumpable> Entry<MD> read(JsonParser parser, JsonReader<MD> metadataReader)
+            public static <MD extends Dumpable> @Nonnull Entry<MD> read(@Nonnull JsonParser parser, @Nonnull JsonReader<MD> metadataReader)
                 throws IOException, JsonReadException
             {
                 JsonLocation arrayStart = JsonReader.expectArrayStart(parser);

--- a/core/src/main/java/com/dropbox/core/v1/DbxDelta.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxDelta.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.v1;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonArrayReader;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;

--- a/core/src/main/java/com/dropbox/core/v1/DbxDelta.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxDelta.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.v1;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.dropbox.core.json.JsonArrayReader;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
@@ -14,7 +15,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
 import java.util.List;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * Represents a single "page" of results from a delta-style API call.
@@ -213,13 +213,13 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
          * </li>
          * </ul>
          */
-        public final /*@Nullable*/MD metadata;
+        public final @Nullable MD metadata;
 
         /**
          * @param lcPath {@link #lcPath}
          * @param metadata {@link #metadata}
          */
-        public Entry(String lcPath, /*@Nullable*/MD metadata)
+        public Entry(String lcPath, @Nullable MD metadata)
         {
             this.lcPath = lcPath;
             this.metadata = metadata;
@@ -269,7 +269,7 @@ public final class DbxDelta<MD extends Dumpable> extends Dumpable
                     throw new JsonReadException("expecting a two-element array of [path, metadata], found a one-element array: " + jq(lcPath), arrayStart);
                 }
 
-                /*@Nullable*/MD metadata;
+                @Nullable MD metadata;
                 try {
                     metadata = metadataReader.readOptional(parser);
                 }

--- a/core/src/main/java/com/dropbox/core/v1/DbxDeltaC.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxDeltaC.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.v1;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import com.dropbox.core.json.JsonArrayReader;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
@@ -12,7 +13,6 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import java.io.IOException;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * Represents a single "page" of results from a delta-style API call.  This is the more
@@ -214,13 +214,13 @@ public class DbxDeltaC<C> extends Dumpable
          * </li>
          * </ul>
          */
-        public final /*@Nullable*/MD metadata;
+        public final @Nullable MD metadata;
 
         /**
          * @param lcPath {@link #lcPath}
          * @param metadata {@link #metadata}
          */
-        public Entry(String lcPath, /*@Nullable*/MD metadata)
+        public Entry(String lcPath, @Nullable MD metadata)
         {
             this.lcPath = lcPath;
             this.metadata = metadata;
@@ -270,7 +270,7 @@ public class DbxDeltaC<C> extends Dumpable
                     throw new JsonReadException("expecting a two-element array of [path, metadata], found a one-element array", arrayStart);
                 }
 
-                /*@Nullable*/MD metadata;
+                @Nullable MD metadata;
                 try {
                     metadata = metadataReader.readOptional(parser);
                 }

--- a/core/src/main/java/com/dropbox/core/v1/DbxDeltaC.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxDeltaC.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.v1;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonArrayReader;
 import com.dropbox.core.json.JsonReadException;
@@ -41,7 +42,7 @@ public class DbxDeltaC<C> extends Dumpable
     /**
      * Apply these entries to your local state to catch up with the Dropbox server's state.
      */
-    public final C entries;
+    public final @Nonnull C entries;
 
     /**
      * A string that is used by the server to keep track of which entries have already been
@@ -53,7 +54,7 @@ public class DbxDeltaC<C> extends Dumpable
      * (such as a database) so you can resume continue you left off.
      * </p>
      */
-    public final String cursor;
+    public final @Nonnull String cursor;
 
     /**
      * If {@code true}, then there are more entries available.  You can retrieve
@@ -68,7 +69,7 @@ public class DbxDeltaC<C> extends Dumpable
      * @param cursor {@link #cursor}
      * @param hasMore {@link #hasMore}
      */
-    public DbxDeltaC(boolean reset, C entries, String cursor, boolean hasMore)
+    public DbxDeltaC(boolean reset, @Nonnull C entries, @Nonnull String cursor, boolean hasMore)
     {
         this.reset = reset;
         this.entries = entries;
@@ -76,7 +77,7 @@ public class DbxDeltaC<C> extends Dumpable
         this.hasMore = hasMore;
     }
 
-    protected void dumpFields(DumpWriter out)
+    protected void dumpFields(@Nonnull DumpWriter out)
     {
         out.f("reset").v(reset);
         out.f("cursor").v(cursor);
@@ -89,21 +90,21 @@ public class DbxDeltaC<C> extends Dumpable
      */
     public static final class Reader<C, MD extends Dumpable> extends JsonReader<DbxDeltaC<C>>
     {
-        public final JsonReader<MD> metadataReader;
-        public final Collector<DbxDeltaC.Entry<MD>, C> entryCollector;
+        public final @Nonnull JsonReader<MD> metadataReader;
+        public final @Nonnull Collector<DbxDeltaC.Entry<MD>, C> entryCollector;
 
-        public Reader(JsonReader<MD> metadataReader, Collector<DbxDeltaC.Entry<MD>, C> entryCollector)
+        public Reader(@Nonnull JsonReader<MD> metadataReader, @Nonnull Collector<DbxDeltaC.Entry<MD>, C> entryCollector)
         {
             this.metadataReader = metadataReader;
             this.entryCollector = entryCollector;
         }
 
-        public DbxDeltaC<C> read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull DbxDeltaC<C> read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             return read(parser, metadataReader, entryCollector);
         }
 
-        public static <C, MD extends Dumpable> DbxDeltaC<C> read(JsonParser parser, JsonReader<MD> metadataReader, Collector<DbxDeltaC.Entry<MD>, C> entryCollector)
+        public static <C, MD extends Dumpable> @Nonnull DbxDeltaC<C> read(@Nonnull JsonParser parser, @Nonnull JsonReader<MD> metadataReader, @Nonnull Collector<DbxDeltaC.Entry<MD>, C> entryCollector)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);
@@ -184,7 +185,7 @@ public class DbxDeltaC<C> extends Dumpable
          * To get the original case-preserved path, look in the {@link #metadata metadata} field.
          * </p>
          */
-        public final String lcPath;
+        public final @Nonnull String lcPath;
 
         /**
          * If this is {@code null}, it means that this path doesn't exist on
@@ -220,13 +221,13 @@ public class DbxDeltaC<C> extends Dumpable
          * @param lcPath {@link #lcPath}
          * @param metadata {@link #metadata}
          */
-        public Entry(String lcPath, @Nullable MD metadata)
+        public Entry(@Nonnull String lcPath, @Nullable MD metadata)
         {
             this.lcPath = lcPath;
             this.metadata = metadata;
         }
 
-        protected void dumpFields(DumpWriter out)
+        protected void dumpFields(@Nonnull DumpWriter out)
         {
             out.f("lcPath").v(lcPath);
             out.f("metadata").v(metadata);
@@ -237,19 +238,19 @@ public class DbxDeltaC<C> extends Dumpable
          */
         public static final class Reader<MD extends Dumpable> extends JsonReader<Entry<MD>>
         {
-            public final JsonReader<MD> metadataReader;
+            public final @Nonnull JsonReader<MD> metadataReader;
 
-            public Reader(JsonReader<MD> metadataReader)
+            public Reader(@Nonnull JsonReader<MD> metadataReader)
             {
                 this.metadataReader = metadataReader;
             }
 
-            public Entry<MD> read(JsonParser parser) throws IOException, JsonReadException
+            public @Nonnull Entry<MD> read(@Nonnull JsonParser parser) throws IOException, JsonReadException
             {
                 return read(parser, metadataReader);
             }
 
-            public static <MD extends Dumpable> Entry<MD> read(JsonParser parser, JsonReader<MD> metadataReader)
+            public static <MD extends Dumpable> @Nonnull Entry<MD> read(@Nonnull JsonParser parser, @Nonnull JsonReader<MD> metadataReader)
                 throws IOException, JsonReadException
             {
                 JsonLocation arrayStart = JsonReader.expectArrayStart(parser);

--- a/core/src/main/java/com/dropbox/core/v1/DbxDeltaC.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxDeltaC.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.v1;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import com.dropbox.core.json.JsonArrayReader;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.json.JsonReader;
@@ -289,4 +289,3 @@ public class DbxDeltaC<C> extends Dumpable
         }
     }
 }
-

--- a/core/src/main/java/com/dropbox/core/v1/DbxEntry.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxEntry.java
@@ -1,5 +1,7 @@
 package com.dropbox.core.v1;
 
+import org.checkerframework.checker.nullness.qual.PolyNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
@@ -17,8 +19,6 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
-/*>>> import checkers.nullness.quals.Nullable; */
-/*>>> import checkers.nullness.quals.PolyNull; */
 
 /**
  * Holds the metadata for a Dropbox file system entry.  Can either be a regular file or a folder.
@@ -165,7 +165,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
 
         };
 
-        public boolean equals(/*@Nullable*/Object o)
+        public boolean equals(@Nullable Object o)
         {
             return o != null && getClass().equals(o.getClass()) && equals((Folder) o);
         }
@@ -233,12 +233,12 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * If this file is a photo, this may contain additional photo-related information.  This field is
          * only populated if you use the {@code includeMediaInfo}
          */
-        public final /*@Nullable*/PhotoInfo photoInfo;
+        public final @Nullable PhotoInfo photoInfo;
 
         /**
          * Contains details about this file if it is a video
          */
-        public final /*@Nullable*/VideoInfo videoInfo;
+        public final @Nullable VideoInfo videoInfo;
 
         /**
          * @param path {@link #path}
@@ -254,7 +254,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          */
         public File(String path, String iconName, boolean mightHaveThumbnail, long numBytes, String humanSize,
                     Date lastModified, Date clientMtime, String rev,
-                    /*@Nullable*/PhotoInfo photoInfo, /*@Nullable*/VideoInfo videoInfo)
+                    @Nullable PhotoInfo photoInfo, @Nullable VideoInfo videoInfo)
         {
             super(path, iconName, mightHaveThumbnail);
             this.numBytes = numBytes;
@@ -288,7 +288,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
 
         private static <T extends Dumpable> void nullablePendingField(
-            DumpWriter w, String fieldName, /*@Nullable*/T value, T pendingValue)
+            DumpWriter w, String fieldName, @Nullable T value, T pendingValue)
         {
             if (value == null) return;
 
@@ -322,9 +322,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
 
         };
 
-        public static final JsonReader<DbxEntry./*@Nullable*/File> ReaderMaybeDeleted = new JsonReader<DbxEntry./*@Nullable*/File>()
+        public static final JsonReader<DbxEntry.@Nullable File> ReaderMaybeDeleted = new JsonReader<DbxEntry.@Nullable File>()
         {
-            public final DbxEntry./*@Nullable*/File read(JsonParser parser)
+            public final DbxEntry.@Nullable File read(JsonParser parser)
                 throws IOException, JsonReadException
             {
                 JsonLocation top = parser.getCurrentLocation();
@@ -339,7 +339,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
 
         };
 
-        public boolean equals(/*@Nullable*/Object o)
+        public boolean equals(@Nullable Object o)
         {
             return o != null && getClass().equals(o.getClass()) && equals((File) o);
         }
@@ -378,14 +378,14 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             /**
              * When the photo was taken.
              */
-            public final /*@Nullable*/Date timeTaken;
+            public final @Nullable Date timeTaken;
 
             /**
              * Where the photo was taken.
              */
-            public final /*@Nullable*/Location location;
+            public final @Nullable Location location;
 
-            public PhotoInfo(/*@Nullable*/Date timeTaken, /*@Nullable*/Location location) {
+            public PhotoInfo(@Nullable Date timeTaken, @Nullable Location location) {
                 this.timeTaken = timeTaken;
                 this.location = location;
             }
@@ -425,7 +425,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
 
             @Override
-            public boolean equals(/*@Nullable*/Object o)
+            public boolean equals(@Nullable Object o)
             {
                 return o != null && getClass().equals(o.getClass()) && equals((PhotoInfo) o);
             }
@@ -457,19 +457,19 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             /**
              * When the video was recorded.
              */
-            public final /*@Nullable*/Date timeTaken;
+            public final @Nullable Date timeTaken;
 
             /**
              * Where the video was recorded.
              */
-            public final /*@Nullable*/Location location;
+            public final @Nullable Location location;
 
             /**
              * The duration of the video, in seconds.
              */
-            public final /*@Nullable*/Long duration;
+            public final @Nullable Long duration;
 
-            public VideoInfo(/*@Nullable*/Date timeTaken, /*@Nullable*/Location location, /*@Nullable*/Long duration)
+            public VideoInfo(@Nullable Date timeTaken, @Nullable Location location, @Nullable Long duration)
             {
                 this.timeTaken = timeTaken;
                 this.location = location;
@@ -518,7 +518,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
 
             @Override
-            public boolean equals(/*@Nullable*/Object o)
+            public boolean equals(@Nullable Object o)
             {
                 return o != null && getClass().equals(o.getClass()) && equals((VideoInfo) o);
             }
@@ -557,10 +557,10 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 this.longitude = longitude;
             }
 
-            public static JsonReader</*@Nullable*/Location> Reader = new JsonReader</*@Nullable*/Location>()
+            public static JsonReader<@Nullable Location> Reader = new JsonReader<@Nullable Location>()
             {
                 @Override
-                public /*@Nullable*/Location read(JsonParser parser)
+                public @Nullable Location read(JsonParser parser)
                     throws IOException, JsonReadException
                 {
                     Location location = null;
@@ -597,7 +597,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
 
             @Override
-            public boolean equals(/*@Nullable*/Object o) {
+            public boolean equals(@Nullable Object o) {
                 return o != null && getClass().equals(o.getClass()) && equals((Location) o);
             }
 
@@ -622,9 +622,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
     };
 
-    public static final JsonReader</*@Nullable*/DbxEntry> ReaderMaybeDeleted = new JsonReader</*@Nullable*/DbxEntry>()
+    public static final JsonReader<@Nullable DbxEntry> ReaderMaybeDeleted = new JsonReader<@Nullable DbxEntry>()
     {
-        public final /*@Nullable*/DbxEntry read(JsonParser parser)
+        public final @Nullable DbxEntry read(JsonParser parser)
             throws IOException, JsonReadException
         {
             WithChildrenC<?> wc = DbxEntry.readMaybeDeleted(parser, null);
@@ -654,20 +654,20 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * contents.  This value can be used with {@link DbxClientV1#getMetadataWithChildrenIfChanged}
          * to void downloading the folder contents if they havne't changed.
          */
-        public final /*@PolyNull*/String hash;
+        public final @PolyNull String hash;
 
         /**
          * If {@link #entry} is a folder, this will contain the metadata of the folder's
          * immediate children.  If it's not a folder, this will be {@code null}.
          */
-        public final /*@PolyNull*/List<DbxEntry> children;
+        public final @PolyNull List<DbxEntry> children;
 
         /**
          * @param entry {@link #entry}
          * @param hash {@link #hash}
          * @param children {@link #children}
          */
-        public WithChildren(DbxEntry entry, /*@PolyNull*/String hash, /*@PolyNull*/List<DbxEntry> children)
+        public WithChildren(DbxEntry entry, @PolyNull String hash, @PolyNull List<DbxEntry> children)
         {
             this.entry = entry;
             this.hash = hash;
@@ -684,9 +684,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
         };
 
-        public static final JsonReader</*@Nullable*/WithChildren> ReaderMaybeDeleted = new JsonReader</*@Nullable*/WithChildren>()
+        public static final JsonReader<@Nullable WithChildren> ReaderMaybeDeleted = new JsonReader<@Nullable WithChildren>()
         {
-            public final /*@Nullable*/WithChildren read(JsonParser parser)
+            public final @Nullable WithChildren read(JsonParser parser)
                 throws IOException, JsonReadException
             {
                 WithChildrenC<List<DbxEntry>> c = DbxEntry.<List<DbxEntry>>readMaybeDeleted(parser, new Collector.ArrayListCollector<DbxEntry>());
@@ -695,7 +695,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
         };
 
-        public boolean equals(/*@Nullable*/Object o)
+        public boolean equals(@Nullable Object o)
         {
             return o != null && getClass().equals(o.getClass()) && equals((WithChildren) o);
         }
@@ -745,20 +745,20 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * contents.  This value can be used with {@link DbxClientV1#getMetadataWithChildrenIfChanged}
          * to void downloading the folder contents if they havne't changed.
          */
-        public final /*@PolyNull*/String hash;
+        public final @PolyNull String hash;
 
         /**
          * If {@link #entry} is a folder, this will contain the metadata of the folder's
          * immediate children.  If it's not a folder, this will be {@code null}.
          */
-        public final /*@PolyNull*/C children;
+        public final @PolyNull C children;
 
         /**
          * @param entry {@link #entry}
          * @param hash {@link #hash}
          * @param children {@link #children}
          */
-        public WithChildrenC(DbxEntry entry, /*@PolyNull*/String hash, /*@PolyNull*/C children)
+        public WithChildrenC(DbxEntry entry, @PolyNull String hash, @PolyNull C children)
         {
             this.entry = entry;
             this.hash = hash;
@@ -777,12 +777,12 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
         }
 
-        public static class ReaderMaybeDeleted<C> extends JsonReader</*@Nullable*/WithChildrenC<C>>
+        public static class ReaderMaybeDeleted<C> extends JsonReader<@Nullable WithChildrenC<C>>
         {
             private final Collector<DbxEntry,? extends C> collector;
             public ReaderMaybeDeleted(Collector<DbxEntry,? extends C> collector) { this.collector = collector; }
 
-            public final /*@Nullable*/WithChildrenC<C> read(JsonParser parser)
+            public final @Nullable WithChildrenC<C> read(JsonParser parser)
                 throws IOException, JsonReadException
             {
                 return DbxEntry.readMaybeDeleted(parser, collector);
@@ -790,7 +790,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
 
         @Override
-        public boolean equals(/*@Nullable*/Object o)
+        public boolean equals(@Nullable Object o)
         {
             return o != null && getClass().equals(o.getClass()) && equals((WithChildrenC) o);
         }
@@ -825,13 +825,13 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
     }
 
-    public static <C> /*@Nullable*/WithChildrenC<C> readMaybeDeleted(JsonParser parser, /*@Nullable*/Collector<DbxEntry, ? extends C> collector)
+    public static <C> @Nullable WithChildrenC<C> readMaybeDeleted(JsonParser parser, @Nullable Collector<DbxEntry, ? extends C> collector)
             throws IOException, JsonReadException
     {
         return _read(parser, collector, true);
     }
 
-    public static <C> WithChildrenC<C> read(JsonParser parser, /*@Nullable*/Collector<DbxEntry, ? extends C> collector)
+    public static <C> WithChildrenC<C> read(JsonParser parser, @Nullable Collector<DbxEntry, ? extends C> collector)
         throws IOException, JsonReadException
     {
         WithChildrenC<C> r = _read(parser, collector, false);
@@ -843,7 +843,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
      * @return
  *     {@code null} if the entry is an 'is_deleted' entry.
      */
-    private static <C> /*@Nullable*/WithChildrenC<C> _read(JsonParser parser, /*@Nullable*/Collector<DbxEntry, ? extends C> collector, boolean allowDeleted)
+    private static <C> @Nullable WithChildrenC<C> _read(JsonParser parser, @Nullable Collector<DbxEntry, ? extends C> collector, boolean allowDeleted)
         throws IOException, JsonReadException
     {
         JsonLocation top = JsonReader.expectObjectStart(parser);

--- a/core/src/main/java/com/dropbox/core/v1/DbxEntry.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxEntry.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.v1;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
@@ -31,7 +32,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
      *
      * @see DbxPathV1#getName
      */
-    public final String name;
+    public final @Nonnull String name;
 
     /**
      * The path to the file or folder, relative to your application's root.
@@ -43,7 +44,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
      * is relative to your application's App Folder within the user's Dropbox.
      * </p>
      */
-    public final String path;
+    public final @Nonnull String path;
 
     /**
      * The name of the icon to use for this file.  The set of names returned by this call match up
@@ -51,7 +52,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
      * field in <a href="https://www.dropbox.com/developers/reference/api#metadata">
      * Dropbox's documentation for the {@code /metadata} HTTP endpoint</a>.
      */
-    public final String iconName;
+    public final @Nonnull String iconName;
 
     /**
      * Whether this file or folder might have a thumbnail image you can retrieve via
@@ -66,7 +67,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
      * @param iconName {@link #iconName}
      * @param mightHaveThumbnail {@link #mightHaveThumbnail}
      */
-    private DbxEntry(String path, String iconName, boolean mightHaveThumbnail)
+    private DbxEntry(@Nonnull String path, @Nonnull String iconName, boolean mightHaveThumbnail)
     {
         this.name = DbxPathV1.getName(path);
         this.path = path;
@@ -74,7 +75,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         this.mightHaveThumbnail = mightHaveThumbnail;
     }
 
-    protected void dumpFields(DumpWriter w)
+    protected void dumpFields(@Nonnull DumpWriter w)
     {
         w.v(path);
         w.f("iconName").v(iconName);
@@ -97,15 +98,15 @@ public abstract class DbxEntry extends Dumpable implements Serializable
      * If this metadata entry is a folder, return it as a {@code DbxEntry.Folder}
      * instance.  If it's not a folder, return {@code null}.
      */
-    public abstract Folder asFolder();
+    public abstract @Nonnull Folder asFolder();
 
     /**
      * If this metadata entry is a file, return it as a {@code DbxEntry.File}
      * instance.  If it's not a file, return {@code null}.
      */
-    public abstract File asFile();
+    public abstract @Nonnull File asFile();
 
-    protected boolean partialEquals(DbxEntry o)
+    protected boolean partialEquals(@Nonnull DbxEntry o)
     {
         if (!name.equals(o.name)) return false;
         if (!path.equals(o.path)) return false;
@@ -137,21 +138,21 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * @param iconName {@link #iconName}
          * @param mightHaveThumbnail {@link #mightHaveThumbnail}
          */
-        public Folder(String path, String iconName, boolean mightHaveThumbnail)
+        public Folder(@Nonnull String path, @Nonnull String iconName, boolean mightHaveThumbnail)
         {
             super(path, iconName, mightHaveThumbnail);
         }
 
-        protected String getTypeName() { return "Folder"; }
+        protected @Nonnull String getTypeName() { return "Folder"; }
 
         public boolean isFolder() { return true; }
         public boolean isFile() { return false; }
-        public Folder asFolder() { return this; }
-        public File asFile() { throw new RuntimeException("not a file"); }
+        public @Nonnull Folder asFolder() { return this; }
+        public @Nonnull File asFile() { throw new RuntimeException("not a file"); }
 
-        public static final JsonReader<DbxEntry.Folder> Reader = new JsonReader<DbxEntry.Folder>()
+        public static final @Nonnull JsonReader<DbxEntry.Folder> Reader = new JsonReader<DbxEntry.Folder>()
         {
-            public final DbxEntry.Folder read(JsonParser parser)
+            public final @Nonnull DbxEntry.Folder read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 JsonLocation top = parser.getCurrentLocation();
@@ -169,7 +170,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             return o != null && getClass().equals(o.getClass()) && equals((Folder) o);
         }
 
-        public boolean equals(Folder o)
+        public boolean equals(@Nonnull Folder o)
         {
             if (!partialEquals(o)) return false;
             return true;
@@ -199,7 +200,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * be localized based on the {@link java.util.Locale Locale} in {@link DbxRequestConfig#userLocale}
          * (passed in to the {@link DbxClientV1} constructor).
          */
-        public final String humanSize;
+        public final @Nonnull String humanSize;
 
         /**
          * The time the file was added, moved, or last had it's contents changed on the Dropbox
@@ -207,7 +208,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * the {@link #clientMtime} is a better estimate.)
          *
          */
-        public final Date lastModified;
+        public final @Nonnull Date lastModified;
 
         /**
          * The modification time sent up by the Dropbox desktop client when the file was added
@@ -219,14 +220,14 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * a way to sort files by date (when displaying a list of files to the user).
          * </p>
          */
-        public final Date clientMtime;
+        public final @Nonnull Date clientMtime;
 
         /**
          * The revision of the file at this path.  This can be used with {@link DbxClientV1#uploadFile}
          * and the {@link DbxWriteMode#update} mode to make sure you're overwriting the revision of
          * the file you think you're overwriting.
          */
-        public final String rev;
+        public final @Nonnull String rev;
 
         /**
          * If this file is a photo, this may contain additional photo-related information.  This field is
@@ -251,8 +252,8 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * @param photoInfo {@link #photoInfo}
          * @param videoInfo {@link #videoInfo}
          */
-        public File(String path, String iconName, boolean mightHaveThumbnail, long numBytes, String humanSize,
-                    Date lastModified, Date clientMtime, String rev,
+        public File(@Nonnull String path, @Nonnull String iconName, boolean mightHaveThumbnail, long numBytes, @Nonnull String humanSize,
+                    @Nonnull Date lastModified, @Nonnull Date clientMtime, @Nonnull String rev,
                     @Nullable PhotoInfo photoInfo, @Nullable VideoInfo videoInfo)
         {
             super(path, iconName, mightHaveThumbnail);
@@ -268,13 +269,13 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         /**
          * Same as the other constructor except {@link #photoInfo} and {@link #videoInfo} are set to {@code null}.
          */
-        public File(String path, String iconName, boolean mightHaveThumbnail, long numBytes, String humanSize,
-                    Date lastModified, Date clientMtime, String rev)
+        public File(@Nonnull String path, @Nonnull String iconName, boolean mightHaveThumbnail, long numBytes, @Nonnull String humanSize,
+                    @Nonnull Date lastModified, @Nonnull Date clientMtime, @Nonnull String rev)
         {
             this(path, iconName, mightHaveThumbnail, numBytes, humanSize, lastModified, clientMtime, rev, null, null);
         }
 
-        protected void dumpFields(DumpWriter w)
+        protected void dumpFields(@Nonnull DumpWriter w)
         {
             super.dumpFields(w);
             w.f("numBytes").v(numBytes);
@@ -287,7 +288,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
 
         private static <T extends Dumpable> void nullablePendingField(
-            DumpWriter w, String fieldName, @Nullable T value, T pendingValue)
+            @Nonnull DumpWriter w, @Nonnull String fieldName, @Nullable T value, @Nonnull T pendingValue)
         {
             if (value == null) return;
 
@@ -299,16 +300,16 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
         }
 
-        protected String getTypeName() { return "File"; }
+        protected @Nonnull String getTypeName() { return "File"; }
 
         public boolean isFolder() { return false; }
         public boolean isFile() { return true; }
-        public Folder asFolder() { throw new RuntimeException("not a folder"); }
-        public File asFile() { return this; }
+        public @Nonnull Folder asFolder() { throw new RuntimeException("not a folder"); }
+        public @Nonnull File asFile() { return this; }
 
-        public static final JsonReader<DbxEntry.File> Reader = new JsonReader<DbxEntry.File>()
+        public static final @Nonnull JsonReader<DbxEntry.File> Reader = new JsonReader<DbxEntry.File>()
         {
-            public final DbxEntry.File read(JsonParser parser)
+            public final @Nonnull DbxEntry.File read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 JsonLocation top = parser.getCurrentLocation();
@@ -321,9 +322,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
 
         };
 
-        public static final JsonReader<DbxEntry.File> ReaderMaybeDeleted = new JsonReader<DbxEntry.File>()
+        public static final @Nonnull JsonReader<DbxEntry.File> ReaderMaybeDeleted = new JsonReader<DbxEntry.File>()
         {
-            public final @Nullable DbxEntry.File read(JsonParser parser)
+            public final @Nullable DbxEntry.File read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 JsonLocation top = parser.getCurrentLocation();
@@ -343,7 +344,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             return o != null && getClass().equals(o.getClass()) && equals((File) o);
         }
 
-        public boolean equals(File o)
+        public boolean equals(@Nonnull File o)
         {
             if (!partialEquals(o)) return false;
             if (numBytes != o.numBytes) return false;
@@ -389,10 +390,10 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 this.location = location;
             }
 
-            public static JsonReader<PhotoInfo> Reader = new JsonReader<PhotoInfo>()
+            public static @Nonnull JsonReader<PhotoInfo> Reader = new JsonReader<PhotoInfo>()
             {
                 @Override
-                public PhotoInfo read(JsonParser parser)
+                public @Nonnull PhotoInfo read(@Nonnull JsonParser parser)
                     throws IOException, JsonReadException
                 {
                     JsonReader.expectObjectStart(parser);
@@ -414,10 +415,10 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 }
             };
 
-            public static final PhotoInfo PENDING = new PhotoInfo(null, null);
+            public static final @Nonnull PhotoInfo PENDING = new PhotoInfo(null, null);
 
             @Override
-            protected void dumpFields(DumpWriter w)
+            protected void dumpFields(@Nonnull DumpWriter w)
             {
                 w.f("timeTaken").v(timeTaken);
                 w.f("location").v(location);
@@ -429,7 +430,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 return o != null && getClass().equals(o.getClass()) && equals((PhotoInfo) o);
             }
 
-            public boolean equals(PhotoInfo o)
+            public boolean equals(@Nonnull PhotoInfo o)
             {
                 // For "pending" values, it must be an exact match.
                 if (o == PENDING || this == PENDING) return o == this;
@@ -475,10 +476,10 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 this.duration = duration;
             }
 
-            public static JsonReader<VideoInfo> Reader = new JsonReader<VideoInfo>()
+            public static @Nonnull JsonReader<VideoInfo> Reader = new JsonReader<VideoInfo>()
             {
                 @Override
-                public VideoInfo read(JsonParser parser)
+                public @Nonnull VideoInfo read(@Nonnull JsonParser parser)
                     throws IOException, JsonReadException
                 {
                     JsonReader.expectObjectStart(parser);
@@ -506,10 +507,10 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             /**
              * The singleton value used when the Dropbox server returns "pending" for
              */
-            public static final VideoInfo PENDING = new VideoInfo(null, null, null);
+            public static final @Nonnull VideoInfo PENDING = new VideoInfo(null, null, null);
 
             @Override
-            protected void dumpFields(DumpWriter w)
+            protected void dumpFields(@Nonnull DumpWriter w)
             {
                 w.f("timeTaken").v(timeTaken);
                 w.f("location").v(location);
@@ -522,7 +523,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 return o != null && getClass().equals(o.getClass()) && equals((VideoInfo) o);
             }
 
-            public boolean equals(VideoInfo o)
+            public boolean equals(@Nonnull VideoInfo o)
             {
                 // For "pending" values, it must be an exact match.
                 if (o == PENDING || this == PENDING) return o == this;
@@ -556,10 +557,10 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 this.longitude = longitude;
             }
 
-            public static JsonReader<Location> Reader = new JsonReader<Location>()
+            public static @Nonnull JsonReader<Location> Reader = new JsonReader<Location>()
             {
                 @Override
-                public @Nullable Location read(JsonParser parser)
+                public @Nullable Location read(@Nonnull JsonParser parser)
                     throws IOException, JsonReadException
                 {
                     Location location = null;
@@ -578,7 +579,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             };
 
             @Override
-            protected void dumpFields(DumpWriter w)
+            protected void dumpFields(@Nonnull DumpWriter w)
             {
                 w.f("latitude").v(latitude);
                 w.f("longitude").v(longitude);
@@ -600,7 +601,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 return o != null && getClass().equals(o.getClass()) && equals((Location) o);
             }
 
-            public boolean equals(Location o)
+            public boolean equals(@Nonnull Location o)
             {
                 if (latitude != o.latitude) return false;
                 if (longitude != o.longitude) return false;
@@ -612,18 +613,18 @@ public abstract class DbxEntry extends Dumpable implements Serializable
     // ------------------------------------------------------
     // JSON parsing
 
-    public static final JsonReader<DbxEntry> Reader = new JsonReader<DbxEntry>()
+    public static final @Nonnull JsonReader<DbxEntry> Reader = new JsonReader<DbxEntry>()
     {
-        public final DbxEntry read(JsonParser parser)
+        public final @Nonnull DbxEntry read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             return DbxEntry.read(parser, null).entry;
         }
     };
 
-    public static final JsonReader<DbxEntry> ReaderMaybeDeleted = new JsonReader<DbxEntry>()
+    public static final @Nonnull JsonReader<DbxEntry> ReaderMaybeDeleted = new JsonReader<DbxEntry>()
     {
-        public final @Nullable DbxEntry read(JsonParser parser)
+        public final @Nullable DbxEntry read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             WithChildrenC<?> wc = DbxEntry.readMaybeDeleted(parser, null);
@@ -646,7 +647,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         /**
          * The metadata for the base file or folder.
          */
-        public final DbxEntry entry;
+        public final @Nonnull DbxEntry entry;
 
         /**
          * If {@link #entry} is a folder, this will contain a hash that identifies the folder's
@@ -666,16 +667,16 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * @param hash {@link #hash}
          * @param children {@link #children}
          */
-        public WithChildren(DbxEntry entry, @Nullable String hash, @Nullable List<DbxEntry> children)
+        public WithChildren(@Nonnull DbxEntry entry, @Nullable String hash, @Nullable List<DbxEntry> children)
         {
             this.entry = entry;
             this.hash = hash;
             this.children = children;
         }
 
-        public static final JsonReader<WithChildren> Reader = new JsonReader<WithChildren>()
+        public static final @Nonnull JsonReader<WithChildren> Reader = new JsonReader<WithChildren>()
         {
-            public final WithChildren read(JsonParser parser)
+            public final @Nonnull WithChildren read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 WithChildrenC<List<DbxEntry>> c = DbxEntry.<List<DbxEntry>>read(parser, new Collector.ArrayListCollector<DbxEntry>());
@@ -683,9 +684,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
         };
 
-        public static final JsonReader<WithChildren> ReaderMaybeDeleted = new JsonReader<WithChildren>()
+        public static final @Nonnull JsonReader<WithChildren> ReaderMaybeDeleted = new JsonReader<WithChildren>()
         {
-            public final @Nullable WithChildren read(JsonParser parser)
+            public final @Nullable WithChildren read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 WithChildrenC<List<DbxEntry>> c = DbxEntry.<List<DbxEntry>>readMaybeDeleted(parser, new Collector.ArrayListCollector<DbxEntry>());
@@ -699,7 +700,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             return o != null && getClass().equals(o.getClass()) && equals((WithChildren) o);
         }
 
-        public boolean equals(WithChildren o)
+        public boolean equals(@Nonnull WithChildren o)
         {
             if (children != null ? !children.equals(o.children) : o.children != null)
                 return false;
@@ -719,7 +720,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
 
         @Override
-        protected void dumpFields(DumpWriter w)
+        protected void dumpFields(@Nonnull DumpWriter w)
         {
             w.v(entry);
             w.f("hash").v(hash);
@@ -737,7 +738,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
     {
         public static final long serialVersionUID = 0;
 
-        public final DbxEntry entry;
+        public final @Nonnull DbxEntry entry;
 
         /**
          * If {@link #entry} is a folder, this will contain a hash that identifies the folder's
@@ -757,7 +758,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * @param hash {@link #hash}
          * @param children {@link #children}
          */
-        public WithChildrenC(DbxEntry entry, @Nullable String hash, @Nullable C children)
+        public WithChildrenC(@Nonnull DbxEntry entry, @Nullable String hash, @Nullable C children)
         {
             this.entry = entry;
             this.hash = hash;
@@ -767,9 +768,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         public static class Reader<C> extends JsonReader<WithChildrenC<C>>
         {
             private final Collector<DbxEntry,? extends C> collector;
-            public Reader(Collector<DbxEntry,? extends C> collector) { this.collector = collector; }
+            public Reader(@Nonnull Collector<DbxEntry,? extends C> collector) { this.collector = collector; }
 
-            public final WithChildrenC<C> read(JsonParser parser)
+            public final @Nonnull WithChildrenC<C> read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 return DbxEntry.read(parser, collector);
@@ -779,9 +780,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         public static class ReaderMaybeDeleted<C> extends JsonReader<WithChildrenC<C>>
         {
             private final Collector<DbxEntry,? extends C> collector;
-            public ReaderMaybeDeleted(Collector<DbxEntry,? extends C> collector) { this.collector = collector; }
+            public ReaderMaybeDeleted(@Nonnull Collector<DbxEntry,? extends C> collector) { this.collector = collector; }
 
-            public final @Nullable WithChildrenC<C> read(JsonParser parser)
+            public final @Nullable WithChildrenC<C> read(@Nonnull JsonParser parser)
                 throws IOException, JsonReadException
             {
                 return DbxEntry.readMaybeDeleted(parser, collector);
@@ -794,7 +795,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             return o != null && getClass().equals(o.getClass()) && equals((WithChildrenC) o);
         }
 
-        public boolean equals(WithChildrenC<?> o)
+        public boolean equals(@Nonnull WithChildrenC<?> o)
         {
             if (children != null ? !children.equals(o.children) : o.children != null)
                 return false;
@@ -814,7 +815,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
 
         @Override
-        protected void dumpFields(DumpWriter w)
+        protected void dumpFields(@Nonnull DumpWriter w)
         {
             w.v(entry);
             w.f("hash").v(hash);
@@ -824,13 +825,13 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
     }
 
-    public static <C> @Nullable WithChildrenC<C> readMaybeDeleted(JsonParser parser, @Nullable Collector<DbxEntry, ? extends C> collector)
+    public static <C> @Nullable WithChildrenC<C> readMaybeDeleted(@Nonnull JsonParser parser, @Nullable Collector<DbxEntry, ? extends C> collector)
             throws IOException, JsonReadException
     {
         return _read(parser, collector, true);
     }
 
-    public static <C> WithChildrenC<C> read(JsonParser parser, @Nullable Collector<DbxEntry, ? extends C> collector)
+    public static <C> @Nonnull WithChildrenC<C> read(@Nonnull JsonParser parser, @Nullable Collector<DbxEntry, ? extends C> collector)
         throws IOException, JsonReadException
     {
         WithChildrenC<C> r = _read(parser, collector, false);
@@ -940,19 +941,19 @@ public abstract class DbxEntry extends Dumpable implements Serializable
 
     private static final class PendingReader<T> extends JsonReader<T>
     {
-        private final JsonReader<T> reader;
-        private final T pendingValue;
+        private final @Nonnull JsonReader<T> reader;
+        private final @Nonnull T pendingValue;
 
-        public PendingReader(JsonReader<T> reader, T pendingValue)
+        public PendingReader(@Nonnull JsonReader<T> reader, @Nonnull T pendingValue)
         {
             this.reader = reader;
             this.pendingValue = pendingValue;
         }
 
-        public static <T> PendingReader<T> mk(JsonReader<T> reader, T pendingValue) { return new PendingReader<T>(reader, pendingValue); }
+        public static <T> @Nonnull PendingReader<T> mk(@Nonnull JsonReader<T> reader, @Nonnull T pendingValue) { return new PendingReader<T>(reader, pendingValue); }
 
         @Override
-        public T read(JsonParser parser)
+        public @Nonnull T read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             JsonToken token = parser.getCurrentToken();

--- a/core/src/main/java/com/dropbox/core/v1/DbxEntry.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxEntry.java
@@ -1,7 +1,6 @@
 package com.dropbox.core.v1;
 
-import org.checkerframework.checker.nullness.qual.PolyNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
@@ -322,9 +321,9 @@ public abstract class DbxEntry extends Dumpable implements Serializable
 
         };
 
-        public static final JsonReader<DbxEntry.@Nullable File> ReaderMaybeDeleted = new JsonReader<DbxEntry.@Nullable File>()
+        public static final JsonReader<DbxEntry.File> ReaderMaybeDeleted = new JsonReader<DbxEntry.File>()
         {
-            public final DbxEntry.@Nullable File read(JsonParser parser)
+            public final @Nullable DbxEntry.File read(JsonParser parser)
                 throws IOException, JsonReadException
             {
                 JsonLocation top = parser.getCurrentLocation();
@@ -557,7 +556,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
                 this.longitude = longitude;
             }
 
-            public static JsonReader<@Nullable Location> Reader = new JsonReader<@Nullable Location>()
+            public static JsonReader<Location> Reader = new JsonReader<Location>()
             {
                 @Override
                 public @Nullable Location read(JsonParser parser)
@@ -622,7 +621,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
         }
     };
 
-    public static final JsonReader<@Nullable DbxEntry> ReaderMaybeDeleted = new JsonReader<@Nullable DbxEntry>()
+    public static final JsonReader<DbxEntry> ReaderMaybeDeleted = new JsonReader<DbxEntry>()
     {
         public final @Nullable DbxEntry read(JsonParser parser)
             throws IOException, JsonReadException
@@ -654,20 +653,20 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * contents.  This value can be used with {@link DbxClientV1#getMetadataWithChildrenIfChanged}
          * to void downloading the folder contents if they havne't changed.
          */
-        public final @PolyNull String hash;
+        public final @Nullable String hash;
 
         /**
          * If {@link #entry} is a folder, this will contain the metadata of the folder's
          * immediate children.  If it's not a folder, this will be {@code null}.
          */
-        public final @PolyNull List<DbxEntry> children;
+        public final @Nullable List<DbxEntry> children;
 
         /**
          * @param entry {@link #entry}
          * @param hash {@link #hash}
          * @param children {@link #children}
          */
-        public WithChildren(DbxEntry entry, @PolyNull String hash, @PolyNull List<DbxEntry> children)
+        public WithChildren(DbxEntry entry, @Nullable String hash, @Nullable List<DbxEntry> children)
         {
             this.entry = entry;
             this.hash = hash;
@@ -684,7 +683,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
         };
 
-        public static final JsonReader<@Nullable WithChildren> ReaderMaybeDeleted = new JsonReader<@Nullable WithChildren>()
+        public static final JsonReader<WithChildren> ReaderMaybeDeleted = new JsonReader<WithChildren>()
         {
             public final @Nullable WithChildren read(JsonParser parser)
                 throws IOException, JsonReadException
@@ -745,20 +744,20 @@ public abstract class DbxEntry extends Dumpable implements Serializable
          * contents.  This value can be used with {@link DbxClientV1#getMetadataWithChildrenIfChanged}
          * to void downloading the folder contents if they havne't changed.
          */
-        public final @PolyNull String hash;
+        public final @Nullable String hash;
 
         /**
          * If {@link #entry} is a folder, this will contain the metadata of the folder's
          * immediate children.  If it's not a folder, this will be {@code null}.
          */
-        public final @PolyNull C children;
+        public final @Nullable C children;
 
         /**
          * @param entry {@link #entry}
          * @param hash {@link #hash}
          * @param children {@link #children}
          */
-        public WithChildrenC(DbxEntry entry, @PolyNull String hash, @PolyNull C children)
+        public WithChildrenC(DbxEntry entry, @Nullable String hash, @Nullable C children)
         {
             this.entry = entry;
             this.hash = hash;
@@ -777,7 +776,7 @@ public abstract class DbxEntry extends Dumpable implements Serializable
             }
         }
 
-        public static class ReaderMaybeDeleted<C> extends JsonReader<@Nullable WithChildrenC<C>>
+        public static class ReaderMaybeDeleted<C> extends JsonReader<WithChildrenC<C>>
         {
             private final Collector<DbxEntry,? extends C> collector;
             public ReaderMaybeDeleted(Collector<DbxEntry,? extends C> collector) { this.collector = collector; }

--- a/core/src/main/java/com/dropbox/core/v1/DbxLongpollDeltaResult.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxLongpollDeltaResult.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import java.io.IOException;
 
+import javax.annotation.Nonnull;
+
 /**
  * The response from a longpoll_delta request.
  */
@@ -31,10 +33,10 @@ public class DbxLongpollDeltaResult
         this.backoff = backoff;
     }
 
-    public static final JsonReader<DbxLongpollDeltaResult> Reader = new JsonReader<DbxLongpollDeltaResult>()
+    public static final @Nonnull JsonReader<DbxLongpollDeltaResult> Reader = new JsonReader<DbxLongpollDeltaResult>()
     {
         @Override
-        public DbxLongpollDeltaResult read(JsonParser parser) throws IOException, JsonReadException
+        public @Nonnull DbxLongpollDeltaResult read(@Nonnull JsonParser parser) throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);
 

--- a/core/src/main/java/com/dropbox/core/v1/DbxPathV1.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxPathV1.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.v1;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 import static com.dropbox.core.util.StringUtil.jq;
 
 

--- a/core/src/main/java/com/dropbox/core/v1/DbxPathV1.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxPathV1.java
@@ -1,8 +1,8 @@
 package com.dropbox.core.v1;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import static com.dropbox.core.util.StringUtil.jq;
 
-/*>>> import checkers.nullness.quals.Nullable; */
 
 /**
  * Utility functions for working with Dropbox paths.  This SDK uses {@code String}s
@@ -23,7 +23,7 @@ public class DbxPathV1
         return (error == null);
     }
 
-    public static /*@Nullable*/String findError(String path)
+    public static @Nullable String findError(String path)
     {
         if (!path.startsWith("/")) return "must start with \"/\"";
         if (path.length() == 1) return null;  // Special case for "/"
@@ -97,7 +97,7 @@ public class DbxPathV1
      *     <li>{@code getParent("/Photos/Recent/Home.jpeg")} &rarr; {@code "/Photos/Recent"}</li>
      * </ul>
      */
-    public static /*@Nullable*/String getParent(String path)
+    public static @Nullable String getParent(String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (!path.startsWith("/")) throw new IllegalArgumentException("Not a valid path.  Doesn't start with a \"/\": \"" + path + "\"");

--- a/core/src/main/java/com/dropbox/core/v1/DbxPathV1.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxPathV1.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.v1;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import static com.dropbox.core.util.StringUtil.jq;
 
@@ -17,13 +18,13 @@ import static com.dropbox.core.util.StringUtil.jq;
  */
 public class DbxPathV1
 {
-    public static boolean isValid(String path)
+    public static boolean isValid(@Nonnull String path)
     {
         String error = findError(path);
         return (error == null);
     }
 
-    public static @Nullable String findError(String path)
+    public static @Nullable String findError(@Nonnull String path)
     {
         if (!path.startsWith("/")) return "must start with \"/\"";
         if (path.length() == 1) return null;  // Special case for "/"
@@ -38,7 +39,7 @@ public class DbxPathV1
         return null;
     }
 
-    public static void checkArg(String argName, String value)
+    public static void checkArg(@Nonnull String argName, @Nonnull String value)
     {
         if (value == null) {
             throw new IllegalArgumentException("'" + argName + "' should not be null");
@@ -49,7 +50,7 @@ public class DbxPathV1
         }
     }
 
-    public static void checkArgNonRoot(String argName, String value)
+    public static void checkArgNonRoot(@Nonnull String argName, @Nonnull String value)
     {
         if ("/".equals(value)) {
             throw new IllegalArgumentException("'" + argName + "' should not be the root path (\"/\")");
@@ -65,7 +66,7 @@ public class DbxPathV1
      *     <li>{@code getName("/Photos/Home.jpeg")} &rarr; {@code "Home.jpeg"}</li>
      * </ul>
      */
-    public static String getName(String path)
+    public static @Nonnull String getName(@Nonnull String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (!path.startsWith("/")) throw new IllegalArgumentException("Not a valid path.  Doesn't start with a \"/\": \"" + path + "\"");
@@ -78,7 +79,7 @@ public class DbxPathV1
         return path.substring(start+1);
     }
 
-    public static String[] split(String path)
+    public static @Nonnull String[] split(@Nonnull String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (!path.startsWith("/")) throw new IllegalArgumentException("Not a valid path.  Doesn't start with a \"/\": \"" + path + "\"");
@@ -97,7 +98,7 @@ public class DbxPathV1
      *     <li>{@code getParent("/Photos/Recent/Home.jpeg")} &rarr; {@code "/Photos/Recent"}</li>
      * </ul>
      */
-    public static @Nullable String getParent(String path)
+    public static @Nullable String getParent(@Nonnull String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (!path.startsWith("/")) throw new IllegalArgumentException("Not a valid path.  Doesn't start with a \"/\": \"" + path + "\"");

--- a/core/src/main/java/com/dropbox/core/v1/DbxThumbnailFormat.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxThumbnailFormat.java
@@ -1,13 +1,15 @@
 package com.dropbox.core.v1;
 
+import javax.annotation.Nonnull;
+
 /**
  * Thumbnail image format presets, to be used with {@link DbxClientV1#getThumbnail}.
  */
 public class DbxThumbnailFormat
 {
-    public final String ident;
+    public final @Nonnull String ident;
 
-    public DbxThumbnailFormat(String ident)
+    public DbxThumbnailFormat(@Nonnull String ident)
     {
         this.ident = ident;
     }
@@ -15,13 +17,13 @@ public class DbxThumbnailFormat
     /**
      * JPEG format, preferred over PNG for photographic images.
      */
-    public static final DbxThumbnailFormat JPEG = new DbxThumbnailFormat("jpeg");
+    public static final @Nonnull DbxThumbnailFormat JPEG = new DbxThumbnailFormat("jpeg");
 
     /**
      * PNG format, preferred over JPEG for non-photographic images, such as
      * screenshots and digital art.
      */
-    public static final DbxThumbnailFormat PNG = new DbxThumbnailFormat("png");
+    public static final @Nonnull DbxThumbnailFormat PNG = new DbxThumbnailFormat("png");
 
     /**
      * Try and guess the right {@code DbxThumbnailFormat} to use based on the image's file
@@ -34,7 +36,7 @@ public class DbxThumbnailFormat
      * DbxThumbnailFormat.bestForFileName("/family.jpg");       // returns DbxThumbnailFormat.JPEG
      * </pre>
      */
-    public static DbxThumbnailFormat bestForFileName(String fileName, DbxThumbnailFormat fallback)
+    public static @Nonnull DbxThumbnailFormat bestForFileName(@Nonnull String fileName, @Nonnull DbxThumbnailFormat fallback)
     {
         fileName = fileName.toLowerCase();
         if (fileName.endsWith(".png") || fileName.endsWith(".gif")) {

--- a/core/src/main/java/com/dropbox/core/v1/DbxThumbnailSize.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxThumbnailSize.java
@@ -1,22 +1,24 @@
 package com.dropbox.core.v1;
 
+import javax.annotation.Nonnull;
+
 /**
  * Thumbnail size presets, to be used with {@link DbxClientV1#getThumbnail}.
  */
 public class DbxThumbnailSize
 {
-    public final String ident;
+    public final @Nonnull String ident;
     public final int width;
     public final int height;
 
-    public DbxThumbnailSize(String ident, int width, int height)
+    public DbxThumbnailSize(@Nonnull String ident, int width, int height)
     {
         this.ident = ident;
         this.width = width;
         this.height = height;
     }
 
-    public String toString()
+    public @Nonnull String toString()
     {
         return "(" + ident + " " + width + "x" + height + ")";
     }
@@ -24,25 +26,25 @@ public class DbxThumbnailSize
     /**
      * 32x32 pixels.
      */
-    public static final DbxThumbnailSize w32h32 = new DbxThumbnailSize("xs", 32, 32);
+    public static final @Nonnull DbxThumbnailSize w32h32 = new DbxThumbnailSize("xs", 32, 32);
 
     /**
      * 64x64 pixels.
      */
-    public static final DbxThumbnailSize w64h64 = new DbxThumbnailSize("s", 64, 64);
+    public static final @Nonnull DbxThumbnailSize w64h64 = new DbxThumbnailSize("s", 64, 64);
 
     /**
      * 128x128 pixels.
      */
-    public static final DbxThumbnailSize w128h128 = new DbxThumbnailSize("m", 128, 128);
+    public static final @Nonnull DbxThumbnailSize w128h128 = new DbxThumbnailSize("m", 128, 128);
 
     /**
      * 640x480 pixels.
      */
-    public static final DbxThumbnailSize w640h480 = new DbxThumbnailSize("l", 640, 480);
+    public static final @Nonnull DbxThumbnailSize w640h480 = new DbxThumbnailSize("l", 640, 480);
 
     /**
      * 1024x768 pixels.
      */
-    public static final DbxThumbnailSize w1024h768 = new DbxThumbnailSize("xl", 1024, 768);
+    public static final @Nonnull DbxThumbnailSize w1024h768 = new DbxThumbnailSize("xl", 1024, 768);
 }

--- a/core/src/main/java/com/dropbox/core/v1/DbxUrlWithExpiration.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxUrlWithExpiration.java
@@ -10,20 +10,22 @@ import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+
 public final class DbxUrlWithExpiration
 {
-    public final String url;
-    public final Date expires;
+    public final @Nonnull String url;
+    public final @Nonnull Date expires;
 
-    public DbxUrlWithExpiration(String url, Date expires)
+    public DbxUrlWithExpiration(@Nonnull String url, @Nonnull Date expires)
     {
         this.url = url;
         this.expires = expires;
     }
 
-    public static final JsonReader<DbxUrlWithExpiration> Reader = new JsonReader<DbxUrlWithExpiration>() {
+    public static final @Nonnull JsonReader<DbxUrlWithExpiration> Reader = new JsonReader<DbxUrlWithExpiration>() {
         @Override
-        public DbxUrlWithExpiration read(JsonParser parser)
+        public @Nonnull DbxUrlWithExpiration read(@Nonnull JsonParser parser)
             throws IOException, JsonReadException
         {
             JsonLocation top = JsonReader.expectObjectStart(parser);

--- a/core/src/main/java/com/dropbox/core/v1/DbxWriteMode.java
+++ b/core/src/main/java/com/dropbox/core/v1/DbxWriteMode.java
@@ -1,5 +1,7 @@
 package com.dropbox.core.v1;
 
+import javax.annotation.Nonnull;
+
 /**
  * Describes how a file should be saved when it is written to Dropbox.  Do not call
  * the constructor.  Instead, call one of the three static functions: {@link #add},
@@ -10,8 +12,8 @@ public final class DbxWriteMode
     // NOTE: The current implementation just holds the URL parameters that we pass
     // to /files_put.  If the upload mode becomes used in other calls, we may need
     // to switch the implementation over to be less tied to that specific endpoint.
-    final String[] params;
-    DbxWriteMode(String... params)
+    final @Nonnull String[] params;
+    DbxWriteMode(@Nonnull String... params)
     {
         this.params = params;
     }
@@ -30,7 +32,7 @@ public final class DbxWriteMode
      * returned by the API call.
      * </p>
      */
-    public static DbxWriteMode add() { return AddInstance; }
+    public static @Nonnull DbxWriteMode add() { return AddInstance; }
     private static final DbxWriteMode AddInstance = new DbxWriteMode("overwrite", "false");
 
     /**
@@ -39,7 +41,7 @@ public final class DbxWriteMode
      * If there's a folder at that path, however, it will not be overwritten and the
      * API call will fail.
      */
-    public static DbxWriteMode force() { return ForceInstance; }
+    public static @Nonnull DbxWriteMode force() { return ForceInstance; }
     private static final DbxWriteMode ForceInstance = new DbxWriteMode("overwrite", "true");
 
     /**
@@ -66,7 +68,7 @@ public final class DbxWriteMode
      * returned by the API call.
      * </p>
      */
-    public static DbxWriteMode update(String revisionToReplace)
+    public static @Nonnull DbxWriteMode update(@Nonnull String revisionToReplace)
     {
         return new DbxWriteMode("parent_rev", revisionToReplace);
     }

--- a/core/src/main/java/com/dropbox/core/v2/DbxAppClientV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxAppClientV2.java
@@ -9,6 +9,9 @@ import com.dropbox.core.v2.common.PathRoot;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Use this class to make remote calls to the Dropbox API app endpoints.  App endpoints expose
  * actions you can perform as a Dropbox app without user authorization.  You'll need your app key
@@ -28,7 +31,7 @@ public class DbxAppClientV2 extends DbxAppClientV2Base {
      * @param key Dropbox app key (e.g. consumer key in OAuth)
      * @param secret Dropbox app secret (e.g. consumer secret in OAuth)
      */
-    public DbxAppClientV2(DbxRequestConfig requestConfig, String key, String secret) {
+    public DbxAppClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull String key, @Nonnull String secret) {
         this(requestConfig, key, secret, DbxHost.DEFAULT);
     }
 
@@ -43,7 +46,10 @@ public class DbxAppClientV2 extends DbxAppClientV2Base {
      * @param host  Dropbox hosts to send requests to (used for mocking and
      *     testing)
      */
-    public DbxAppClientV2(DbxRequestConfig requestConfig, String key, String secret, DbxHost host) {
+    public DbxAppClientV2(@Nonnull DbxRequestConfig requestConfig,
+                          @Nonnull String key,
+                          @Nonnull String secret,
+                          @Nonnull DbxHost host) {
         super(new DbxAppRawClientV2(requestConfig, key, secret, host, null));
     }
 
@@ -60,7 +66,11 @@ public class DbxAppClientV2 extends DbxAppClientV2Base {
      * @param userId The user ID of the current Dropbox account. Used for
      *               multi-Dropbox account use-case.
      */
-    public DbxAppClientV2(DbxRequestConfig requestConfig, String key, String secret, DbxHost host, String userId) {
+    public DbxAppClientV2(@Nonnull DbxRequestConfig requestConfig,
+                          @Nonnull String key,
+                          @Nonnull String secret,
+                          @Nonnull DbxHost host,
+                          @Nullable String userId) {
         super(new DbxAppRawClientV2(requestConfig, key, secret, host, userId));
     }
 
@@ -68,17 +78,21 @@ public class DbxAppClientV2 extends DbxAppClientV2Base {
      * {@link DbxRawClientV2} raw client that adds app auth headers to all requests.
      */
     private static final class DbxAppRawClientV2 extends DbxRawClientV2 {
-        private final String key;
-        private final String secret;
+        private final @Nonnull String key;
+        private final @Nonnull String secret;
 
-        private DbxAppRawClientV2(DbxRequestConfig requestConfig, String key, String secret, DbxHost host, String userId) {
+        private DbxAppRawClientV2(@Nonnull DbxRequestConfig requestConfig,
+                                  @Nonnull String key,
+                                  @Nonnull String secret,
+                                  @Nonnull DbxHost host,
+                                  @Nullable String userId) {
             super(requestConfig, host, userId, null);
             this.key = key;
             this.secret = secret;
         }
 
         @Override
-        public DbxRefreshResult refreshAccessToken() {
+        public @Nullable DbxRefreshResult refreshAccessToken() {
             //no op
             return null;
         }
@@ -94,13 +108,13 @@ public class DbxAppClientV2 extends DbxAppClientV2Base {
         }
 
         @Override
-        protected void addAuthHeaders(List<HttpRequestor.Header> headers) {
+        protected void addAuthHeaders(@Nonnull List<HttpRequestor.Header> headers) {
             DbxRequestUtil.removeAuthHeader(headers);
             DbxRequestUtil.addBasicAuthHeader(headers, key, secret);
         }
 
         @Override
-        protected DbxRawClientV2 withPathRoot(PathRoot pathRoot) {
+        protected @Nonnull DbxRawClientV2 withPathRoot(@Nonnull PathRoot pathRoot) {
             throw new UnsupportedOperationException("App endpoints don't support Dropbox-API-Path-Root header.");
         }
     }

--- a/core/src/main/java/com/dropbox/core/v2/DbxClientV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxClientV2.java
@@ -12,6 +12,9 @@ import com.dropbox.core.v2.common.PathRoot;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Use this class to make remote calls to the Dropbox API user endpoints.  User
  * endpoints expose actions you can perform as a Dropbox user.  You'll need an
@@ -32,7 +35,7 @@ public class DbxClientV2 extends DbxClientV2Base {
      *     gives your app the ability to make Dropbox API calls. Typically
      *     acquired through {@link com.dropbox.core.DbxWebAuth}
      */
-    public DbxClientV2(DbxRequestConfig requestConfig, String accessToken) {
+    public DbxClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull String accessToken) {
         this(requestConfig, accessToken, DbxHost.DEFAULT, null);
     }
 
@@ -47,7 +50,7 @@ public class DbxClientV2 extends DbxClientV2Base {
      * @param userId The user ID of the current Dropbox account. Used for
      *               multi-Dropbox account use-case.
      */
-    public DbxClientV2(DbxRequestConfig requestConfig, String accessToken, String userId) {
+    public DbxClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull String accessToken, @Nullable String userId) {
         this(requestConfig, accessToken, DbxHost.DEFAULT, userId);
     }
 
@@ -62,7 +65,7 @@ public class DbxClientV2 extends DbxClientV2Base {
      * @param requestConfig Default attributes to use for each request
      * @param credential The credential object containing all the information for authentication.
      */
-    public DbxClientV2(DbxRequestConfig requestConfig, DbxCredential credential) {
+    public DbxClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull DbxCredential credential) {
         this(requestConfig, credential, DbxHost.DEFAULT, null, null);
     }
 
@@ -78,7 +81,7 @@ public class DbxClientV2 extends DbxClientV2Base {
      * @param host  Dropbox hosts to send requests to (used for mocking and
      *     testing)
      */
-    public DbxClientV2(DbxRequestConfig requestConfig, String accessToken, DbxHost host) {
+    public DbxClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull String accessToken, @Nonnull DbxHost host) {
         this(requestConfig, accessToken, host, null);
     }
 
@@ -95,16 +98,19 @@ public class DbxClientV2 extends DbxClientV2Base {
      * @param userId The user ID of the current Dropbox account. Used for multi-Dropbox
      *               account use-case.
      */
-    public DbxClientV2(DbxRequestConfig requestConfig, String accessToken, DbxHost host, String userId) {
+    public DbxClientV2(@Nonnull DbxRequestConfig requestConfig,
+                       @Nonnull String accessToken,
+                       @Nonnull DbxHost host,
+                       @Nullable String userId) {
         this(requestConfig, new DbxCredential(accessToken), host, userId, null);
     }
 
     private DbxClientV2(
-        DbxRequestConfig requestConfig,
-        DbxCredential credential,
-        DbxHost host,
-        String userId,
-        PathRoot pathRoot) {
+        @Nonnull DbxRequestConfig requestConfig,
+        @Nonnull DbxCredential credential,
+        @Nonnull DbxHost host,
+        @Nullable String userId,
+        @Nullable PathRoot pathRoot) {
         super(new DbxUserRawClientV2(requestConfig, credential, host, userId, pathRoot));
     }
 
@@ -115,7 +121,7 @@ public class DbxClientV2 extends DbxClientV2Base {
      *
      * @param client Raw v2 client ot use for issuing requests
      */
-    DbxClientV2(DbxRawClientV2 client) {
+    DbxClientV2(@Nonnull DbxRawClientV2 client) {
         super(client);
     }
 
@@ -133,7 +139,7 @@ public class DbxClientV2 extends DbxClientV2Base {
      *
      * @throws IllegalArgumentException  If {@code pathRoot} is {@code null}
      */
-    public DbxClientV2 withPathRoot(PathRoot pathRoot) {
+    public @Nonnull DbxClientV2 withPathRoot(@Nonnull PathRoot pathRoot) {
         if (pathRoot == null) {
             throw new IllegalArgumentException("'pathRoot' should not be null");
         }
@@ -150,7 +156,7 @@ public class DbxClientV2 extends DbxClientV2Base {
      * token.
      * @throws DbxException If refresh failed before of general problems like network issue.
      */
-    public DbxRefreshResult refreshAccessToken() throws DbxException {
+    public @Nonnull DbxRefreshResult refreshAccessToken() throws DbxException {
         return this._client.refreshAccessToken();
     }
 
@@ -158,10 +164,13 @@ public class DbxClientV2 extends DbxClientV2Base {
      * {@link DbxRawClientV2} raw client that adds user OAuth2 auth headers to all requests.
      */
     private static final class DbxUserRawClientV2 extends DbxRawClientV2 {
-        private final DbxCredential credential;
+        private final @Nonnull DbxCredential credential;
 
-        DbxUserRawClientV2(DbxRequestConfig requestConfig, DbxCredential credential, DbxHost host,
-                           String userId, PathRoot pathRoot) {
+        DbxUserRawClientV2(@Nonnull DbxRequestConfig requestConfig,
+                           @Nonnull DbxCredential credential,
+                           @Nonnull DbxHost host,
+                           @Nullable String userId,
+                           @Nullable PathRoot pathRoot) {
             super(requestConfig, host, userId, pathRoot);
 
             if (credential == null) throw new NullPointerException("credential");
@@ -169,7 +178,7 @@ public class DbxClientV2 extends DbxClientV2Base {
         }
 
         @Override
-        public DbxRefreshResult refreshAccessToken() throws DbxException {
+        public @Nonnull DbxRefreshResult refreshAccessToken() throws DbxException {
             credential.refresh(this.getRequestConfig());
             return new DbxRefreshResult(credential.getAccessToken(), (credential.getExpiresAt() - System.currentTimeMillis())/1000);
         }
@@ -185,13 +194,13 @@ public class DbxClientV2 extends DbxClientV2Base {
         }
 
         @Override
-        protected void addAuthHeaders(List<HttpRequestor.Header> headers) {
+        protected void addAuthHeaders(@Nonnull List<HttpRequestor.Header> headers) {
             DbxRequestUtil.removeAuthHeader(headers);
             DbxRequestUtil.addAuthHeader(headers, credential.getAccessToken());
         }
 
         @Override
-        protected DbxRawClientV2 withPathRoot(PathRoot pathRoot) {
+        protected @Nonnull DbxRawClientV2 withPathRoot(@Nonnull PathRoot pathRoot) {
             return new DbxUserRawClientV2(
                 this.getRequestConfig(),
                 this.credential,

--- a/core/src/main/java/com/dropbox/core/v2/DbxDownloadStyleBuilder.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxDownloadStyleBuilder.java
@@ -14,6 +14,9 @@ import com.dropbox.core.util.IOUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * The common interface for all builders associated with download style methods. After setting any
  * optional request parameters, use {@link #start} or {@link #download} to initiate the request.
@@ -57,15 +60,15 @@ import java.io.OutputStream;
  * @param <R> The return type of the {@link DbxDownloader}
  */
 public abstract class DbxDownloadStyleBuilder<R> {
-    private Long start;
-    private Long length;
+    private @Nullable Long start;
+    private @Nullable Long length;
 
     protected DbxDownloadStyleBuilder() {
         this.start = null;
         this.length = null;
     }
 
-    protected List<HttpRequestor.Header> getHeaders() {
+    protected @Nonnull List<HttpRequestor.Header> getHeaders() {
         if (start == null) {
             return Collections.emptyList();
         }
@@ -95,7 +98,7 @@ public abstract class DbxDownloadStyleBuilder<R> {
      *
      * @throws DbxException if an error occursing issuing the request
      */
-    public abstract DbxDownloader<R> start() throws DbxException;
+    public abstract @Nonnull DbxDownloader<R> start() throws DbxException;
 
     /**
      * Sets the partial byte range to download.
@@ -113,7 +116,7 @@ public abstract class DbxDownloadStyleBuilder<R> {
      *
      * @throws IllegalArgumentException if {@code start} or {@code length} are negative
      */
-    public DbxDownloadStyleBuilder<R> range(long start, long length) {
+    public @Nonnull DbxDownloadStyleBuilder<R> range(long start, long length) {
         if (start < 0) throw new IllegalArgumentException("start must be non-negative");
         if (length < 1) throw new IllegalArgumentException("length must be positive");
 
@@ -138,7 +141,7 @@ public abstract class DbxDownloadStyleBuilder<R> {
      *
      * @throws IllegalArgumentException if {@code start} is negative
      */
-    public DbxDownloadStyleBuilder<R> range(long start) {
+    public @Nonnull DbxDownloadStyleBuilder<R> range(long start) {
         if (start < 0) throw new IllegalArgumentException("start must be non-negative");
 
         this.start = start;
@@ -161,7 +164,7 @@ public abstract class DbxDownloadStyleBuilder<R> {
      * @throws DbxException if an error occurs reading the response or response body
      * @throws IOException if an error occurs writing the response body to the output stream.
      */
-    public R download(OutputStream out) throws DbxException, IOException {
+    public @Nullable R download(@Nonnull OutputStream out) throws DbxException, IOException {
         return start().download(out);
     }
 }

--- a/core/src/main/java/com/dropbox/core/v2/DbxPathV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxPathV2.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.v2;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.annotation.Nullable;
 
 /**
  * Utility functions for working with Dropbox paths.  This SDK uses {@code String}s

--- a/core/src/main/java/com/dropbox/core/v2/DbxPathV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxPathV2.java
@@ -1,5 +1,6 @@
 package com.dropbox.core.v2;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -15,13 +16,13 @@ import javax.annotation.Nullable;
  */
 public class DbxPathV2
 {
-    public static boolean isValid(String path)
+    public static boolean isValid(@Nonnull String path)
     {
         String error = findError(path);
         return (error == null);
     }
 
-    public static @Nullable String findError(String path)
+    public static @Nullable String findError(@Nonnull String path)
     {
         if (path.length() == 0) return null;  // Special case for ""
 
@@ -44,7 +45,7 @@ public class DbxPathV2
      *     <li>{@code getName("/Photos/Home.jpeg")} &rarr; {@code "Home.jpeg"}</li>
      * </ul>
      */
-    public static String getName(String path)
+    public static @Nullable String getName(@Nonnull String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (path.length() == 0) return null;
@@ -58,7 +59,7 @@ public class DbxPathV2
         return path.substring(start+1);
     }
 
-    public static String[] split(String path)
+    public static @Nonnull String[] split(@Nonnull String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (path.length() == 0) return new String[0];
@@ -77,7 +78,7 @@ public class DbxPathV2
      *     <li>{@code getParent("/Photos/Recent/Home.jpeg")} &rarr; {@code "/Photos/Recent"}</li>
      * </ul>
      */
-    public static @Nullable String getParent(String path)
+    public static @Nullable String getParent(@Nonnull String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (path.length() == 0) return null;

--- a/core/src/main/java/com/dropbox/core/v2/DbxPathV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxPathV2.java
@@ -1,6 +1,6 @@
 package com.dropbox.core.v2;
 
-/*>>> import checkers.nullness.quals.Nullable; */
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Utility functions for working with Dropbox paths.  This SDK uses {@code String}s
@@ -21,7 +21,7 @@ public class DbxPathV2
         return (error == null);
     }
 
-    public static /*@Nullable*/String findError(String path)
+    public static @Nullable String findError(String path)
     {
         if (path.length() == 0) return null;  // Special case for ""
 
@@ -77,7 +77,7 @@ public class DbxPathV2
      *     <li>{@code getParent("/Photos/Recent/Home.jpeg")} &rarr; {@code "/Photos/Recent"}</li>
      * </ul>
      */
-    public static /*@Nullable*/String getParent(String path)
+    public static @Nullable String getParent(String path)
     {
         if (path == null) throw new IllegalArgumentException("'path' can't be null");
         if (path.length() == 0) return null;

--- a/core/src/main/java/com/dropbox/core/v2/DbxRawClientV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxRawClientV2.java
@@ -35,10 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-/*>>> import checkers.nullness.quals.NonNull; */
-/*>>> import checkers.nullness.quals.Nullable; */
-/*>>> import checkers.nullness.quals.MonotonicNonNull; */
-/*>>> import checkers.initialization.quals.Initialized; */
 
 /**
  * Use this class to make remote calls to the Dropbox API.  You'll need an access token first,

--- a/core/src/main/java/com/dropbox/core/v2/DbxRawClientV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxRawClientV2.java
@@ -35,6 +35,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 
 /**
  * Use this class to make remote calls to the Dropbox API.  You'll need an access token first,
@@ -46,18 +49,18 @@ import java.util.Random;
  * </p>
  */
 public abstract class DbxRawClientV2 {
-    public static final String USER_AGENT_ID = "OfficialDropboxJavaSDKv2";
+    public static final @Nonnull String USER_AGENT_ID = "OfficialDropboxJavaSDKv2";
 
-    private static final JsonFactory JSON = new JsonFactory();
-    private static final Random RAND = new Random();
+    private static final @Nonnull JsonFactory JSON = new JsonFactory();
+    private static final @Nonnull Random RAND = new Random();
 
-    private final DbxRequestConfig requestConfig;
-    private final DbxHost host;
+    private final @Nonnull DbxRequestConfig requestConfig;
+    private final @Nonnull DbxHost host;
 
     /* for multiple Dropbox account use-case */
-    private final String userId;
+    private final @Nullable String userId;
 
-    private final PathRoot pathRoot;
+    private final @Nullable PathRoot pathRoot;
 
     /**
      * @param requestConfig Configuration controlling How requests should be issued to Dropbox
@@ -66,7 +69,10 @@ public abstract class DbxRawClientV2 {
      * @param userId The user ID of the current Dropbox account. Used for multi-Dropbox account use-case.
      * @param pathRoot We will send this value in Dropbox-API-Path-Root header if it presents.
      */
-    protected DbxRawClientV2(DbxRequestConfig requestConfig, DbxHost host, String userId, PathRoot pathRoot) {
+    protected DbxRawClientV2(@Nonnull DbxRequestConfig requestConfig,
+                             @Nonnull DbxHost host,
+                             @Nullable String userId,
+                             @Nullable PathRoot pathRoot) {
         if (requestConfig == null) throw new NullPointerException("requestConfig");
         if (host == null) throw new NullPointerException("host");
 
@@ -81,9 +87,9 @@ public abstract class DbxRawClientV2 {
      *
      * @param headers List of request headers. Add authentication headers to this list.
      */
-    protected abstract void addAuthHeaders(List<HttpRequestor.Header> headers);
+    protected abstract void addAuthHeaders(@Nonnull List<HttpRequestor.Header> headers);
 
-    public abstract DbxRefreshResult refreshAccessToken() throws DbxException;
+    public abstract @Nullable DbxRefreshResult refreshAccessToken() throws DbxException;
 
     protected abstract boolean canRefreshAccessToken();
 
@@ -106,15 +112,15 @@ public abstract class DbxRawClientV2 {
      *
      * @param pathRoot {@code pathRoot} object containing the content for Dropbox-API-Path-Root header.
      */
-    protected abstract DbxRawClientV2 withPathRoot(PathRoot pathRoot);
+    protected abstract @Nonnull DbxRawClientV2 withPathRoot(@Nonnull PathRoot pathRoot);
 
-    public <ArgT,ResT,ErrT> ResT rpcStyle(final String host,
-                                          final String path,
-                                          final ArgT arg,
+    public <ArgT,ResT,ErrT> @Nullable ResT rpcStyle(final @Nonnull String host,
+                                          final @Nonnull String path,
+                                          final @Nullable ArgT arg,
                                           final boolean noAuth,
-                                          final StoneSerializer<ArgT> argSerializer,
-                                          final StoneSerializer<ResT> responseSerializer,
-                                          final StoneSerializer<ErrT> errorSerializer)
+                                          final @Nonnull StoneSerializer<ArgT> argSerializer,
+                                          final @Nonnull StoneSerializer<ResT> responseSerializer,
+                                          final @Nonnull StoneSerializer<ErrT> errorSerializer)
         throws DbxWrappedException, DbxException {
 
         final byte [] body = writeAsBytes(argSerializer, arg);
@@ -131,10 +137,10 @@ public abstract class DbxRawClientV2 {
         headers.add(new HttpRequestor.Header("Content-Type", "application/json; charset=utf-8"));
 
         return executeRetriableWithRefresh(requestConfig.getMaxRetries(), new RetriableExecution<ResT> () {
-            private String userIdAnon;
+            private @Nullable String userIdAnon;
 
             @Override
-            public ResT execute() throws DbxWrappedException, DbxException {
+            public @Nullable ResT execute() throws DbxWrappedException, DbxException {
                 if (!noAuth) {
                     addAuthHeaders(headers);
                 }
@@ -157,21 +163,21 @@ public abstract class DbxRawClientV2 {
                 }
             }
 
-            private RetriableExecution<ResT> init(String userId){
+            private @Nonnull RetriableExecution<ResT> init(@Nullable String userId){
                 this.userIdAnon = userId;
                 return this;
             }
         }.init(this.userId));
     }
 
-    public <ArgT,ResT,ErrT> DbxDownloader<ResT> downloadStyle(final String host,
-                                                              final String path,
-                                                              final ArgT arg,
+    public <ArgT,ResT,ErrT> @Nonnull DbxDownloader<ResT> downloadStyle(final @Nonnull String host,
+                                                              final @Nonnull String path,
+                                                              final @Nullable ArgT arg,
                                                               final boolean noAuth,
-                                                              final List<HttpRequestor.Header> extraHeaders,
-                                                              final StoneSerializer<ArgT> argSerializer,
-                                                              final StoneSerializer<ResT> responseSerializer,
-                                                              final StoneSerializer<ErrT> errorSerializer)
+                                                              final @Nonnull List<HttpRequestor.Header> extraHeaders,
+                                                              final @Nonnull StoneSerializer<ArgT> argSerializer,
+                                                              final @Nonnull StoneSerializer<ResT> responseSerializer,
+                                                              final @Nonnull StoneSerializer<ErrT> errorSerializer)
         throws DbxWrappedException, DbxException {
 
         final List<HttpRequestor.Header> headers = new ArrayList<HttpRequestor.Header>(extraHeaders);
@@ -186,10 +192,10 @@ public abstract class DbxRawClientV2 {
         final byte[] body = new byte[0];
 
         return executeRetriableWithRefresh(requestConfig.getMaxRetries(), new RetriableExecution<DbxDownloader<ResT>>() {
-            private String userIdAnon;
+            private @Nullable String userIdAnon;
 
             @Override
-            public DbxDownloader<ResT> execute() throws DbxWrappedException, DbxException {
+            public @Nonnull DbxDownloader<ResT> execute() throws DbxWrappedException, DbxException {
                 if (!noAuth) {
                     addAuthHeaders(headers);
                 }
@@ -228,14 +234,14 @@ public abstract class DbxRawClientV2 {
                 }
             }
 
-            private RetriableExecution<DbxDownloader<ResT>> init(String userId){
+            private @Nonnull RetriableExecution<DbxDownloader<ResT>> init(@Nullable String userId){
                 this.userIdAnon = userId;
                 return this;
             }
         }.init(this.userId));
     }
 
-    private static <T> byte [] writeAsBytes(StoneSerializer<T> serializer, T arg) throws DbxException {
+    private static <T> @Nonnull byte [] writeAsBytes(@Nonnull StoneSerializer<T> serializer, @Nullable T arg) throws DbxException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
             serializer.serialize(arg, out);
@@ -245,7 +251,7 @@ public abstract class DbxRawClientV2 {
         return out.toByteArray();
     }
 
-    private static <T> String headerSafeJson(StoneSerializer<T> serializer, T value) {
+    private static <T> @Nonnull String headerSafeJson(@Nonnull StoneSerializer<T> serializer, @Nullable T value) {
         StringWriter out = new StringWriter();
         try {
             JsonGenerator g = JSON.createGenerator(out);
@@ -260,11 +266,11 @@ public abstract class DbxRawClientV2 {
         return out.toString();
     }
 
-    public <ArgT> HttpRequestor.Uploader uploadStyle(String host,
-                                                     String path,
-                                                     ArgT arg,
+    public <ArgT> @Nonnull HttpRequestor.Uploader uploadStyle(@Nonnull String host,
+                                                     @Nonnull String path,
+                                                     @Nullable ArgT arg,
                                                      boolean noAuth,
-                                                     StoneSerializer<ArgT> argSerializer)
+                                                     @Nonnull StoneSerializer<ArgT> argSerializer)
         throws DbxException {
 
         String uri = DbxRequestUtil.buildUri(host, path);
@@ -291,7 +297,7 @@ public abstract class DbxRawClientV2 {
      *
      * @return configuration to use for issuing requests.
      */
-    public DbxRequestConfig getRequestConfig() {
+    public @Nonnull DbxRequestConfig getRequestConfig() {
         return requestConfig;
     }
 
@@ -300,7 +306,7 @@ public abstract class DbxRawClientV2 {
      *
      * @return Dropbox hosts to use for requests.
      */
-    public DbxHost getHost() {
+    public @Nonnull DbxHost getHost() {
         return host;
     }
 
@@ -309,7 +315,7 @@ public abstract class DbxRawClientV2 {
      *
      * @return The user ID of the current Dropbox account.
      */
-    public String getUserId() {
+    public @Nullable String getUserId() {
         return userId;
     }
 
@@ -321,7 +327,7 @@ public abstract class DbxRawClientV2 {
      * behavior backwards compatibility in v1, we leave the old implementation in {@code
      * DbxRequestUtil} unchanged.
      */
-    private static <T> T executeRetriable(int maxRetries, RetriableExecution<T> execution) throws DbxWrappedException, DbxException {
+    private static <T> @Nullable T executeRetriable(int maxRetries, @Nonnull RetriableExecution<T> execution) throws DbxWrappedException, DbxException {
         if (maxRetries == 0) {
             return execution.execute();
         }
@@ -341,7 +347,7 @@ public abstract class DbxRawClientV2 {
         }
     }
 
-    private <T> T executeRetriableWithRefresh(int maxRetries, RetriableExecution<T>
+    private <T> @Nullable T executeRetriableWithRefresh(int maxRetries, @Nonnull RetriableExecution<T>
         execution) throws DbxWrappedException, DbxException {
         try {
             return executeRetriable(maxRetries, execution);
@@ -385,6 +391,6 @@ public abstract class DbxRawClientV2 {
     }
 
     private interface RetriableExecution<T> {
-        T execute() throws DbxWrappedException, DbxException;
+        @Nullable T execute() throws DbxWrappedException, DbxException;
     }
 }

--- a/core/src/main/java/com/dropbox/core/v2/DbxTeamClientV2.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxTeamClientV2.java
@@ -12,6 +12,9 @@ import com.dropbox.core.v2.common.PathRoot;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Use this class to make remote calls to the Dropbox API team endpoints.  Team
  * endpoints expose actions you can perform on or for a Dropbox team.  You'll
@@ -27,7 +30,7 @@ import java.util.List;
  * in a thread safe {@link HttpRequestor} implementation. </p>
  */
 public class DbxTeamClientV2 extends DbxTeamClientV2Base {
-    private final DbxCredential credential;
+    private final @Nonnull DbxCredential credential;
 
     /**
      * Creates a client that uses the given OAuth 2 access token as
@@ -38,7 +41,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      *     gives your app the ability to make Dropbox API calls. Typically
      *     acquired through {@link com.dropbox.core.DbxWebAuth}
      */
-    public DbxTeamClientV2(DbxRequestConfig requestConfig, String accessToken) {
+    public DbxTeamClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull String accessToken) {
         this(requestConfig, accessToken, DbxHost.DEFAULT);
     }
 
@@ -54,7 +57,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      * @param host  Dropbox hosts to send requests to (used for mocking and
      *     testing)
      */
-    public DbxTeamClientV2(DbxRequestConfig requestConfig, String accessToken, DbxHost host) {
+    public DbxTeamClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull String accessToken, @Nonnull DbxHost host) {
         this(requestConfig, accessToken, host, null);
     }
 
@@ -69,7 +72,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      * @param requestConfig Default attributes to use for each request
      * @param credential The credential object containing all the information for authentication.
      */
-    public DbxTeamClientV2(DbxRequestConfig requestConfig, DbxCredential credential) {
+    public DbxTeamClientV2(@Nonnull DbxRequestConfig requestConfig, @Nonnull DbxCredential credential) {
         this(requestConfig, credential, DbxHost.DEFAULT, null);
     }
 
@@ -86,7 +89,10 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      * @param userId The user ID of the current Dropbox account. Used for
      *               multi-Dropbox account use-case.
      */
-    public DbxTeamClientV2(DbxRequestConfig requestConfig, String accessToken, DbxHost host, String userId) {
+    public DbxTeamClientV2(@Nonnull DbxRequestConfig requestConfig,
+                           @Nonnull String accessToken,
+                           @Nonnull DbxHost host,
+                           @Nullable String userId) {
         this(requestConfig, new DbxCredential(accessToken), host, userId);
     }
 
@@ -102,8 +108,10 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      * @param userId The user ID of the current Dropbox account. Used for
      *               multi-Dropbox account use-case.
      */
-    public DbxTeamClientV2(DbxRequestConfig requestConfig, DbxCredential credential, DbxHost host,
-                           String userId) {
+    public DbxTeamClientV2(@Nonnull DbxRequestConfig requestConfig,
+                           @Nonnull DbxCredential credential,
+                           @Nonnull DbxHost host,
+                           @Nullable String userId) {
         super(new DbxTeamRawClientV2(requestConfig, credential, host, userId, null, null, null));
         this.credential = credential;
     }
@@ -118,7 +126,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      * token.
      * @throws DbxException If refresh failed before of general problems like network issue.
      */
-    public DbxRefreshResult refreshAccessToken() throws DbxException {
+    public @Nonnull DbxRefreshResult refreshAccessToken() throws DbxException {
         return this._client.refreshAccessToken();
     }
 
@@ -136,7 +144,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      *
      * @throws IllegalArgumentException  If {@code memberId} is {@code null}
      */
-    public DbxClientV2 asMember(String memberId) {
+    public @Nonnull DbxClientV2 asMember(@Nonnull String memberId) {
         if (memberId == null) {
             throw new IllegalArgumentException("'memberId' should not be null");
         }
@@ -167,7 +175,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      *
      * @throws IllegalArgumentException  If {@code adminId} is {@code null}
      */
-    public DbxClientV2 asAdmin(String adminId) {
+    public @Nonnull DbxClientV2 asAdmin(@Nonnull String adminId) {
         if (adminId == null) {
             throw new IllegalArgumentException("'adminId' should not be null");
         }
@@ -190,18 +198,18 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
      * to perform requests as a particular team member).
      */
     private static final class DbxTeamRawClientV2 extends DbxRawClientV2 {
-        private final DbxCredential credential;
-        private final String memberId;
-        private final String adminId;
+        private final @Nonnull DbxCredential credential;
+        private final @Nullable String memberId;
+        private final @Nullable String adminId;
 
         private DbxTeamRawClientV2(
-            DbxRequestConfig requestConfig,
-            DbxCredential credential,
-            DbxHost host,
-            String userId,
-            String memberId,
-            String adminId,
-            PathRoot pathRoot) {
+            @Nonnull DbxRequestConfig requestConfig,
+            @Nonnull DbxCredential credential,
+            @Nonnull DbxHost host,
+            @Nullable String userId,
+            @Nullable String memberId,
+            @Nullable String adminId,
+            @Nullable PathRoot pathRoot) {
             super(requestConfig, host, userId, pathRoot);
 
             if (credential == null) throw new NullPointerException("credential");
@@ -212,7 +220,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
         }
 
         @Override
-        public DbxRefreshResult refreshAccessToken() throws DbxException {
+        public @Nonnull DbxRefreshResult refreshAccessToken() throws DbxException {
             credential.refresh(this.getRequestConfig());
             return new DbxRefreshResult(credential.getAccessToken(), (credential.getExpiresAt() - System.currentTimeMillis())/1000);
         }
@@ -228,7 +236,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
         }
 
         @Override
-        protected void addAuthHeaders(List<HttpRequestor.Header> headers) {
+        protected void addAuthHeaders(@Nonnull List<HttpRequestor.Header> headers) {
             DbxRequestUtil.removeAuthHeader(headers);
             DbxRequestUtil.addAuthHeader(headers, credential.getAccessToken());
             if (memberId != null) {
@@ -240,7 +248,7 @@ public class DbxTeamClientV2 extends DbxTeamClientV2Base {
         }
 
         @Override
-        protected DbxRawClientV2 withPathRoot(PathRoot pathRoot) {
+        protected @Nonnull DbxRawClientV2 withPathRoot(@Nonnull PathRoot pathRoot) {
             return new DbxTeamRawClientV2(
                 this.getRequestConfig(),
                 this.credential,

--- a/core/src/main/java/com/dropbox/core/v2/DbxUploadStyleBuilder.java
+++ b/core/src/main/java/com/dropbox/core/v2/DbxUploadStyleBuilder.java
@@ -6,6 +6,9 @@ import com.dropbox.core.util.IOUtil;
 import java.io.IOException;
 import java.io.InputStream;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * The common interface for all builders associated with upload style methods. After setting any
  * optional request parameters, use {@link #start} or {@link #uploadAndFinish} to initiate the
@@ -70,7 +73,7 @@ public abstract class DbxUploadStyleBuilder<R,E, X extends DbxApiException> {
      *
      * @throws DbxException if an error occursing initializing the request
      */
-    public abstract DbxUploader<R, E, X> start() throws DbxException;
+    public abstract @Nonnull DbxUploader<R, E, X> start() throws DbxException;
 
     /**
      * Convenience method for {@link DbxUploader#uploadAndFinish(InputStream)}:
@@ -87,7 +90,7 @@ public abstract class DbxUploadStyleBuilder<R,E, X extends DbxApiException> {
      * @throws DbxException if an error occurs uploading the data or reading the response
      * @throws IOException if an error occurs reading the input stream.
      */
-    public R uploadAndFinish(InputStream in) throws X, DbxException, IOException
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in) throws X, DbxException, IOException
     {
         return start().uploadAndFinish(in);
     }
@@ -108,7 +111,7 @@ public abstract class DbxUploadStyleBuilder<R,E, X extends DbxApiException> {
      * @throws DbxException if an error occurs uploading the data or reading the response
      * @throws IOException if an error occurs reading the input stream.
      */
-    public R uploadAndFinish(InputStream in, long limit) throws X, DbxException, IOException
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in, long limit) throws X, DbxException, IOException
     {
         return start().uploadAndFinish(in, limit);
     }
@@ -131,7 +134,9 @@ public abstract class DbxUploadStyleBuilder<R,E, X extends DbxApiException> {
      * @throws DbxException if an error occurs uploading the data or reading the response
      * @throws IOException if an error occurs reading the input stream.
      */
-    public R uploadAndFinish(InputStream in, long limit, IOUtil.ProgressListener progressListener)
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in,
+                                       long limit,
+                                       @Nullable IOUtil.ProgressListener progressListener)
             throws X, DbxException, IOException
     {
         return start().uploadAndFinish(in, limit, progressListener);
@@ -154,7 +159,7 @@ public abstract class DbxUploadStyleBuilder<R,E, X extends DbxApiException> {
      * @throws DbxException if an error occurs uploading the data or reading the response
      * @throws IOException if an error occurs reading the input stream.
      */
-    public R uploadAndFinish(InputStream in, IOUtil.ProgressListener progressListener)
+    public @Nullable R uploadAndFinish(@Nonnull InputStream in, @Nullable IOUtil.ProgressListener progressListener)
             throws X, DbxException, IOException
     {
         return start().uploadAndFinish(in, progressListener);

--- a/core/src/main/java/com/dropbox/core/v2/callbacks/DbxGlobalCallbackFactory.java
+++ b/core/src/main/java/com/dropbox/core/v2/callbacks/DbxGlobalCallbackFactory.java
@@ -1,5 +1,8 @@
 package com.dropbox.core.v2.callbacks;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Client should implement methods in this class to allow for consistent, global handling of route-specific error types,
  * as well as general network errors. Normally, error handling is done on a request-by-request basis.
@@ -10,8 +13,8 @@ package com.dropbox.core.v2.callbacks;
  */
 public interface DbxGlobalCallbackFactory {
     // Should instantiate separate callback object on each method invocation
-    <T> DbxRouteErrorCallback<T> createRouteErrorCallback(String userId, T routeError);
+    <T> @Nullable DbxRouteErrorCallback<T> createRouteErrorCallback(@Nullable String userId, @Nullable T routeError);
 
     // Should instantiate separate callback object on each method invocation
-    DbxNetworkErrorCallback createNetworkErrorCallback(String userId);
+    @Nonnull DbxNetworkErrorCallback createNetworkErrorCallback(@Nullable String userId);
 }

--- a/core/src/main/java/com/dropbox/core/v2/callbacks/DbxNetworkErrorCallback.java
+++ b/core/src/main/java/com/dropbox/core/v2/callbacks/DbxNetworkErrorCallback.java
@@ -2,9 +2,11 @@ package com.dropbox.core.v2.callbacks;
 
 import com.dropbox.core.DbxException;
 
+import javax.annotation.Nonnull;
+
 /**
  * Abstract class for network error callback.
  */
 public abstract class DbxNetworkErrorCallback {
-    public abstract void onNetworkError(DbxException networkError);
+    public abstract void onNetworkError(@Nonnull DbxException networkError);
 }

--- a/core/src/main/java/com/dropbox/core/v2/callbacks/DbxRouteErrorCallback.java
+++ b/core/src/main/java/com/dropbox/core/v2/callbacks/DbxRouteErrorCallback.java
@@ -1,16 +1,18 @@
 package com.dropbox.core.v2.callbacks;
 
+import javax.annotation.Nullable;
+
 /**
  * Interface for route error callback.
  */
 public abstract class DbxRouteErrorCallback<T> implements Runnable {
-    private T routeError = null;
+    private @Nullable T routeError = null;
 
-    public T getRouteError() {
+    public @Nullable T getRouteError() {
         return routeError;
     }
 
-    public void setRouteError(T routeError) {
+    public void setRouteError(@Nullable T routeError) {
         this.routeError = routeError;
     }
 }

--- a/examples/android/dependencies/releaseRuntimeClasspath.txt
+++ b/examples/android/dependencies/releaseRuntimeClasspath.txt
@@ -58,7 +58,6 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.guava:listenablefuture:1.0
 com.squareup.okhttp3:okhttp:4.0.0
 com.squareup.okio:okio:2.2.2
-org.checkerframework:checker-qual:4.1.0
 org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

--- a/examples/android/dependencies/releaseRuntimeClasspath.txt
+++ b/examples/android/dependencies/releaseRuntimeClasspath.txt
@@ -58,6 +58,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.guava:listenablefuture:1.0
 com.squareup.okhttp3:okhttp:4.0.0
 com.squareup.okio:okio:2.2.2
+org.checkerframework:checker-qual:4.1.0
 org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxApiWrapper.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxApiWrapper.kt
@@ -49,7 +49,9 @@ class DropboxApiWrapper(
                     .uploadBuilder("/$fileName") //Upload to the root of Dropbox
                     .withMode(WriteMode.OVERWRITE)
                     .uploadAndFinish(inputStream)
-                DropboxUploadApiResponse.Success(fileMetadata)
+                DropboxUploadApiResponse.Success(
+                    requireNotNull(fileMetadata) { "Upload did not return file metadata." }
+                )
             } catch (exception: DbxException) {
                 DropboxUploadApiResponse.Failure(exception)
             }
@@ -139,7 +141,9 @@ class DropboxApiWrapper(
                         )
                             .withMode(WriteMode.OVERWRITE)
                             .uploadAndFinish(inputStream)
-                        FileMetadataApiResult.Success(metadata)
+                        FileMetadataApiResult.Success(
+                            requireNotNull(metadata) { "Upload did not return file metadata." }
+                        )
                     }
                 } catch (e: DbxException) {
                     FileMetadataApiResult.Error(e)
@@ -190,5 +194,4 @@ class DropboxApiWrapper(
         }
     }
 }
-
 

--- a/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxCredentialUtil.kt
+++ b/examples/android/src/main/java/com/dropbox/core/examples/android/internal/api/DropboxCredentialUtil.kt
@@ -14,7 +14,7 @@ class DropboxCredentialUtil(appContext: Context) {
     )
 
     fun readCredentialLocally(): DbxCredential? {
-        val serializedCredentialJson = sharedPreferences.getString("credential", null)
+        val serializedCredentialJson = sharedPreferences.getString("credential", null) ?: return null
         Log.d(TAG, "Local Credential Value from Shared Preferences: $serializedCredentialJson")
         return try {
             DbxCredential.Reader.readFully(serializedCredentialJson)

--- a/examples/examples/src/main/java/com/dropbox/core/examples/CredentialsUtil.kt
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/CredentialsUtil.kt
@@ -69,11 +69,15 @@ object CredentialsUtil {
     private val authOutputFile = File("../../auth_output")
 
     fun getDbxCredential(): DbxCredential {
-        return DbxCredential.Reader.readFromFile(authOutputFile)
+        return requireNotNull(DbxCredential.Reader.readFromFile(authOutputFile)) {
+            "Credential file did not contain credentials."
+        }
     }
 
     fun getAuthInfo(): DbxAuthInfo {
-        return DbxAuthInfo.Reader.readFromFile(authOutputFile)
+        return requireNotNull(DbxAuthInfo.Reader.readFromFile(authOutputFile)) {
+            "Credential file did not contain auth info."
+        }
     }
 
 }

--- a/examples/examples/src/main/java/com/dropbox/core/examples/authorize/AuthorizeExample.kt
+++ b/examples/examples/src/main/java/com/dropbox/core/examples/authorize/AuthorizeExample.kt
@@ -59,6 +59,10 @@ object AuthorizeExample {
             System.err.println("Error reading <app-info-file>: " + ex.message)
             System.exit(1)
             return
+        } ?: run {
+            System.err.println("Error reading <app-info-file>: app info file did not contain app info.")
+            System.exit(1)
+            return
         }
 
         // Run through Dropbox API authorization process

--- a/examples/java/dependencies/compileClasspath.txt
+++ b/examples/java/dependencies/compileClasspath.txt
@@ -2,3 +2,4 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
+org.checkerframework:checker-qual:4.1.0

--- a/examples/java/dependencies/compileClasspath.txt
+++ b/examples/java/dependencies/compileClasspath.txt
@@ -2,4 +2,3 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
-org.checkerframework:checker-qual:4.1.0

--- a/examples/java/dependencies/runtimeClasspath.txt
+++ b/examples/java/dependencies/runtimeClasspath.txt
@@ -2,3 +2,4 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
+org.checkerframework:checker-qual:4.1.0

--- a/examples/java/dependencies/runtimeClasspath.txt
+++ b/examples/java/dependencies/runtimeClasspath.txt
@@ -2,4 +2,3 @@ ch.randelshofer:fastdoubleparser:0.8.0
 com.fasterxml.jackson.core:jackson-core:2.15.0
 com.fasterxml.jackson:jackson-bom:2.15.0
 com.google.code.findbugs:jsr305:3.0.2
-org.checkerframework:checker-qual:4.1.0

--- a/gradle/dropboxJavaSdkLibs.versions.toml
+++ b/gradle/dropboxJavaSdkLibs.versions.toml
@@ -28,6 +28,7 @@ jackson-core = 'com.fasterxml.jackson.core:jackson-core:2.15.0'
 jackson-databind = 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 jetty-server = "org.eclipse.jetty:jetty-server:11.0.15"
 json = "org.json:json:20230618"
+checker-qual = 'org.checkerframework:checker-qual:4.1.0'
 jakarta-servlet-api = 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 jsr305 = 'com.google.code.findbugs:jsr305:3.0.2'
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/dropboxJavaSdkLibs.versions.toml
+++ b/gradle/dropboxJavaSdkLibs.versions.toml
@@ -28,7 +28,6 @@ jackson-core = 'com.fasterxml.jackson.core:jackson-core:2.15.0'
 jackson-databind = 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 jetty-server = "org.eclipse.jetty:jetty-server:11.0.15"
 json = "org.json:json:20230618"
-checker-qual = 'org.checkerframework:checker-qual:4.1.0'
 jakarta-servlet-api = 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 jsr305 = 'com.google.code.findbugs:jsr305:3.0.2'
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
Convert handwritten Java sources from Checker Framework comment-style nullability markers to real Checker Framework type-use annotations. Add checker-qual as an API dependency and update dependency guard snapshots for downstream modules.