### PR TITLE
Migrate to AWS Secrets Manager

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,5 @@
 # This workflow will build the project with Gradle, run integration tests, and release.
-# Because secrets are not available on external forks, this job is expected to fail
-# on external pull requests.
+# Secret-backed jobs fetch credentials from AWS Secrets Manager using GitHub OIDC.
 
 name: Build, Check, Publish
 
@@ -46,13 +45,6 @@ jobs:
     - name: Ensure no changes in Generated Code
       run: ./scripts/check-clean-git-status
 
-    - name: Obtain oauth access token for integration tests
-      env:
-        APP_KEY: ${{ secrets.APP_KEY }}
-        APP_SECRET: ${{ secrets.APP_SECRET }}
-        REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
-      run: ./generate-ci-auth-file
-
     - name: Ensure Binary Compatibility
       run: ./gradlew :core:apiCheck :android:apiCheck
 
@@ -61,6 +53,60 @@ jobs:
 
     - name: Check
       run: ./gradlew check
+
+  integration:
+    runs-on: ubuntu-latest
+    if: github.repository == 'dropbox/dropbox-sdk-java' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: [build]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Gradle Wrapper Validation
+      uses: gradle/actions/wrapper-validation@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'zulu'
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9.14'
+    - run: python -m pip install ply six packaging
+
+    - name: Grant execute permissions
+      run: chmod +x gradlew
+        && chmod +x update-submodules
+        && chmod +x generate-ci-auth-file
+
+    - name: Set up submodules
+      run: ./update-submodules
+
+    - name: Generate Stone
+      run: ./gradlew :core:generateStone
+
+    - name: Configure AWS credentials (OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::521590706193:role/oidc-github-dropbox-dropbox-sdk-java-branch-main
+        aws-region: us-west-2
+
+    - name: Get integration test secrets from AWS Secrets Manager
+      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      with:
+        secret-ids: |
+          APP_KEY,dropbox-sdk-java-app-key
+          APP_SECRET,dropbox-sdk-java-app-secret
+          REFRESH_TOKEN,dropbox-sdk-java-refresh-token
+        parse-json-secrets: false
+
+    - name: Obtain oauth access token for integration tests
+      run: ./generate-ci-auth-file
 
     - name: Run Integration Tests for Examples
       run: ./gradlew :examples:examples:test :examples:java:test -Pci=true --info
@@ -80,7 +126,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.repository == 'dropbox/dropbox-sdk-java' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    needs: [build]
+    needs: [build, integration]
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -106,13 +155,29 @@ jobs:
       - name: Update submodules
         run: ./update-submodules
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::521590706193:role/oidc-github-dropbox-dropbox-sdk-java-branch-main
+          aws-region: us-west-2
+
+      - name: Get Maven Central secrets from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            OSSRH_USERNAME,sdk-release-maven-central-token-username
+            OSSRH_PASSWORD,sdk-release-maven-central-token-password
+            SIGNING_KEY,sdk-release-signing-key
+            SIGNING_PASSWORD,sdk-release-signing-password
+          parse-json-secrets: false
+
       - name: Upload Artifacts
         run: ./gradlew publishToMavenCentral --no-daemon --no-parallel --no-configuration-cache --stacktrace
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ env.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ env.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ env.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ env.SIGNING_PASSWORD }}
 
       - name: Retrieve version
         run: |
@@ -122,8 +187,8 @@ jobs:
         run: ./gradlew publishAndReleaseToMavenCentral --no-daemon --no-parallel
         if: "!endsWith(env.VERSION_NAME, '-SNAPSHOT')"
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ env.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ env.OSSRH_PASSWORD }}
 
       - name: Upload Test Reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,19 +13,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Gradle Wrapper Validation
-      uses: gradle/actions/wrapper-validation@v4
+      uses: gradle/actions/wrapper-validation@v6
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'zulu'
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9.14'
     - run: python -m pip install ply six packaging
@@ -62,19 +62,19 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: Gradle Wrapper Validation
-      uses: gradle/actions/wrapper-validation@v3
+      uses: gradle/actions/wrapper-validation@v6
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'zulu'
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9.14'
     - run: python -m pip install ply six packaging
@@ -91,13 +91,13 @@ jobs:
       run: ./gradlew :core:generateStone
 
     - name: Configure AWS credentials (OIDC)
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::521590706193:role/oidc-github-dropbox-dropbox-sdk-java-branch-main
         aws-region: us-west-2
 
     - name: Get integration test secrets from AWS Secrets Manager
-      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3
       with:
         secret-ids: |
           APP_KEY,dropbox-sdk-java-app-key
@@ -132,19 +132,19 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
 
       - name: Install JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 21
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9.14'
       - run: python -m pip install ply && pip install six
@@ -156,13 +156,13 @@ jobs:
         run: ./update-submodules
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::521590706193:role/oidc-github-dropbox-dropbox-sdk-java-branch-main
           aws-region: us-west-2
 
       - name: Get Maven Central secrets from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             OSSRH_USERNAME,sdk-release-maven-central-token-username
@@ -191,7 +191,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ env.OSSRH_PASSWORD }}
 
       - name: Upload Test Reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: TestReports
           path: |
@@ -199,7 +199,7 @@ jobs:
             android/build/reports/
 
       - name: Upload JavaDocs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: JavaDocs
           path: |
@@ -207,7 +207,7 @@ jobs:
             android/build/docs/javadoc/
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BuildArtifacts
           path: |


### PR DESCRIPTION
This PR moves us off of Github Secrets and also bumps actions to the latest major versions. Previously, checks were immediately failing due to artifacts v3 being hard deprecated.

It also slightly changes the structure of the workflow to where PR checks will no longer require secrets, they just run build and check. Integration tests (which require secrets) will only run when a PR is merged to main.
