### PR TITLE
Release v8.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+8.0.2 (2026-07-15)
+---------------------------------------------
+- [#587](https://github.com/dropbox/dropbox-sdk-java/pull/587) Fix Android URL encoder compatibility.
+
 8.0.1 (2026-06-30)
 ---------------------------------------------
 - Update generated SDK code from the latest Dropbox API spec.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you're using Maven, then edit your project's "pom.xml" and add this to the `<
 <dependency>
     <groupId>com.dropbox.core</groupId>
     <artifactId>dropbox-core-sdk</artifactId>
-    <version>8.0.1</version>
+    <version>8.0.2</version>
 </dependency>
 ```
 
@@ -42,7 +42,7 @@ If you are using Gradle, then edit your project's "build.gradle" and add this to
 ```groovy
 dependencies {
     // ...
-    implementation 'com.dropbox.core:dropbox-core-sdk:8.0.1'
+    implementation 'com.dropbox.core:dropbox-core-sdk:8.0.2'
 }
 ```
 
@@ -277,8 +277,8 @@ Edit your project's "build.gradle" and add the following to the dependencies sec
 ```
 dependencies {
     // ...
-    implementation 'com.dropbox.core:dropbox-core-sdk:8.0.1'
-    implementation 'com.dropbox.core:dropbox-android-sdk:8.0.1'
+    implementation 'com.dropbox.core:dropbox-core-sdk:8.0.2'
+    implementation 'com.dropbox.core:dropbox-android-sdk:8.0.2'
 }
 ```
 If you leverage jettifier and see the following errors then please add `android.jetifier.ignorelist = jackson-core,fastdoubleparser` to your `gradle.properties` file.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # POM
 GROUP = com.dropbox.core
-VERSION_NAME=8.1.0-SNAPSHOT
+VERSION_NAME=8.0.2
 
 POM_URL = https://github.com/dropbox/dropbox-sdk-java/
 POM_SCM_URL = https://github.com/dropbox/dropbox-sdk-java/


### PR DESCRIPTION
## Release v8.0.2

This release includes the Android URL encoder compatibility fix from #587.

## Validation

- `./gradlew :core:test --no-daemon`