### PR TITLE
Add an option to generate API calls using a DbxRequest wrapper

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -135,6 +135,10 @@ public class com/dropbox/core/DbxPKCEWebAuth {
 	public fun finishFromRedirect (Ljava/lang/String;Lcom/dropbox/core/DbxSessionStore;Ljava/util/Map;)Lcom/dropbox/core/DbxAuthFinish;
 }
 
+public abstract interface class com/dropbox/core/DbxRequest {
+	public abstract fun call ()Ljava/lang/Object;
+}
+
 public class com/dropbox/core/DbxRequestConfig {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -306,7 +306,7 @@ tasks.named("generateTestStone", StoneTask) {
             ),
             new StoneConfig(
                     packageName: packageName,
-                    callRequest: true,
+                    generateRequest: true,
                     client: new ClientSpec(
                             name: 'DbxClientV2Base',
                             javadoc: 'TestClass.',

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -306,6 +306,7 @@ tasks.named("generateTestStone", StoneTask) {
             ),
             new StoneConfig(
                     packageName: packageName,
+                    callRequest: true,
                     client: new ClientSpec(
                             name: 'DbxClientV2Base',
                             javadoc: 'TestClass.',

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/DbxTestTestRequests.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/DbxTestTestRequests.java
@@ -87,7 +87,7 @@ public class DbxTestTestRequests {
      * @param breed  Must not be {@code null}.
      *
      * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     *     {@code DbxDownloader&lt;Fish&gt;}.
      */
     public DbxRequest<DbxDownloader<Fish>> testDownloadRequest(String name, String breed) {
         return () -> testDownload(name, breed);
@@ -162,7 +162,7 @@ public class DbxTestTestRequests {
      * @param sessionId  Must not be {@code null}.
      *
      * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     *     {@code DbxDownloader&lt;Fish&gt;}.
      */
     public DbxRequest<DbxDownloader<Fish>> testDownloadV2Request(UninitializedReason reason, String sessionId) {
         return () -> testDownloadV2(reason, sessionId);
@@ -208,8 +208,7 @@ public class DbxTestTestRequests {
     /**
      * See {@link DbxTestTestRequests#testRoute}.
      *
-     * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     * @return A {@link DbxRequest} that can be executed later.
      */
     public DbxRequest<java.lang.Void> testRouteRequest() {
         return () -> { testRoute(); return null; };
@@ -258,8 +257,7 @@ public class DbxTestTestRequests {
      *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
      *     null}.
      *
-     * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     * @return A {@link DbxRequest} that can be executed later.
      */
     public DbxRequest<java.lang.Void> testRouteV2Request(String name) {
         return () -> { testRouteV2(name); return null; };
@@ -286,8 +284,7 @@ public class DbxTestTestRequests {
      *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
      *     null}.
      *
-     * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     * @return A {@link DbxRequest} that can be executed later.
      */
     public DbxRequest<java.lang.Void> testRouteV2Request(String name, Date born) {
         return () -> { testRouteV2(name, born); return null; };
@@ -333,7 +330,7 @@ public class DbxTestTestRequests {
      * @param sessionId  Must not be {@code null}.
      *
      * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     *     {@code TestUploadUploader}.
      */
     public DbxRequest<TestUploadUploader> testUploadRequest(UninitializedReason reason, String sessionId) {
         return () -> testUpload(reason, sessionId);
@@ -383,7 +380,7 @@ public class DbxTestTestRequests {
      * @param breed  Must not be {@code null}.
      *
      * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     *     {@code TestUploadV2Uploader}.
      */
     public DbxRequest<TestUploadV2Uploader> testUploadV2Request(String name, String breed) {
         return () -> testUploadV2(name, breed);
@@ -451,7 +448,7 @@ public class DbxTestTestRequests {
      * @param breed  Must not be {@code null}.
      *
      * @return A {@link DbxRequest} that can be executed later to obtain the
-     *     result.
+     *     {@code TestUploadV3Uploader}.
      */
     public DbxRequest<TestUploadV3Uploader> testUploadV3Request(String name, String breed) {
         return () -> testUploadV3(name, breed);

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/DbxTestTestRequests.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/DbxTestTestRequests.java
@@ -6,6 +6,7 @@ package com.dropbox.core.stone.test;
 import com.dropbox.core.DbxApiException;
 import com.dropbox.core.DbxDownloader;
 import com.dropbox.core.DbxException;
+import com.dropbox.core.DbxRequest;
 import com.dropbox.core.DbxUploader;
 import com.dropbox.core.DbxWrappedException;
 import com.dropbox.core.http.HttpRequestor;
@@ -78,6 +79,21 @@ public class DbxTestTestRequests {
     }
 
     /**
+     * See {@link DbxTestTestRequests#testDownload(String,String)}.
+     *
+     * @param name  Used in {@link
+     *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
+     *     null}.
+     * @param breed  Must not be {@code null}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<DbxDownloader<Fish>> testDownloadRequest(String name, String breed) {
+        return () -> testDownload(name, breed);
+    }
+
+    /**
      *
      * @param name  Used in {@link
      *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
@@ -139,6 +155,20 @@ public class DbxTestTestRequests {
     }
 
     /**
+     * See {@link
+     * DbxTestTestRequests#testDownloadV2(UninitializedReason,String)}.
+     *
+     * @param reason  Must not be {@code null}.
+     * @param sessionId  Must not be {@code null}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<DbxDownloader<Fish>> testDownloadV2Request(UninitializedReason reason, String sessionId) {
+        return () -> testDownloadV2(reason, sessionId);
+    }
+
+    /**
      *
      * @param reason  Must not be {@code null}.
      * @param sessionId  Must not be {@code null}.
@@ -173,6 +203,16 @@ public class DbxTestTestRequests {
         catch (DbxWrappedException ex) {
             throw new DbxApiException(ex.getRequestId(), ex.getUserMessage(), "Unexpected error response for \"test_route\":" + ex.getErrorValue());
         }
+    }
+
+    /**
+     * See {@link DbxTestTestRequests#testRoute}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<java.lang.Void> testRouteRequest() {
+        return () -> { testRoute(); return null; };
     }
 
     //
@@ -212,6 +252,20 @@ public class DbxTestTestRequests {
     }
 
     /**
+     * See {@link DbxTestTestRequests#testRouteV2(String,Date)}.
+     *
+     * @param name  Used in {@link
+     *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
+     *     null}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<java.lang.Void> testRouteV2Request(String name) {
+        return () -> { testRouteV2(name); return null; };
+    }
+
+    /**
      *
      * @param name  Used in {@link
      *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
@@ -223,6 +277,20 @@ public class DbxTestTestRequests {
     public void testRouteV2(String name, Date born) throws ParentUnionException, DbxException {
         Pet _arg = new Pet(name, born);
         testRouteV2(_arg);
+    }
+
+    /**
+     * See {@link DbxTestTestRequests#testRouteV2(String,Date)}.
+     *
+     * @param name  Used in {@link
+     *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
+     *     null}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<java.lang.Void> testRouteV2Request(String name, Date born) {
+        return () -> { testRouteV2(name, born); return null; };
     }
 
     //
@@ -258,6 +326,19 @@ public class DbxTestTestRequests {
         return testUpload(_arg);
     }
 
+    /**
+     * See {@link DbxTestTestRequests#testUpload(UninitializedReason,String)}.
+     *
+     * @param reason  Must not be {@code null}.
+     * @param sessionId  Must not be {@code null}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<TestUploadUploader> testUploadRequest(UninitializedReason reason, String sessionId) {
+        return () -> testUpload(reason, sessionId);
+    }
+
     //
     // route 2/test/test_upload_v2
     //
@@ -291,6 +372,21 @@ public class DbxTestTestRequests {
     public TestUploadV2Uploader testUploadV2(String name, String breed) throws DbxException {
         Dog _arg = new Dog(name, breed);
         return testUploadV2(_arg);
+    }
+
+    /**
+     * See {@link DbxTestTestRequests#testUploadV2(String,String)}.
+     *
+     * @param name  Used in {@link
+     *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
+     *     null}.
+     * @param breed  Must not be {@code null}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<TestUploadV2Uploader> testUploadV2Request(String name, String breed) {
+        return () -> testUploadV2(name, breed);
     }
 
     /**
@@ -344,6 +440,21 @@ public class DbxTestTestRequests {
     public TestUploadV3Uploader testUploadV3(String name, String breed) throws DbxException {
         Dog _arg = new Dog(name, breed);
         return testUploadV3(_arg);
+    }
+
+    /**
+     * See {@link DbxTestTestRequests#testUploadV3(String,String)}.
+     *
+     * @param name  Used in {@link
+     *     DbxTestTestRequests#testRouteV2(String,Date)}. Must not be {@code
+     *     null}.
+     * @param breed  Must not be {@code null}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     result.
+     */
+    public DbxRequest<TestUploadV3Uploader> testUploadV3Request(String name, String breed) {
+        return () -> testUploadV3(name, breed);
     }
 
     /**

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/DbxTestTestUploadV3Builder.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/DbxTestTestUploadV3Builder.java
@@ -4,6 +4,7 @@
 package com.dropbox.core.stone.test;
 
 import com.dropbox.core.DbxException;
+import com.dropbox.core.DbxRequest;
 import com.dropbox.core.util.LangUtil;
 import com.dropbox.core.v2.DbxUploadStyleBuilder;
 
@@ -64,5 +65,15 @@ public class DbxTestTestUploadV3Builder extends DbxUploadStyleBuilder<Void, Pare
     public TestUploadV3Uploader start() throws ParentUnionException, DbxException {
         Dog arg_ = this._builder.build();
         return _client.testUploadV3(arg_);
+    }
+
+    /**
+     * See {@link DbxTestTestRequests#testUploadV3(String,String)}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     {@code TestUploadV3Uploader}.
+     */
+    public DbxRequest<TestUploadV3Uploader> startRequest() {
+        return () -> start();
     }
 }

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/TestDownloadBuilder.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/TestDownloadBuilder.java
@@ -6,6 +6,7 @@ package com.dropbox.core.stone.test;
 import com.dropbox.core.DbxApiException;
 import com.dropbox.core.DbxDownloader;
 import com.dropbox.core.DbxException;
+import com.dropbox.core.DbxRequest;
 import com.dropbox.core.util.LangUtil;
 import com.dropbox.core.v2.DbxDownloadStyleBuilder;
 
@@ -66,5 +67,15 @@ public class TestDownloadBuilder extends DbxDownloadStyleBuilder<Fish> {
     public DbxDownloader<Fish> start() throws DbxApiException, DbxException {
         Dog arg_ = this._builder.build();
         return _client.testDownload(arg_, getHeaders());
+    }
+
+    /**
+     * See {@link DbxTestTestRequests#testDownload(String,String)}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     {@code DbxDownloader&lt;Fish&gt;}.
+     */
+    public DbxRequest<DbxDownloader<Fish>> startRequest() {
+        return () -> start();
     }
 }

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/TestDownloadV2Builder.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/TestDownloadV2Builder.java
@@ -5,6 +5,7 @@ package com.dropbox.core.stone.test;
 
 import com.dropbox.core.DbxDownloader;
 import com.dropbox.core.DbxException;
+import com.dropbox.core.DbxRequest;
 import com.dropbox.core.v2.DbxDownloadStyleBuilder;
 
 /**
@@ -45,5 +46,16 @@ public class TestDownloadV2Builder extends DbxDownloadStyleBuilder<Fish> {
     public DbxDownloader<Fish> start() throws ParentUnionException, DbxException {
         Uninitialized arg_ = new Uninitialized(reason, sessionId);
         return _client.testDownloadV2(arg_, getHeaders());
+    }
+
+    /**
+     * See {@link
+     * DbxTestTestRequests#testDownloadV2(UninitializedReason,String)}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     {@code DbxDownloader&lt;Fish&gt;}.
+     */
+    public DbxRequest<DbxDownloader<Fish>> startRequest() {
+        return () -> start();
     }
 }

--- a/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/TestUploadV2Builder.java
+++ b/core/build/generated_stone_source/test/src/com/dropbox/core/stone/test/TestUploadV2Builder.java
@@ -4,6 +4,7 @@
 package com.dropbox.core.stone.test;
 
 import com.dropbox.core.DbxException;
+import com.dropbox.core.DbxRequest;
 import com.dropbox.core.util.LangUtil;
 import com.dropbox.core.v2.DbxUploadStyleBuilder;
 
@@ -64,5 +65,15 @@ public class TestUploadV2Builder extends DbxUploadStyleBuilder<Void, ParentUnion
     public TestUploadV2Uploader start() throws ParentUnionException, DbxException {
         Dog arg_ = this._builder.build();
         return _client.testUploadV2(arg_);
+    }
+
+    /**
+     * See {@link DbxTestTestRequests#testUploadV2(String,String)}.
+     *
+     * @return A {@link DbxRequest} that can be executed later to obtain the
+     *     {@code TestUploadV2Uploader}.
+     */
+    public DbxRequest<TestUploadV2Uploader> startRequest() {
+        return () -> start();
     }
 }

--- a/core/generator/java/java.stoneg.py
+++ b/core/generator/java/java.stoneg.py
@@ -621,7 +621,7 @@ _CMDLINE_PARSER.add_argument('--javadoc-refs', type=str, default=None,
                                   'exist.')
 _CMDLINE_PARSER.add_argument('--unused-classes-to-generate', default=None, help='Specify types ' +
                                                                                 'that we want to generate regardless of whether they are used.')
-_CMDLINE_PARSER.add_argument('--call-request', action="store_true", default=False,
+_CMDLINE_PARSER.add_argument('--generate-request', action="store_true", default=False,
                              help='Generate additional *Request methods that return DbxRequest<T>.')
 
 
@@ -731,7 +731,7 @@ class JavaImporter:
             'java.util.HashMap',
             'java.util.Map',
         )
-        if self._j._args.call_request:
+        if self._j._args.generate_request:
             self.add_imports('com.dropbox.core.DbxRequest')
         for route in namespace.routes:
             self.add_imports_for_route(route)
@@ -799,7 +799,7 @@ class JavaImporter:
         elif j.request_style(route) == 'upload':
             self.add_imports('com.dropbox.core.v2.DbxUploadStyleBuilder')
 
-        if self._j._args.call_request:
+        if self._j._args.generate_request:
             self.add_imports('com.dropbox.core.DbxRequest')
 
     def add_imports_for_route_uploader(self, route):
@@ -2807,7 +2807,7 @@ class JavaCodeGenerationInstance:
             else:
                 assert False, "unrecognized route request style: %s" % j.request_style(route)
 
-        if is_public and self.g.args.call_request:
+        if is_public and self.g.args.generate_request:
             request_args = w.fmt('%s arg', j.java_class(route.arg_data_type)) if j.has_arg(route) else ''
             request_arg_names = 'arg' if j.has_arg(route) else ''
             self._emit_request_method_body(route, request_args, request_arg_names, return_class,
@@ -2927,7 +2927,7 @@ class JavaCodeGenerationInstance:
             else:
                 w.out('%s(_arg);', j.route_method(route))
 
-        if self.g.args.call_request:
+        if self.g.args.generate_request:
             request_args = ', '.join(
                 w.fmt('%s %s', j.java_class(f), j.param_name(f)) for f in fields
             )
@@ -3904,7 +3904,7 @@ class JavaCodeGenerationInstance:
                     else:
                         w.out('_client.%s(%s);', j.route_method(route), ', '.join(args))
 
-                if self.g.args.call_request:
+                if self.g.args.generate_request:
                     self._emit_request_method_body(route, '', '', return_class,
                                                    method_name='startRequest', delegate='start()')
 

--- a/core/generator/java/java.stoneg.py
+++ b/core/generator/java/java.stoneg.py
@@ -799,6 +799,9 @@ class JavaImporter:
         elif j.request_style(route) == 'upload':
             self.add_imports('com.dropbox.core.v2.DbxUploadStyleBuilder')
 
+        if self._j._args.call_request:
+            self.add_imports('com.dropbox.core.DbxRequest')
+
     def add_imports_for_route_uploader(self, route):
         self.add_imports(
             'com.dropbox.core.DbxWrappedException',
@@ -3896,6 +3899,29 @@ class JavaCodeGenerationInstance:
                         w.out('return _client.%s(%s);', j.route_method(route), ', '.join(args))
                     else:
                         w.out('_client.%s(%s);', j.route_method(route), ', '.join(args))
+
+                if self.g.args.call_request:
+                    if return_class == JavaClass('void'):
+                        boxed_return = JavaClass('java.lang.Void')
+                    else:
+                        boxed_return = return_class
+                    request_class = JavaClass('com.dropbox.core.DbxRequest', generics=(boxed_return,))
+
+                    w.out('')
+                    dbx_request_ref = w.javadoc_ref(JavaClass('com.dropbox.core.DbxRequest'))
+                    if return_class == JavaClass('void'):
+                        returns_doc = "A %s that can be executed later." % dbx_request_ref
+                    else:
+                        result_type = w.resolved_class(boxed_return, generics=True)
+                        returns_doc = "A %s that can be executed later to obtain the {@code %s}." % (
+                            dbx_request_ref, result_type,
+                        )
+                    w.javadoc("See %s." % w.javadoc_ref(route), returns=returns_doc)
+                    with w.block('public %s startRequest()', request_class):
+                        if return_class == JavaClass('void'):
+                            w.out('return () -> { start(); return null; };')
+                        else:
+                            w.out('return () -> start();')
 
     def generate_field_assignment(self, field, lhs=None, rhs=None, allow_default=True):
         assert isinstance(field, Field), repr(field)

--- a/core/generator/java/java.stoneg.py
+++ b/core/generator/java/java.stoneg.py
@@ -621,6 +621,8 @@ _CMDLINE_PARSER.add_argument('--javadoc-refs', type=str, default=None,
                                   'exist.')
 _CMDLINE_PARSER.add_argument('--unused-classes-to-generate', default=None, help='Specify types ' +
                                                                                 'that we want to generate regardless of whether they are used.')
+_CMDLINE_PARSER.add_argument('--call-request', action="store_true", default=False,
+                             help='Generate additional *Request methods that return DbxRequest<T>.')
 
 
 class JavaCodeGenerator(CodeBackend):
@@ -729,6 +731,8 @@ class JavaImporter:
             'java.util.HashMap',
             'java.util.Map',
         )
+        if self._j._args.call_request:
+            self.add_imports('com.dropbox.core.DbxRequest')
         for route in namespace.routes:
             self.add_imports_for_route(route)
 
@@ -2800,6 +2804,12 @@ class JavaCodeGenerationInstance:
             else:
                 assert False, "unrecognized route request style: %s" % j.request_style(route)
 
+        if is_public and self.g.args.call_request:
+            request_args = w.fmt('%s arg', j.java_class(route.arg_data_type)) if j.has_arg(route) else ''
+            request_arg_names = 'arg' if j.has_arg(route) else ''
+            self._emit_request_method_body(route, request_args, request_arg_names, return_class,
+                                           params=params)
+
     def generate_route(self, route, required_only=True):
         assert isinstance(route, ApiRoute), repr(route)
 
@@ -2914,6 +2924,15 @@ class JavaCodeGenerationInstance:
             else:
                 w.out('%s(_arg);', j.route_method(route))
 
+        if self.g.args.call_request:
+            request_args = ', '.join(
+                w.fmt('%s %s', j.java_class(f), j.param_name(f)) for f in fields
+            )
+            request_arg_names = ', '.join(j.param_name(f) for f in fields)
+            request_params = w._javadoc_fields(fields, route, allow_defaults=False)
+            self._emit_request_method_body(route, request_args, request_arg_names, return_class,
+                                           params=request_params)
+
     def generate_route_builder_method(self, route):
         assert isinstance(route, ApiRoute), repr(route)
 
@@ -2952,6 +2971,31 @@ class JavaCodeGenerationInstance:
                 w.out('return new %s(this, argBuilder_);', return_class)
             else:
                 w.out('return new %s(this, %s);', return_class, builder_args)
+
+    def _emit_request_method_body(self, route, args, arg_names, return_class, fields=(), params=()):
+        """Emit the request method signature and body."""
+        w = self.w
+        j = self.j
+
+        if return_class == JavaClass('void'):
+            boxed_return = JavaClass('java.lang.Void')
+        else:
+            boxed_return = return_class
+
+        request_class = JavaClass('com.dropbox.core.DbxRequest', generics=(boxed_return,))
+        method_name = j.route_method(route) + 'Request'
+
+        w.out('')
+        returns_doc = "A %s that can be executed later to obtain the result." % (
+            w.javadoc_ref(JavaClass('com.dropbox.core.DbxRequest')),
+        )
+        doc = "See %s." % w.javadoc_ref(route)
+        w.javadoc(doc, params=params, returns=returns_doc)
+        with w.block('public %s %s(%s)', request_class, method_name, args):
+            if return_class == JavaClass('void'):
+                w.out('return () -> { %s(%s); return null; };', j.route_method(route), arg_names)
+            else:
+                w.out('return () -> %s(%s);', j.route_method(route), arg_names)
 
     def translate_error_wrapper(self, route, error_wrapper_var):
         assert isinstance(route, ApiRoute), repr(route)

--- a/core/generator/java/java.stoneg.py
+++ b/core/generator/java/java.stoneg.py
@@ -2986,9 +2986,14 @@ class JavaCodeGenerationInstance:
         method_name = j.route_method(route) + 'Request'
 
         w.out('')
-        returns_doc = "A %s that can be executed later to obtain the result." % (
-            w.javadoc_ref(JavaClass('com.dropbox.core.DbxRequest')),
-        )
+        dbx_request_ref = w.javadoc_ref(JavaClass('com.dropbox.core.DbxRequest'))
+        if return_class == JavaClass('void'):
+            returns_doc = "A %s that can be executed later." % dbx_request_ref
+        else:
+            result_type = w.resolved_class(boxed_return, generics=True)
+            returns_doc = "A %s that can be executed later to obtain the {@code %s}." % (
+                dbx_request_ref, result_type,
+            )
         doc = "See %s." % w.javadoc_ref(route)
         w.javadoc(doc, params=params, returns=returns_doc)
         with w.block('public %s %s(%s)', request_class, method_name, args):

--- a/core/generator/java/java.stoneg.py
+++ b/core/generator/java/java.stoneg.py
@@ -2975,7 +2975,8 @@ class JavaCodeGenerationInstance:
             else:
                 w.out('return new %s(this, %s);', return_class, builder_args)
 
-    def _emit_request_method_body(self, route, args, arg_names, return_class, fields=(), params=()):
+    def _emit_request_method_body(self, route, args, arg_names, return_class,
+                                   fields=(), params=(), method_name=None, delegate=None):
         """Emit the request method signature and body."""
         w = self.w
         j = self.j
@@ -2986,7 +2987,10 @@ class JavaCodeGenerationInstance:
             boxed_return = return_class
 
         request_class = JavaClass('com.dropbox.core.DbxRequest', generics=(boxed_return,))
-        method_name = j.route_method(route) + 'Request'
+        if method_name is None:
+            method_name = j.route_method(route) + 'Request'
+        if delegate is None:
+            delegate = '%s(%s)' % (j.route_method(route), arg_names)
 
         w.out('')
         dbx_request_ref = w.javadoc_ref(JavaClass('com.dropbox.core.DbxRequest'))
@@ -3001,9 +3005,9 @@ class JavaCodeGenerationInstance:
         w.javadoc(doc, params=params, returns=returns_doc)
         with w.block('public %s %s(%s)', request_class, method_name, args):
             if return_class == JavaClass('void'):
-                w.out('return () -> { %s(%s); return null; };', j.route_method(route), arg_names)
+                w.out('return () -> { %s; return null; };', delegate)
             else:
-                w.out('return () -> %s(%s);', j.route_method(route), arg_names)
+                w.out('return () -> %s;', delegate)
 
     def translate_error_wrapper(self, route, error_wrapper_var):
         assert isinstance(route, ApiRoute), repr(route)
@@ -3901,27 +3905,8 @@ class JavaCodeGenerationInstance:
                         w.out('_client.%s(%s);', j.route_method(route), ', '.join(args))
 
                 if self.g.args.call_request:
-                    if return_class == JavaClass('void'):
-                        boxed_return = JavaClass('java.lang.Void')
-                    else:
-                        boxed_return = return_class
-                    request_class = JavaClass('com.dropbox.core.DbxRequest', generics=(boxed_return,))
-
-                    w.out('')
-                    dbx_request_ref = w.javadoc_ref(JavaClass('com.dropbox.core.DbxRequest'))
-                    if return_class == JavaClass('void'):
-                        returns_doc = "A %s that can be executed later." % dbx_request_ref
-                    else:
-                        result_type = w.resolved_class(boxed_return, generics=True)
-                        returns_doc = "A %s that can be executed later to obtain the {@code %s}." % (
-                            dbx_request_ref, result_type,
-                        )
-                    w.javadoc("See %s." % w.javadoc_ref(route), returns=returns_doc)
-                    with w.block('public %s startRequest()', request_class):
-                        if return_class == JavaClass('void'):
-                            w.out('return () -> { start(); return null; };')
-                        else:
-                            w.out('return () -> start();')
+                    self._emit_request_method_body(route, '', '', return_class,
+                                                   method_name='startRequest', delegate='start()')
 
     def generate_field_assignment(self, field, lhs=None, rhs=None, allow_default=True):
         assert isinstance(field, Field), repr(field)

--- a/core/src/main/java/com/dropbox/core/DbxRequest.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequest.java
@@ -1,0 +1,19 @@
+package com.dropbox.core;
+
+/**
+ * A functional interface representing a request that produces a result and may throw a checked
+ * exception. Similar to {@link java.util.concurrent.Callable}, but intended for use in contexts
+ * where the operation represents an API request.
+ *
+ * @param <T> the type of result produced by this request
+ */
+@FunctionalInterface
+public interface DbxRequest<T> {
+    /**
+     * Executes the request and returns the result.
+     *
+     * @return the result of the request
+     * @throws Exception if the request fails
+     */
+    T call() throws Exception;
+}

--- a/core/src/main/java/com/dropbox/core/DbxRequest.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequest.java
@@ -1,19 +1,13 @@
 package com.dropbox.core;
 
+import java.util.concurrent.Callable;
+
 /**
  * A functional interface representing a request that produces a result {@code <T>} and may throw a checked
- * exception. Similar to {@link java.util.concurrent.Callable}, but intended for use in contexts
+ * exception. Extends {@link java.util.concurrent.Callable} but is intended for use in contexts
  * where the operation represents an API request.
  *
  * @param <T> the type of result produced by this request
  */
 @FunctionalInterface
-public interface DbxRequest<T> {
-    /**
-     * Executes the request and returns the result.
-     *
-     * @return the result of the request
-     * @throws Exception if the request fails
-     */
-    T call() throws Exception;
-}
+public interface DbxRequest<T> extends Callable<T> { }

--- a/core/src/main/java/com/dropbox/core/DbxRequest.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequest.java
@@ -1,7 +1,7 @@
 package com.dropbox.core;
 
 /**
- * A functional interface representing a request that produces a result and may throw a checked
+ * A functional interface representing a request that produces a result {@code <T>} and may throw a checked
  * exception. Similar to {@link java.util.concurrent.Callable}, but intended for use in contexts
  * where the operation represents an API request.
  *

--- a/core/src/test/java/com/dropbox/core/stone/DbxRequestMethodTest.java
+++ b/core/src/test/java/com/dropbox/core/stone/DbxRequestMethodTest.java
@@ -1,0 +1,55 @@
+package com.dropbox.core.stone;
+
+import static org.mockito.Mockito.*;
+
+import com.dropbox.core.DbxDownloader;
+import com.dropbox.core.DbxRequest;
+import com.dropbox.core.stone.test.DbxTestTestRequests;
+import com.dropbox.core.stone.test.Fish;
+import com.dropbox.core.stone.test.TestUploadUploader;
+import com.dropbox.core.stone.test.UninitializedReason;
+import com.dropbox.core.v2.DbxRawClientV2;
+
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class DbxRequestMethodTest {
+
+    @Test
+    public void testVoidRouteRequestReturnsDbxRequest() {
+        DbxRawClientV2 mockClient = mock(DbxRawClientV2.class, RETURNS_DEEP_STUBS);
+        DbxTestTestRequests requests = new DbxTestTestRequests(mockClient);
+
+        DbxRequest<Void> request = requests.testRouteRequest();
+        assertNotNull(request);
+    }
+
+    @Test
+    public void testDownloadRouteRequestReturnsDbxRequest() {
+        DbxRawClientV2 mockClient = mock(DbxRawClientV2.class, RETURNS_DEEP_STUBS);
+        DbxTestTestRequests requests = new DbxTestTestRequests(mockClient);
+
+        DbxRequest<DbxDownloader<Fish>> request = requests.testDownloadRequest("fido", "lab");
+        assertNotNull(request);
+    }
+
+    @Test
+    public void testUploadRouteRequestReturnsDbxRequest() {
+        DbxRawClientV2 mockClient = mock(DbxRawClientV2.class, RETURNS_DEEP_STUBS);
+        DbxTestTestRequests requests = new DbxTestTestRequests(mockClient);
+
+        DbxRequest<TestUploadUploader> request = requests.testUploadRequest(UninitializedReason.BAD_REQUEST, "session123");
+        assertNotNull(request);
+    }
+
+    @Test
+    public void testRouteV2RequestWithParams() {
+        DbxRawClientV2 mockClient = mock(DbxRawClientV2.class, RETURNS_DEEP_STUBS);
+        DbxTestTestRequests requests = new DbxTestTestRequests(mockClient);
+
+        DbxRequest<Void> request = requests.testRouteV2Request("buddy");
+        assertNotNull(request);
+    }
+}

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
@@ -125,6 +125,10 @@ abstract class StoneTask : DefaultTask() {
                 generatorArgs.addAll(generatorArgs.indexOf(":all") + 1, listOf("--filter-by-route-attr", buildRouteFilter(stoneConfig)))
             }
 
+            if (stoneConfig.callRequest) {
+                generatorArgs += "--call-request"
+            }
+
             if (stoneConfig.dataTypesOnly) {
                 generatorArgs += "--data-types-only"
             } else {

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/StoneTask.kt
@@ -125,8 +125,8 @@ abstract class StoneTask : DefaultTask() {
                 generatorArgs.addAll(generatorArgs.indexOf(":all") + 1, listOf("--filter-by-route-attr", buildRouteFilter(stoneConfig)))
             }
 
-            if (stoneConfig.callRequest) {
-                generatorArgs += "--call-request"
+            if (stoneConfig.generateRequest) {
+                generatorArgs += "--generate-request"
             }
 
             if (stoneConfig.dataTypesOnly) {

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/model/StoneConfig.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/model/StoneConfig.kt
@@ -6,7 +6,7 @@ class StoneConfig(
     var packageName: String = "com.dropbox.stone",
     var globalRouteFilter: String? = null,
     var dataTypesOnly: Boolean = false,
-    var callRequest: Boolean = false,
+    var generateRequest: Boolean = false,
     var client: ClientSpec? = null,
     var routeWhitelistFilter: String? = null,
 ) : Serializable

--- a/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/model/StoneConfig.kt
+++ b/stone-java-gradle-plugin/src/main/kotlin/com/dropbox/stone/java/model/StoneConfig.kt
@@ -6,6 +6,7 @@ class StoneConfig(
     var packageName: String = "com.dropbox.stone",
     var globalRouteFilter: String? = null,
     var dataTypesOnly: Boolean = false,
+    var callRequest: Boolean = false,
     var client: ClientSpec? = null,
     var routeWhitelistFilter: String? = null,
 ) : Serializable


### PR DESCRIPTION
## Summary
This PR adds `DbxRequest` to the public API and adds an optional parameter to the Java Stone backend on using it to generate additional methods that wrap the synchronous methods. This allows callers to capture the API request as an object

`DbxRequest` is functionally identical to `java.util.Callable`; we intend on using as a namespace for Kotlin extensions but don't want to pollute `Callable` with those extensions so we're introducing a new type.

Newly generated methods with be suffixed with `*Request` and apply to all method types (RPC, download & upload) where they return the result (if any) or the `DbxDownloader`/`DbxUploader` class. For now, no changes to `DbxDownloader`/`DbxUploader`.

## Test Plan
New tests pass