### PR TITLE
Install packaging in publish workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.9.14'
-      - run: python -m pip install ply && pip install six
+      - run: python -m pip install ply six packaging
 
       - name: Grant execute permissions
         run: chmod +x gradlew && chmod +x update-submodules


### PR DESCRIPTION
## Summary
- install Python packaging in the publish job, matching build and integration
- fixes the merged main publish failure in https://github.com/dropbox/dropbox-sdk-java/actions/runs/28244281303

## Verification
- parsed .github/workflows/check.yml with Ruby YAML
- ran git diff --check