### PR TITLE
Update API declarations in spec_update workflow

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -90,6 +90,8 @@ jobs:
           cd ../../../..
       - name: Generate Stone
         run: ./gradlew :core:generateStone
+      - name: Update API declarations
+        run: ./gradlew :core:apiDump :android:apiDump
 
       - name: Close Old Pull Requests
         id: close-old-prs


### PR DESCRIPTION
## Summary
- Run `./gradlew :core:apiDump :android:apiDump` after `:core:generateStone` so the committed `.api` binary-compatibility declarations are regenerated

## Problem
The spec update PR #594 fails `:core:apiCheck` (the kotlinx binary-compatibility-validator). When a spec update adds/changes public API, the checked-in `core/api/core.api` no longer matches and CI errors with "You can run :core:apiDump task to overwrite API declarations". Running apiDump in the workflow keeps it in sync.

## Test plan
- [ ] Re-trigger `spec_update` and confirm the resulting PR passes `apiCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)