### PR TITLE
Fix Android URL encoder compatibility

### DIFF
--- a/core/src/main/java/com/dropbox/core/DbxOAuth1Upgrader.java
+++ b/core/src/main/java/com/dropbox/core/DbxOAuth1Upgrader.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /**
@@ -105,7 +105,14 @@ public final class DbxOAuth1Upgrader
 
     private static String encode(String s)
     {
-        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+        try {
+            // Use the String overload for Android API compatibility. The Charset overload was
+            // added to Android much later than the String overload.
+            return URLEncoder.encode(s, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            // UTF-8 is required by every Java implementation.
+            throw new AssertionError(ex);
+        }
     }
 
     /**

--- a/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
+++ b/core/src/main/java/com/dropbox/core/DbxRequestUtil.java
@@ -1,11 +1,11 @@
 package com.dropbox.core;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +38,14 @@ public final class DbxRequestUtil {
     public static DbxGlobalCallbackFactory sharedCallbackFactory;
 
     public static String encodeUrlParam(String s) {
-        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+        try {
+            // Use the String overload for Android API compatibility. The Charset overload was
+            // added to Android much later than the String overload.
+            return URLEncoder.encode(s, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            // UTF-8 is required by every Java implementation.
+            throw new AssertionError(ex);
+        }
     }
 
     public static String buildUrlWithParams(/*@Nullable*/String userLocale,

--- a/core/src/test/java/com/dropbox/core/DbxRequestUtilTest.java
+++ b/core/src/test/java/com/dropbox/core/DbxRequestUtilTest.java
@@ -1,0 +1,14 @@
+package com.dropbox.core;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.testng.annotations.Test;
+
+public class DbxRequestUtilTest {
+
+    @Test
+    public void testEncodeUrlParam() {
+        assertThat(DbxRequestUtil.encodeUrlParam("hello world/+"))
+            .isEqualTo("hello+world%2F%2B");
+    }
+}


### PR DESCRIPTION
Fixes #583

## Summary
- Use the Android-compatible `URLEncoder.encode(String, String)` overload instead of the newer Charset overload.
- Apply the fix to both request URL encoding and OAuth 1 upgrading.
- Add regression coverage for URL encoding.

## Testing
- `./gradlew :core:test --no-daemon`