### PR TITLE
Prepare next development version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # POM
 GROUP = com.dropbox.core
-VERSION_NAME=8.0.1
+VERSION_NAME=8.1.0-SNAPSHOT
 
 POM_URL = https://github.com/dropbox/dropbox-sdk-java/
 POM_SCM_URL = https://github.com/dropbox/dropbox-sdk-java/


### PR DESCRIPTION
Summary:
- Restore VERSION_NAME to 8.1.0-SNAPSHOT after the 8.0.1 release.

Verification:
- ./gradlew check --no-daemon