### PR TITLE
Fix Javadoc generation on JDK 21

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,9 @@ jobs:
     - name: Check
       run: ./gradlew check
 
+    - name: Generate Javadocs
+      run: ./gradlew :core:javadoc :android:javaDocReleaseGeneration
+
   integration:
     runs-on: ubuntu-latest
     if: github.repository == 'dropbox/dropbox-sdk-java' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -207,13 +207,14 @@ tasks.named("javadoc", Javadoc) {
     title = "${project.mavenName} ${versionName} API"
     failOnError = true
 
-    // JDK 8's javadoc has an on-by-default lint called "missing", which requires that everything
-    // be documented. Disable this lint because we intentionally don't document some things.
+    // JDK's javadoc has on-by-default lints for missing docs and unresolved references. Disable
+    // these because we intentionally don't document some things and generated/cross-module links
+    // are not always resolvable in this standalone Javadoc task.
     //
     // NOTE: ugly hack to set our doclint settings due to strange handling of string options by the
     // javadoc task.
     if (JavaVersion.current().isJava8Compatible()) {
-        options.addBooleanOption "Xdoclint:all,-missing", true
+        options.addBooleanOption "Xdoclint:all,-missing,-reference", true
     }
     options.addStringOption "link", "http://docs.oracle.com/javase/8/docs/api/"
 }

--- a/core/src/main/java/com/dropbox/core/DbxWebAuth.java
+++ b/core/src/main/java/com/dropbox/core/DbxWebAuth.java
@@ -24,7 +24,7 @@ import com.dropbox.core.v2.DbxRawClientV2;
  * for a user when they first use your application.  Once you have an access token for that user, it
  * remains valid for years.
  *
- * <h1> Redirect example </h1>
+ * <h2> Redirect example </h2>
  * <p> One-time setup typically done on server initialization: </p>
  * <pre>
  *     {@link DbxRequestConfig} requestConfig = new DbxRequestConfig("text-edit/0.1");
@@ -34,7 +34,7 @@ import com.dropbox.core.v2.DbxRawClientV2;
  *     String redirectUri = "http://my-server.com/dropbox-auth-finish";
  * </pre>
  *
- * <h2> Part 1 </h2>
+ * <h3> Part 1 </h3>
  * <p> Handler for "http://my-server.com/dropbox-auth-start": </p>
  * <pre>
  *     {@link jakarta.servlet.http.HttpServletRequest} request = ...
@@ -59,7 +59,7 @@ import com.dropbox.core.v2.DbxRawClientV2;
  *     response.sendRedirect(authorizePageUrl);
  * </pre>
  *
- * <h2> Part 2 </h2>
+ * <h3> Part 2 </h3>
  * <p> Handler for "http://my-server.com/dropbox-auth-finish": </p>
  * <pre>
  *     {@link jakarta.servlet.http.HttpServletRequest} request = ...
@@ -111,7 +111,7 @@ import com.dropbox.core.v2.DbxRawClientV2;
  *     ...
  * </pre>
  *
- * <h1> No Redirect Example </h1>
+ * <h2> No Redirect Example </h2>
  *
  * <pre>
  *     {@link DbxRequestConfig} requestConfig = new DbxRequestConfig("text-edit/0.1");


### PR DESCRIPTION
## Summary
- fix JDK 21 Javadoc heading validation in DbxWebAuth docs
- disable Javadoc doclint reference failures for generated and cross-module links
- fixes the current main publish failure in https://github.com/dropbox/dropbox-sdk-java/actions/runs/28247617980
- adds docs tasks to PR checks to catch this earlier.